### PR TITLE
schemas: add parts schema and schema validator

### DIFF
--- a/craft_parts/data/schema/parts.json
+++ b/craft_parts/data/schema/parts.json
@@ -1,232 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "definitions": {
-        "grammar-string": {
-            "oneOf": [
-                {
-                    "type": "string",
-                    "usage": "<string>"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "minitems": 1,
-                        "uniqueItems": true,
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "usage": "on <selector>[,<selector>...]:",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^on\\s+.+$": {
-                                        "$ref": "#/definitions/grammar-string"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "usage": "to <selector>[,<selector>...]:",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^to\\s+.+$": {
-                                        "$ref": "#/definitions/grammar-string"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "usage": "try:",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^try$": {
-                                        "$ref": "#/definitions/grammar-string"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "usage": "else:",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^else$": {
-                                        "$ref": "#/definitions/grammar-string"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "string",
-                                "pattern": "else fail"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
-        "grammar-array": {
-            "type": "array",
-            "minitems": 1,
-            "uniqueItems": true,
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "usage": "<string>"
-                    },
-                    {
-                        "type": "object",
-                        "usage": "on <selector>[,<selector>...]:",
-                        "additionalProperties": false,
-                        "patternProperties": {
-                            "^on\\s+.+$": {
-                                "$ref": "#/definitions/grammar-array"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "usage": "to <selector>[,<selector>...]:",
-                        "additionalProperties": false,
-                        "patternProperties": {
-                            "^to\\s+.+$": {
-                                "$ref": "#/definitions/grammar-array"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "usage": "try:",
-                        "additionalProperties": false,
-                        "patternProperties": {
-                            "^try$": {
-                                "$ref": "#/definitions/grammar-array"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "usage": "else:",
-                        "additionalProperties": false,
-                        "patternProperties": {
-                            "^else$": {
-                                "$ref": "#/definitions/grammar-array"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        "apt-deb": {
-            "type": "object",
-            "description": "deb repositories",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "apt"
-                    ]
-                },
-                "architectures": {
-                    "type": "array",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "description": "Architectures to enable, or restrict to, for this repository.  Defaults to host architecture."
-                    }
-                },
-                "formats": {
-                    "type": "array",
-                    "description": "deb types to enable.  Defaults to [deb, deb-src].",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "deb",
-                            "deb-src"
-                        ]
-                    }
-                },
-                "components": {
-                    "type": "array",
-                    "minItems": 0,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "description": "Deb repository components to enable, e.g. 'main, multiverse, unstable'"
-                    }
-                },
-                "key-id": {
-                    "type": "string",
-                    "description": "GPG key identifier / fingerprint. May be used to identify key file in <project>/snap/keys/<key-id>.asc",
-                    "pattern": "^[a-zA-Z0-9-_]*$"
-                },
-                "key-server": {
-                    "type": "string",
-                    "description": "GPG keyserver to use to fetch GPG <key-id>, e.g. 'keyserver.ubuntu.com'. Defaults to keyserver.ubuntu.com if key is not found in project."
-                },
-                "suites": {
-                    "type": "array",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security')."
-                    }
-                },
-                "url": {
-                    "type": "string",
-                    "description": "Deb repository URL, e.g. 'http://archive.canonical.com/ubuntu'."
-                }
-            },
-            "required": [
-                "type",
-                "components",
-                "key-id",
-                "suites",
-                "url"
-            ],
-            "validation-failure": "{!r} is not properly configured deb repository"
-        },
-        "apt-ppa": {
-            "type": "object",
-            "description": "PPA repository",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "apt"
-                    ]
-                },
-                "ppa": {
-                    "type": "string",
-                    "description": "ppa path: e.g. 'canonical-kernel-team/unstable'"
-                }
-            },
-            "required": [
-                "type",
-                "ppa"
-            ],
-            "validation-failure": "{!r} is not properly configured PPA repository"
-        },
-        "system-username-scope": {
-            "type": "string",
-            "description": "short-form user configuration (<username>: <scope>)",
-            "enum": [
-                "shared"
-            ],
-            "validation-failure": "{!r} is not a valid user scope. Valid scopes include: 'shared'"
-        }
-    },
     "title": "part schema",
     "type": "object",
+    "definitions": {},
     "properties": {
-        "build-packages": {
-            "$ref": "#/definitions/grammar-array",
-            "description": "top level build packages."
-        },
         "parts": {
             "type": "object",
             "minProperties": 1,
@@ -245,7 +22,7 @@
                             "description": "plugin name"
                         },
                         "source": {
-                            "$ref": "#/definitions/grammar-string"
+                            "type": "string"
                         },
                         "source-checksum": {
                             "type": "string",
@@ -304,22 +81,22 @@
                         },
                         "stage-snaps": {
                             "$comment": "For some reason 'default' doesn't work if in the ref",
-                            "$ref": "#/definitions/grammar-array",
+                            "type": "array",
                             "default": []
                         },
                         "stage-packages": {
                             "$comment": "For some reason 'default' doesn't work if in the ref",
-                            "$ref": "#/definitions/grammar-array",
+                            "type": "array",
                             "default": []
                         },
                         "build-snaps": {
                             "$comment": "For some reason 'default' doesn't work if in the ref",
-                            "$ref": "#/definitions/grammar-array",
+                            "type": "array",
                             "default": []
                         },
                         "build-packages": {
                             "$comment": "For some reason 'default' doesn't work if in the ref",
-                            "$ref": "#/definitions/grammar-array",
+                            "type": "array",
                             "default": []
                         },
                         "build-environment": {

--- a/craft_parts/data/schema/parts.json
+++ b/craft_parts/data/schema/parts.json
@@ -1,0 +1,423 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "grammar-string": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "usage": "<string>"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "minitems": 1,
+                        "uniqueItems": true,
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "usage": "on <selector>[,<selector>...]:",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^on\\s+.+$": {
+                                        "$ref": "#/definitions/grammar-string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "usage": "to <selector>[,<selector>...]:",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^to\\s+.+$": {
+                                        "$ref": "#/definitions/grammar-string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "usage": "try:",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^try$": {
+                                        "$ref": "#/definitions/grammar-string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "usage": "else:",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^else$": {
+                                        "$ref": "#/definitions/grammar-string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "string",
+                                "pattern": "else fail"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "grammar-array": {
+            "type": "array",
+            "minitems": 1,
+            "uniqueItems": true,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "usage": "<string>"
+                    },
+                    {
+                        "type": "object",
+                        "usage": "on <selector>[,<selector>...]:",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^on\\s+.+$": {
+                                "$ref": "#/definitions/grammar-array"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "usage": "to <selector>[,<selector>...]:",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^to\\s+.+$": {
+                                "$ref": "#/definitions/grammar-array"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "usage": "try:",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^try$": {
+                                "$ref": "#/definitions/grammar-array"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "usage": "else:",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^else$": {
+                                "$ref": "#/definitions/grammar-array"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "apt-deb": {
+            "type": "object",
+            "description": "deb repositories",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "apt"
+                    ]
+                },
+                "architectures": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Architectures to enable, or restrict to, for this repository.  Defaults to host architecture."
+                    }
+                },
+                "formats": {
+                    "type": "array",
+                    "description": "deb types to enable.  Defaults to [deb, deb-src].",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "deb",
+                            "deb-src"
+                        ]
+                    }
+                },
+                "components": {
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Deb repository components to enable, e.g. 'main, multiverse, unstable'"
+                    }
+                },
+                "key-id": {
+                    "type": "string",
+                    "description": "GPG key identifier / fingerprint. May be used to identify key file in <project>/snap/keys/<key-id>.asc",
+                    "pattern": "^[a-zA-Z0-9-_]*$"
+                },
+                "key-server": {
+                    "type": "string",
+                    "description": "GPG keyserver to use to fetch GPG <key-id>, e.g. 'keyserver.ubuntu.com'. Defaults to keyserver.ubuntu.com if key is not found in project."
+                },
+                "suites": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Deb repository suites to enable, e.g. 'xenial-updates, xenial-security')."
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Deb repository URL, e.g. 'http://archive.canonical.com/ubuntu'."
+                }
+            },
+            "required": [
+                "type",
+                "components",
+                "key-id",
+                "suites",
+                "url"
+            ],
+            "validation-failure": "{!r} is not properly configured deb repository"
+        },
+        "apt-ppa": {
+            "type": "object",
+            "description": "PPA repository",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "apt"
+                    ]
+                },
+                "ppa": {
+                    "type": "string",
+                    "description": "ppa path: e.g. 'canonical-kernel-team/unstable'"
+                }
+            },
+            "required": [
+                "type",
+                "ppa"
+            ],
+            "validation-failure": "{!r} is not properly configured PPA repository"
+        },
+        "system-username-scope": {
+            "type": "string",
+            "description": "short-form user configuration (<username>: <scope>)",
+            "enum": [
+                "shared"
+            ],
+            "validation-failure": "{!r} is not a valid user scope. Valid scopes include: 'shared'"
+        }
+    },
+    "title": "part schema",
+    "type": "object",
+    "properties": {
+        "build-packages": {
+            "$ref": "#/definitions/grammar-array",
+            "description": "top level build packages."
+        },
+        "parts": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": false,
+            "validation-failure": "{!r} is not a valid part name. Part names consist of lower-case alphanumeric characters, hyphens and plus signs. As a special case, 'plugins' is also not a valid part name.",
+            "patternProperties": {
+                "^(?!plugins$)[a-z0-9][a-z0-9+-]*$": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "minProperties": 1,
+                    "properties": {
+                        "plugin": {
+                            "type": "string",
+                            "description": "plugin name"
+                        },
+                        "source": {
+                            "$ref": "#/definitions/grammar-string"
+                        },
+                        "source-checksum": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "source-branch": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "source-commit": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "source-depth": {
+                            "type": "integer",
+                            "default": 0
+                        },
+                        "source-subdir": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "source-tag": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "source-type": {
+                            "type": "string",
+                            "default": "",
+                            "enum": [
+                                "bzr",
+                                "git",
+                                "hg",
+                                "mercurial",
+                                "subversion",
+                                "svn",
+                                "tar",
+                                "zip",
+                                "deb",
+                                "rpm",
+                                "7z",
+                                "local"
+                            ]
+                        },
+                        "disable-parallel": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "after": {
+                            "type": "array",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": []
+                        },
+                        "stage-snaps": {
+                            "$comment": "For some reason 'default' doesn't work if in the ref",
+                            "$ref": "#/definitions/grammar-array",
+                            "default": []
+                        },
+                        "stage-packages": {
+                            "$comment": "For some reason 'default' doesn't work if in the ref",
+                            "$ref": "#/definitions/grammar-array",
+                            "default": []
+                        },
+                        "build-snaps": {
+                            "$comment": "For some reason 'default' doesn't work if in the ref",
+                            "$ref": "#/definitions/grammar-array",
+                            "default": []
+                        },
+                        "build-packages": {
+                            "$comment": "For some reason 'default' doesn't work if in the ref",
+                            "$ref": "#/definitions/grammar-array",
+                            "default": []
+                        },
+                        "build-environment": {
+                            "type": "array",
+                            "default": [],
+                            "minitems": 1,
+                            "items": {
+                                "type": "object",
+                                "minProperties": 1,
+                                "maxProperties": 1,
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "build-attributes": {
+                            "type": "array",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "enable-patchelf",
+                                    "no-patchelf",
+                                    "no-install",
+                                    "debug",
+                                    "keep-execstack"
+                                ]
+                            },
+                            "default": []
+                        },
+                        "organize": {
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        },
+                        "filesets": {
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "array",
+                                "minitems": 1
+                            }
+                        },
+                        "stage": {
+                            "type": "array",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [
+                                "*"
+                            ]
+                        },
+                        "prime": {
+                            "type": "array",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [
+                                "*"
+                            ]
+                        },
+                        "override-pull": {
+                            "type": "string"
+                        },
+                        "override-build": {
+                            "type": "string"
+                        },
+                        "override-stage": {
+                            "type": "string"
+                        },
+                        "override-prime": {
+                            "type": "string"
+                        },
+                        "parse-info": {
+                            "type": "array",
+                            "minitems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": []
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "parts"
+    ],
+
+    "additionalProperties": true
+}

--- a/craft_parts/manager.py
+++ b/craft_parts/manager.py
@@ -16,6 +16,7 @@
 
 """The parts lifecycle manager."""
 
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 from craft_parts import sequencer
@@ -23,7 +24,10 @@ from craft_parts.actions import Action
 from craft_parts.dirs import ProjectDirs
 from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part
+from craft_parts.schemas import Validator
 from craft_parts.steps import Step
+
+_SCHEMA_DIR = Path(__file__).parent / "data" / "schema"
 
 
 class LifecycleManager:
@@ -64,7 +68,8 @@ class LifecycleManager:
     ):
         # TODO: validate base_dir
 
-        # TODO: validate parts schema
+        self._validator = Validator(_SCHEMA_DIR / "parts.json")
+        self._validator.validate(all_parts)
 
         # TODO: validate or slugify application name
 
@@ -87,6 +92,7 @@ class LifecycleManager:
         self._target_arch = project_info.target_arch
         self._sequencer = sequencer.Sequencer(
             part_list=self._part_list,
+            validator=self._validator,
             project_info=project_info,
         )
         self._project_info = project_info

--- a/craft_parts/schemas.py
+++ b/craft_parts/schemas.py
@@ -1,0 +1,127 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Schema validation helpers and definitions."""
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Dict, Union
+
+import jsonschema  # type: ignore
+
+from craft_parts import errors
+
+
+class Validator:
+    """Parts schema validator.
+
+    :param filename: The schema file name.
+    """
+
+    def __init__(self, filename: Union[str, Path]):
+        self._load_schema(filename)
+
+    @property
+    def schema(self) -> Dict[str, Any]:
+        """Return all schema properties."""
+        return self._schema["properties"].copy()
+
+    @property
+    def part_schema(self) -> Dict[str, Any]:
+        """Return part-specific schema properties."""
+        sub = self.schema["parts"]["patternProperties"]
+        properties = sub["^(?!plugins$)[a-z0-9][a-z0-9+-]*$"]["properties"]
+        return properties
+
+    @property
+    def definitions_schema(self):
+        """Return sub-schema that describes definitions used within schema."""
+        return self._schema["definitions"].copy()
+
+    def _load_schema(self, filename: Union[str, Path]) -> None:
+        try:
+            with open(filename) as schema_file:
+                self._schema = json.load(schema_file)
+        except FileNotFoundError as err:
+            raise errors.SchemaNotFound(filename) from err
+
+    def validate(self, data: Dict[str, Any]) -> None:
+        """Validate the given data against the validator's schema.
+
+        :param data: The structured data to validate against the schema.
+        """
+        validate_schema(data=data, schema=self._schema)
+
+    def merge_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        """Update the supplied schema with data from the validator schema.
+
+        :param schema: The schema to update.
+
+        :returns: The updated schema.
+        """
+        schema = copy.deepcopy(schema)
+
+        if "properties" not in schema:
+            schema["properties"] = {}
+
+        if "definitions" not in schema:
+            schema["definitions"] = {}
+
+        # The part schema takes precedence over the plugin's schema.
+        schema["properties"].update(self.part_schema)
+        schema["definitions"].update(self.definitions_schema)
+
+        return schema
+
+    def expand_part_properties(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Return properties with all part schema properties included.
+
+        Any schema properties not set will contain their default value as defined
+        in the schema itself.
+
+        :param part_properties: The part properties to expand.
+
+        :returns: a dictionary containing all part schema properties.
+        """
+        # First make a deep copy of the part schema. It contains nested mutables,
+        # and we'd rather not change them.
+        part_schema = copy.deepcopy(self.part_schema)
+
+        # Come up with a dictionary of part schema properties and their default
+        # values as defined in the schema.
+        properties = {}
+        for schema_property, subschema in part_schema.items():
+            properties[schema_property] = subschema.get("default")
+
+        # Now expand (overwriting if necessary) the default schema properties with
+        # the ones from the actual part.
+        properties.update(part_properties)
+
+        return properties
+
+
+def validate_schema(*, data: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    """Validate properties according to the given schema.
+
+    :param data: The structured data to validate against the schema.
+    :param schema: The validation schema.
+    """
+    format_check = jsonschema.FormatChecker()
+    try:
+        jsonschema.validate(data, schema, format_checker=format_check)
+    except jsonschema.ValidationError as err:
+        raise errors.SchemaValidationError.from_validation_error(err)

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -22,6 +22,7 @@ from typing import List, Optional, Sequence
 from craft_parts.actions import Action
 from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part, part_list_by_name, sort_parts
+from craft_parts.schemas import Validator
 from craft_parts.steps import Step
 
 logger = logging.getLogger(__name__)
@@ -34,8 +35,11 @@ class Sequencer:
     :param project_info: Information about this project.
     """
 
-    def __init__(self, *, part_list: List[Part], project_info: ProjectInfo):
+    def __init__(
+        self, *, part_list: List[Part], validator: Validator, project_info: ProjectInfo
+    ):
         self._part_list = sort_parts(part_list)
+        self._validator = validator
         self._project_info = project_info
         self._actions: List[Action] = []
 

--- a/craft_parts/utils/formatting_utils.py
+++ b/craft_parts/utils/formatting_utils.py
@@ -1,0 +1,47 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Text formatting utilities."""
+
+from typing import Iterable
+
+
+def humanize_list(
+    items: Iterable[str], conjunction: str, item_format: str = "{!r}"
+) -> str:
+    """Format a list into a human-readable string.
+
+    :param list items: List to humanize.
+    :param str conjunction: The conjunction used to join the final element to
+                            the rest of the list (e.g. 'and').
+    :param str item_format: Format string to use per item.
+    """
+    if not items:
+        return ""
+
+    quoted_items = [item_format.format(item) for item in sorted(items)]
+    if not quoted_items:
+        return ""
+
+    if len(quoted_items) == 1:
+        return quoted_items[0]
+
+    humanized = ", ".join(quoted_items[:-1])
+
+    if len(quoted_items) > 2:
+        humanized += ","
+
+    return "{} {} {}".format(humanized, conjunction, quoted_items[-1])

--- a/craft_parts/utils/schema_helpers.py
+++ b/craft_parts/utils/schema_helpers.py
@@ -1,0 +1,147 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2018 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to reformat jsonschema error messages."""
+
+import collections
+import contextlib
+from typing import Dict, List
+
+import jsonschema  # type: ignore
+
+from craft_parts.utils import formatting_utils
+
+# dict of jsonschema validator -> cause pairs. Wish jsonschema just gave us
+# better messages.
+_VALIDATION_ERROR_CAUSES = {
+    "maxLength": "maximum length is {validator_value}",
+    "minLength": "minimum length is {validator_value}",
+}
+
+
+def determine_preamble(error: jsonschema.ValidationError) -> str:
+    """Obtain the jsonschema validation error message preamble.
+
+    :param error: The jsonschema validation error.
+
+    :returns: The error preamble.
+    """
+    messages = []
+    path = _determine_property_path(error)
+    if path:
+        messages.append(
+            "The '{}' property does not match the required schema:".format(
+                "/".join(path)
+            )
+        )
+    return " ".join(messages)
+
+
+def determine_cause(error: jsonschema.ValidationError) -> str:
+    """Obtain the cause from the jsonschema validation error.
+
+    :param error: The jsonschema validation error.
+
+    :returns: The jsonschema validation error.
+    """
+    messages: List[str] = []
+
+    with contextlib.suppress(TypeError, KeyError):
+        msg: str = error.validator_value["validation-failure"].format(error)
+        messages.append(msg)
+
+    # The schema itself may have a custom validation error message. If so,
+    # use it as well.
+    with contextlib.suppress(AttributeError, TypeError, KeyError):
+        key = error
+        if (
+            error.schema.get("type") == "object"
+            and error.validator == "additionalProperties"
+        ):
+            key = list(error.instance.keys())[0]
+
+        msg = error.schema["validation-failure"].format(key)
+        messages.append(msg)
+
+    # anyOf failures might have usable context... try to improve them a bit
+    if error.validator == "anyOf":
+        contextual_messages: Dict[str, List[str]] = collections.OrderedDict()
+        for contextual_error in error.context:
+            key = contextual_error.schema_path.popleft()
+            if key not in contextual_messages:
+                contextual_messages[key] = []
+            message = contextual_error.message
+            if message:
+                # Sure it starts lower-case (not all messages do)
+                contextual_messages[key].append(message[0].lower() + message[1:])
+
+        oneof_messages: List[str] = []
+        for key, value in contextual_messages.items():
+            oneof_messages.append(formatting_utils.humanize_list(value, "and", "{}"))
+
+        messages.append(formatting_utils.humanize_list(oneof_messages, "or", "{}"))
+
+    return " ".join(messages)
+
+
+def determine_supplemental_info(error: jsonschema.ValidationError) -> str:
+    """Obtain additional information from the jsonschema validation error.
+
+    :param error: The jsonschema validation error.
+    """
+    message = _VALIDATION_ERROR_CAUSES.get(error.validator, "").format(
+        validator_value=error.validator_value
+    )
+
+    if not message and error.validator == "anyOf":
+        message = _interpret_anyof(error)
+
+    if not message and error.cause:
+        message = error.cause
+
+    return message
+
+
+def _determine_property_path(error: jsonschema.ValidationError) -> List[str]:
+    path: List[str] = []
+    absolute_path = error.absolute_path
+    while absolute_path:
+        element = absolute_path.popleft()
+        # assume numbers are indices and use 'xxx[123]' notation.
+        if isinstance(element, int):
+            path[-1] = "{}[{}]".format(path[-1], element)
+        else:
+            path.append(str(element))
+
+    return path
+
+
+def _interpret_anyof(error: jsonschema.ValidationError) -> str:
+    """Interpret a validation error caused by the anyOf validator.
+
+    :returns: A string containing a (hopefully) helpful validation error
+        message. It may be empty.
+    """
+    usages = []
+    try:
+        for validator in error.validator_value:
+            usages.append(validator["usage"])
+    except (TypeError, KeyError):
+        return ""
+
+    return "must be one of {}".format(
+        formatting_utils.humanize_list(usages, "or", "{}")
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     keywords="craft_parts",
     name="craft-parts",
-    package_data={"craft_parts": ["py.typed", "data/schema"]},
+    package_data={"craft_parts": ["py.typed", "data/schema/parts.json"]},
     packages=find_packages(include=["craft_parts", "craft_parts.*"]),
     setup_requires=setup_requirements,
     test_suite="tests",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -14,6 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
+
+import pytest
+
 from craft_parts import errors
 
 
@@ -62,3 +66,20 @@ def test_invalid_architecture():
     assert err.brief == "Architecture 'm68k' is not supported."
     assert err.details is None
     assert err.resolution == "Make sure the architecture name is correct."
+
+
+@pytest.mark.parametrize("schema_file", ["/some/path", Path("/some/path")])
+def test_schema_not_found(schema_file):
+    err = errors.SchemaNotFound(schema_file)
+    assert err.brief == "Unable to find the schema definition file '/some/path'."
+    assert err.resolution == "Make sure craft-parts is correctly installed."
+
+
+def test_schema_validation_error():
+    err = errors.SchemaValidationError("validation failed")
+    assert err.brief == "Schema validation error."
+    assert err.details == "validation failed"
+    assert (
+        err.resolution
+        == "Review the YAML file and make sure it conforms to the schema."
+    )

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,201 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from craft_parts import errors, schemas
+from craft_parts.schemas import Validator
+from tests import TESTS_DIR
+
+_SCHEMA_DIR = TESTS_DIR.parent / "craft_parts" / "data" / "schema"
+
+
+class TestValidateSchema:
+    """Schema validation tests."""
+
+    _schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "data": {
+                "type": "string",
+            },
+        },
+        "required": ["data"],
+    }
+
+    def test_validate_schema(self):
+        data = {"data": "value"}
+        schemas.validate_schema(data=data, schema=TestValidateSchema._schema)
+
+    def test_validate_schema_error(self):
+        data = {}
+        with pytest.raises(errors.SchemaValidationError) as raised:
+            schemas.validate_schema(data=data, schema=TestValidateSchema._schema)
+        assert raised.value.details == "'data' is a required property"
+
+
+class TestValidator:
+    """Validator tests with generic schema."""
+
+    _schema_json = textwrap.dedent(
+        """
+        {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "additionalProperties": { "enum": [ false ] },
+            "properties": {
+                "data": {
+                    "type": "string"
+                 }
+            },
+            "required": ["data"]
+        }
+        """
+    )
+
+    @pytest.mark.usefixtures("new_dir")
+    def test_validator(self):
+        Path("schema.json").write_text(TestValidator._schema_json)
+        validator = Validator("schema.json")
+
+        validator.validate({"data": "value"})
+
+        assert validator.schema == {"data": {"type": "string"}}
+
+    def test_validator_invalid_filename(self):
+        with pytest.raises(errors.SchemaNotFound) as raised:
+            Validator("does_not_exist.json")
+        assert raised.value.path == "does_not_exist.json"
+
+
+class TestPartsValidation:
+    """Validator tests with parts schema."""
+
+    @pytest.mark.parametrize(
+        "name", ["plugins", "qwe#rty", "qwe_rty", "queue rty", "queue  rty", "part/sub"]
+    )
+    def test_invalid_part_names(self, name):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+        data = {"parts": {name: {"plugin": "nil"}}}
+
+        with pytest.raises(errors.SchemaValidationError) as raised:
+            validator.validate(data)
+
+        expected_message = (
+            f"The 'parts' property does not match the required schema: {name!r} is "
+            "not a valid part name. Part names consist of lower-case "
+            "alphanumeric characters, hyphens and plus signs. "
+            "As a special case, 'plugins' is also not a valid part name."
+        )
+        assert raised.value.details.endswith(expected_message)
+
+    def test_part_schema(self):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+
+        with open(_SCHEMA_DIR / "parts.json") as f:
+            schema = json.load(f)
+
+        pattern_properties = schema["properties"]["parts"]["patternProperties"]
+        properties = pattern_properties["^(?!plugins$)[a-z0-9][a-z0-9+-]*$"][
+            "properties"
+        ]
+
+        assert validator.part_schema == properties
+
+    def test_definitions_schema(self):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+
+        with open(_SCHEMA_DIR / "parts.json") as f:
+            schema = json.load(f)
+
+        assert validator.definitions_schema == schema["definitions"]
+
+    def test_merge_schemas_trivial(self):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+        merged = validator.merge_schema({})
+
+        assert merged["properties"] == validator.part_schema
+        assert merged["definitions"] == validator.definitions_schema
+
+    def test_merge_schemas(self):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+
+        schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "more-properties": {"type": "string"},
+            },
+            "definitions": {
+                "more-definitions": "value",
+            },
+        }
+
+        merged = validator.merge_schema(schema)
+
+        # make sure we're not modifying the original schema data
+        assert merged != schema
+
+        schema["properties"].update(validator.part_schema)
+        schema["definitions"].update(validator.definitions_schema)
+
+        assert merged == schema
+
+    def test_expand_part_properties(self):
+        validator = Validator(_SCHEMA_DIR / "parts.json")
+        expanded = validator.expand_part_properties(
+            {
+                "after": ["foo", "bar"],
+                "new-property": "some value",
+            }
+        )
+
+        assert expanded == {
+            "after": ["foo", "bar"],
+            "build-attributes": [],
+            "build-environment": [],
+            "build-packages": [],
+            "build-snaps": [],
+            "disable-parallel": False,
+            "filesets": {},
+            "new-property": "some value",
+            "organize": {},
+            "override-build": None,
+            "override-prime": None,
+            "override-pull": None,
+            "override-stage": None,
+            "parse-info": [],
+            "plugin": None,
+            "prime": ["*"],
+            "source": None,
+            "source-branch": "",
+            "source-checksum": "",
+            "source-commit": "",
+            "source-depth": 0,
+            "source-subdir": "",
+            "source-tag": "",
+            "source-type": "",
+            "stage": ["*"],
+            "stage-packages": [],
+            "stage-snaps": [],
+        }

--- a/tests/unit/utils/test_formatting_utils.py
+++ b/tests/unit/utils/test_formatting_utils.py
@@ -1,0 +1,46 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.utils import formatting_utils
+
+
+@pytest.mark.parametrize(
+    "items,result",
+    [
+        [[], ""],
+        [["foo"], "'foo'"],
+        [["foo", "bar"], "'bar' & 'foo'"],
+        [[3, 2, 1], "1, 2, & 3"],
+    ],
+)
+def test_humanize_list(items, result):
+    hl = formatting_utils.humanize_list(iter(items), "&")
+    assert hl == result
+
+
+@pytest.mark.parametrize(
+    "items,item_format,result",
+    [
+        [["foo"], "{!r}", "'foo'"],
+        [[1], "{!r}", "1"],
+        [[42], "{:2x}", "2a"],
+    ],
+)
+def test_humanize_list_item_format(items, item_format, result):
+    hl = formatting_utils.humanize_list(iter(items), "&", item_format)
+    assert hl == result


### PR DESCRIPTION
Validate the parts definition data against the schema. The validator is
largely ported from snapcraft with minor refactoring. Error handling and
`jsonschema.ValidationError` post-processing is also ported from snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
