### PR TITLE
parts: refactor to remove stored dictionary data

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -89,7 +89,7 @@ class PartSpecificationError(PartsError):
     :param message: The error message.
     """
 
-    def __init__(self, part_name: str, message: str):
+    def __init__(self, *, part_name: str, message: str):
         self.part_name = part_name
         self.message = message
         brief = f"Part {part_name!r} definition error: {message}."

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -81,3 +81,18 @@ class InvalidArchitecture(PartsError):
         resolution = "Make sure the architecture name is correct."
 
         super().__init__(brief=brief, resolution=resolution)
+
+
+class PartSpecificationError(PartsError):
+    """Parts were not correctly specified.
+
+    :param message: The error message.
+    """
+
+    def __init__(self, part_name: str, message: str):
+        self.part_name = part_name
+        self.message = message
+        brief = f"Part {part_name!r} definition error: {message}."
+        resolution = f"Review part {part_name!r} and make sure it's correct."
+
+        super().__init__(brief=brief, resolution=resolution)

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -170,7 +170,9 @@ class Part:
         project_dirs: ProjectDirs = None,
     ):
         if not isinstance(data, dict):
-            raise errors.PartSpecificationError(name, "part data is not a dictionary")
+            raise errors.PartSpecificationError(
+                part_name=name, message="part data is not a dictionary"
+            )
 
         if not project_dirs:
             project_dirs = ProjectDirs()
@@ -186,7 +188,7 @@ class Part:
         try:
             self.spec = PartSpec.unmarshal(data)
         except ValueError as err:
-            raise errors.PartSpecificationError(name, str(err))
+            raise errors.PartSpecificationError(part_name=name, message=str(err))
 
     def __repr__(self):
         return f"Part({self.name!r})"

--- a/craft_parts/unmarshal.py
+++ b/craft_parts/unmarshal.py
@@ -1,0 +1,93 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers for data class unmarshaling."""
+
+from typing import Any, Dict, List, Optional
+
+
+class DataUnmarshaler:
+    """Unmarshal data with validation helpers.
+
+    :param data: The dictionary to unmarshal data from.
+    """
+
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def pop_string(self, key: str, default: str = "") -> str:
+        """Pop an item and validates it as a string."""
+        value = self._data.pop(key, default)
+        if not isinstance(value, str):
+            raise ValueError(f"{key!r} must be a string")
+        return value
+
+    def pop_optional_string(self, key: str, default: str = None) -> Optional[str]:
+        """Pop an item and validates it as a string."""
+        value = self._data.pop(key, default)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"{key!r} must be a string")
+        return value
+
+    def pop_integer(self, key: str, default: int = 0) -> int:
+        """Pop an item and validates it as a boolean."""
+        value = self._data.pop(key, default)
+        if not isinstance(value, int):
+            raise ValueError(f"{key!r} must be an integer")
+        return value
+
+    def pop_boolean(self, key: str, default: bool = False) -> bool:
+        """Pop an item and validates it as a boolean."""
+        value = self._data.pop(key, default)
+        if not isinstance(value, bool):
+            raise ValueError(f"{key!r} must be a boolean")
+        return value
+
+    def pop_list_str(self, key: str, default: List[str] = None) -> List[str]:
+        """Pop an item and validates it as a list of strings."""
+        if not default:
+            default = []
+        print("===", type(self._data))
+        value = self._data.pop(key, default)
+        if not isinstance(value, list):
+            raise ValueError(f"{key!r} must be a list of strings")
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError(f"{key!r} must be a list of strings")
+        return value
+
+    def pop_list_dict(
+        self, key: str, default: List[Dict[str, str]] = None
+    ) -> List[Dict[str, str]]:
+        """Pop an item and validates it as a list of dicts."""
+        if not default:
+            default = []
+        value = self._data.pop(key, default)
+        if not isinstance(value, list):
+            raise ValueError(f"{key!r} must be a list of dictionaries")
+        for item in value:
+            if not isinstance(item, dict):
+                raise ValueError(f"{key!r} must be a list of dictionaries")
+        return value
+
+    def pop_dict(self, key: str, default: Dict[str, Any] = None) -> Dict[str, Any]:
+        """Pop an item and validates it as a dict."""
+        if not default:
+            default = {}
+        value = self._data.pop(key, default)
+        if not isinstance(value, dict):
+            raise ValueError(f"{key!r} must be a dictionary")
+        return value

--- a/craft_parts/unmarshal.py
+++ b/craft_parts/unmarshal.py
@@ -16,7 +16,7 @@
 
 """Helpers for data class unmarshaling."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, KeysView, List, Optional
 
 
 class DataUnmarshaler:
@@ -25,45 +25,53 @@ class DataUnmarshaler:
     :param data: The dictionary to unmarshal data from.
     """
 
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: Dict[str, Any], consume: bool = False):
+        if consume:
+            self._retrieve = self._pop
+        else:
+            self._retrieve = self._get
+
         self._data = data
 
-    def pop_string(self, key: str, default: str = "") -> str:
+    def keys(self) -> KeysView[str]:
+        """Return the current data dictionary keys."""
+        return self._data.keys()
+
+    def get_string(self, key: str, default: str = "") -> str:
         """Pop an item and validates it as a string."""
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, str):
             raise ValueError(f"{key!r} must be a string")
         return value
 
-    def pop_optional_string(
+    def get_optional_string(
         self, key: str, default: Optional[str] = None
     ) -> Optional[str]:
         """Pop an item and validates it as a string."""
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if value is not None and not isinstance(value, str):
             raise ValueError(f"{key!r} must be a string")
         return value
 
-    def pop_integer(self, key: str, default: int = 0) -> int:
+    def get_integer(self, key: str, default: int = 0) -> int:
         """Pop an item and validates it as a boolean."""
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, int):
             raise ValueError(f"{key!r} must be an integer")
         return value
 
-    def pop_boolean(self, key: str, default: bool = False) -> bool:
+    def get_boolean(self, key: str, default: bool = False) -> bool:
         """Pop an item and validates it as a boolean."""
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, bool):
             raise ValueError(f"{key!r} must be a boolean")
         return value
 
-    def pop_list_str(self, key: str, default: Optional[List[str]] = None) -> List[str]:
+    def get_list_str(self, key: str, default: Optional[List[str]] = None) -> List[str]:
         """Pop an item and validates it as a list of strings."""
         if not default:
             default = []
-        print("===", type(self._data))
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, list):
             raise ValueError(f"{key!r} must be a list of strings")
         for item in value:
@@ -71,13 +79,13 @@ class DataUnmarshaler:
                 raise ValueError(f"{key!r} must be a list of strings")
         return value
 
-    def pop_list_dict(
+    def get_list_dict(
         self, key: str, default: Optional[List[Dict[str, str]]] = None
     ) -> List[Dict[str, str]]:
         """Pop an item and validates it as a list of dicts."""
         if not default:
             default = []
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, list):
             raise ValueError(f"{key!r} must be a list of dictionaries")
         for item in value:
@@ -85,13 +93,19 @@ class DataUnmarshaler:
                 raise ValueError(f"{key!r} must be a list of dictionaries")
         return value
 
-    def pop_dict(
+    def get_dict(
         self, key: str, default: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Pop an item and validates it as a dict."""
         if not default:
             default = {}
-        value = self._data.pop(key, default)
+        value = self._retrieve(key, default)
         if not isinstance(value, dict):
             raise ValueError(f"{key!r} must be a dictionary")
         return value
+
+    def _get(self, key, default):
+        return self._data.get(key, default)
+
+    def _pop(self, key, default):
+        return self._data.pop(key, default)

--- a/craft_parts/unmarshal.py
+++ b/craft_parts/unmarshal.py
@@ -35,7 +35,9 @@ class DataUnmarshaler:
             raise ValueError(f"{key!r} must be a string")
         return value
 
-    def pop_optional_string(self, key: str, default: str = None) -> Optional[str]:
+    def pop_optional_string(
+        self, key: str, default: Optional[str] = None
+    ) -> Optional[str]:
         """Pop an item and validates it as a string."""
         value = self._data.pop(key, default)
         if value is not None and not isinstance(value, str):
@@ -56,7 +58,7 @@ class DataUnmarshaler:
             raise ValueError(f"{key!r} must be a boolean")
         return value
 
-    def pop_list_str(self, key: str, default: List[str] = None) -> List[str]:
+    def pop_list_str(self, key: str, default: Optional[List[str]] = None) -> List[str]:
         """Pop an item and validates it as a list of strings."""
         if not default:
             default = []
@@ -70,7 +72,7 @@ class DataUnmarshaler:
         return value
 
     def pop_list_dict(
-        self, key: str, default: List[Dict[str, str]] = None
+        self, key: str, default: Optional[List[Dict[str, str]]] = None
     ) -> List[Dict[str, str]]:
         """Pop an item and validates it as a list of dicts."""
         if not default:
@@ -83,7 +85,9 @@ class DataUnmarshaler:
                 raise ValueError(f"{key!r} must be a list of dictionaries")
         return value
 
-    def pop_dict(self, key: str, default: Dict[str, Any] = None) -> Dict[str, Any]:
+    def pop_dict(
+        self, key: str, default: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Pop an item and validates it as a dict."""
         if not default:
             default = {}

--- a/craft_parts/utils/formatting_utils.py
+++ b/craft_parts/utils/formatting_utils.py
@@ -1,0 +1,55 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Text formatting utilities."""
+
+from typing import Iterable, Sized
+
+
+def humanize_list(
+    items: Iterable[str], conjunction: str, item_format: str = "{!r}"
+) -> str:
+    """Format a list into a human-readable string.
+
+    :param list items: List to humanize.
+    :param str conjunction: The conjunction used to join the final element to
+                            the rest of the list (e.g. 'and').
+    :param str item_format: Format string to use per item.
+    """
+    if not items:
+        return ""
+
+    quoted_items = [item_format.format(item) for item in sorted(items)]
+    if not quoted_items:
+        return ""
+
+    if len(quoted_items) == 1:
+        return quoted_items[0]
+
+    humanized = ", ".join(quoted_items[:-1])
+
+    if len(quoted_items) > 2:
+        humanized += ","
+
+    return "{} {} {}".format(humanized, conjunction, quoted_items[-1])
+
+
+def pluralize(container: Sized, if_one: str, if_multiple: str) -> str:
+    """Return the appropriate plural form according to the number of elements."""
+    if len(container) > 1:
+        return if_multiple
+
+    return if_one

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -62,3 +62,12 @@ def test_invalid_architecture():
     assert err.brief == "Architecture 'm68k' is not supported."
     assert err.details is None
     assert err.resolution == "Make sure the architecture name is correct."
+
+
+def test_part_specification_error():
+    err = errors.PartSpecificationError("foo", "something is wrong")
+    assert err.part_name == "foo"
+    assert err.message == "something is wrong"
+    assert err.brief == "Part 'foo' definition error: something is wrong."
+    assert err.details is None
+    assert err.resolution == "Review part 'foo' and make sure it's correct."

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -65,7 +65,7 @@ def test_invalid_architecture():
 
 
 def test_part_specification_error():
-    err = errors.PartSpecificationError("foo", "something is wrong")
+    err = errors.PartSpecificationError(part_name="foo", message="something is wrong")
     assert err.part_name == "foo"
     assert err.message == "something is wrong"
     assert err.brief == "Part 'foo' definition error: something is wrong."

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -64,6 +64,11 @@ class TestPartSpecs:
         new_data = spec.marshal()
         assert data_copy == new_data
 
+    def test_unmarshal_not_dict(self):
+        with pytest.raises(ValueError) as raised:
+            PartSpec.unmarshal(False)  # type: ignore
+        assert str(raised.value) == "part data is not a dictionary"
+
     def test_unmarshal_unknown_data(self):
         data = {
             "plugin": "nil",
@@ -75,7 +80,7 @@ class TestPartSpecs:
         assert data == {"unknown": True}
 
 
-class TestPartBasics:
+class TestPartData:
     """Test basic part creation and representation."""
 
     def test_part_dirs(self, new_dir):
@@ -266,6 +271,22 @@ class TestPartOrdering:
 
         with pytest.raises(errors.PartDependencyCycle):
             parts.sort_parts([p1, p2, p3])
+
+
+class TestPartErrors:
+    """Verify exceptions raised on part creation."""
+
+    def test_part_spec_not_dict(self):
+        with pytest.raises(errors.PartSpecificationError) as raised:
+            Part("foo", False)  # type: ignore
+        assert raised.value.part_name == "foo"
+        assert raised.value.message == "part data is not a dictionary"
+
+    def test_part_unmarshal_type_error(self):
+        with pytest.raises(errors.PartSpecificationError) as raised:
+            Part("foo", {"plugin": False})
+        assert raised.value.part_name == "foo"
+        assert raised.value.message == "'plugin' must be a string"
 
 
 class TestPartHelpers:

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -14,24 +14,79 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from copy import deepcopy
+
 import pytest
 
 from craft_parts import errors, parts
 from craft_parts.dirs import ProjectDirs
-from craft_parts.parts import Part
+from craft_parts.parts import Part, PartSpec
 from craft_parts.steps import Step
+
+
+class TestPartSpecs:
+    """Test part specification creation."""
+
+    def test_marshal_unmarshal(self):
+        data = {
+            "plugin": "nil",
+            "source": "http://example.com/hello-2.3.tar.gz",
+            "source-checksum": "md5/d9210476aac5f367b14e513bdefdee08",
+            "source-branch": "release",
+            "source-commit": "2514f9533ec9b45d07883e10a561b248497a8e3c",
+            "source-depth": 3,
+            "source-subdir": "src",
+            "source-tag": "v2.3",
+            "source-type": "tar",
+            "disable-parallel": True,
+            "after": ["bar"],
+            "stage-snaps": ["stage-snap1", "stage-snap2"],
+            "stage-packages": ["stage-pkg1", "stage-pkg2"],
+            "build-snaps": ["build-snap1", "build-snap2"],
+            "build-packages": ["build-pkg1", "build-pkg2"],
+            "build-environment": [{"ENV1": "on"}, {"ENV2": "off"}],
+            "build-attributes": ["attr1", "attr2"],
+            "organize": {"src1": "dest1", "src2": "dest2"},
+            "stage": ["-usr/docs"],
+            "prime": ["*"],
+            "override-pull": "override-pull",
+            "override-build": "override-build",
+            "override-stage": "override-stage",
+            "override-prime": "override-prime",
+        }
+
+        data_copy = deepcopy(data)
+
+        # unmarshaling consumes unmarshaled data
+        spec = PartSpec.unmarshal(data)
+        assert data == {}
+
+        new_data = spec.marshal()
+        assert data_copy == new_data
+
+    def test_unmarshal_unknown_data(self):
+        data = {
+            "plugin": "nil",
+            "unknown": True,
+        }
+
+        # unknown data is not consumed
+        PartSpec.unmarshal(data)
+        assert data == {"unknown": True}
 
 
 class TestPartBasics:
     """Test basic part creation and representation."""
 
-    def test_part(self, new_dir):
+    def test_part_dirs(self, new_dir):
         p = Part("foo", {"bar": "baz"})
         assert f"{p!r}" == "Part('foo')"
         assert p.name == "foo"
-        assert p.properties == {"bar": "baz"}
+        assert p.parts_dir == new_dir / "parts"
         assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src"
         assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
         assert p.part_install_dir == new_dir / "parts/foo/install"
         assert p.part_state_dir == new_dir / "parts/foo/state"
         assert p.part_packages_dir == new_dir / "parts/foo/stage_packages"
@@ -41,8 +96,11 @@ class TestPartBasics:
 
     def test_part_work_dir(self, new_dir):
         p = Part("foo", {}, project_dirs=ProjectDirs(work_dir="foobar"))
+        assert p.parts_dir == new_dir / "foobar/parts"
         assert p.part_src_dir == new_dir / "foobar/parts/foo/src"
+        assert p.part_src_subdir == new_dir / "foobar/parts/foo/src"
         assert p.part_build_dir == new_dir / "foobar/parts/foo/build"
+        assert p.part_build_subdir == new_dir / "foobar/parts/foo/build"
         assert p.part_install_dir == new_dir / "foobar/parts/foo/install"
         assert p.part_state_dir == new_dir / "foobar/parts/foo/state"
         assert p.part_packages_dir == new_dir / "foobar/parts/foo/stage_packages"
@@ -50,120 +108,95 @@ class TestPartBasics:
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 
+    def test_part_src_build_subdir(self, new_dir):
+        p = Part("foo", {"source-subdir": "foobar"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build/foobar"
+
     def test_part_source(self):
         p = Part("foo", {})
-        assert p.source is None
+        assert p.spec.source is None
 
         p = Part("foo", {"source": "foobar"})
-        assert p.source == "foobar"
+        assert p.spec.source == "foobar"
 
-    def test_part_properties(self):
-        p = Part("foo", {"foo": "bar"})
-        x = p.properties
-        assert x == {"foo": "bar"}
+    def test_part_stage_fileset(self):
+        p = Part("foo", {"stage": ["a", "b", "c"]})
+        assert p.spec.stage_fileset == ["a", "b", "c"]
 
-        # should be immutable
-        x["foo"] = "something else"
-        assert p.properties == {"foo": "bar"}
+    def test_part_prime_fileset(self):
+        p = Part("foo", {"prime": ["a", "b", "c"]})
+        assert p.spec.prime_fileset == ["a", "b", "c"]
+
+    def test_part_organize_fileset(self):
+        p = Part("foo", {"organize": {"a": "b", "c": "d"}})
+        assert p.spec.organize_fileset == {"a": "b", "c": "d"}
 
     def test_part_dependencies(self):
         p = Part("foo", {"after": ["bar"]})
-        x = p.dependencies
-        assert x == ["bar"]
-
-        # should be immutable
-        x.append("extra")
         assert p.dependencies == ["bar"]
 
     def test_part_plugin(self):
         p = Part("foo", {"plugin": "nil"})
-        assert p.plugin == "nil"
+        assert p.spec.plugin == "nil"
 
     def test_part_plugin_missing(self):
         p = Part("foo", {})
-        assert p.plugin is None
+        assert p.spec.plugin is None
 
     def test_part_build_environment(self):
         p = Part("foo", {"build-environment": [{"BAR": "bar"}]})
-        x = p.build_environment
-        assert x == [{"BAR": "bar"}]
-
-        # should be immutable
-        x[0]["BAR"] = "something else"
-        x.append({"FOOBAR": "foobar"})
-        assert p.build_environment == [{"BAR": "bar"}]
+        assert p.spec.build_environment == [{"BAR": "bar"}]
 
     @pytest.mark.parametrize(
         "tc_spec,tc_result",
         [
-            ({}, None),
-            ({"stage-packages": []}, None),
+            ({}, []),
+            ({"stage-packages": []}, []),
             ({"stage-packages": ["foo", "bar"]}, ["foo", "bar"]),
         ],
     )
     def test_part_stage_packages(self, tc_spec, tc_result):
         p = Part("foo", tc_spec)
-        x = p.stage_packages
-        assert x == tc_result
-
-        # should be immutable
-        if x is not None:
-            x.append("foobar")
-            assert p.stage_packages == tc_result
+        assert p.spec.stage_packages == tc_result
 
     @pytest.mark.parametrize(
         "tc_spec,tc_result",
         [
-            ({}, None),
-            ({"stage-snaps": []}, None),
+            ({}, []),
+            ({"stage-snaps": []}, []),
             ({"stage-snaps": ["foo", "bar"]}, ["foo", "bar"]),
         ],
     )
     def test_part_stage_snaps(self, tc_spec, tc_result):
         p = Part("foo", tc_spec)
-        x = p.stage_snaps
-        assert x == tc_result
-
-        # should be immutable
-        if x is not None:
-            x.append("foobar")
-            assert p.stage_snaps == tc_result
+        assert p.spec.stage_snaps == tc_result
 
     @pytest.mark.parametrize(
         "tc_spec,tc_result",
         [
-            ({}, None),
-            ({"build-packages": []}, None),
+            ({}, []),
+            ({"build-packages": []}, []),
             ({"build-packages": ["foo", "bar"]}, ["foo", "bar"]),
         ],
     )
     def test_part_build_packages(self, tc_spec, tc_result):
         p = Part("foo", tc_spec)
-        x = p.build_packages
-        assert x == tc_result
-
-        # should be immutable
-        if x is not None:
-            x.append("foobar")
-            assert p.build_packages == tc_result
+        assert p.spec.build_packages == tc_result
 
     @pytest.mark.parametrize(
         "tc_spec,tc_result",
         [
-            ({}, None),
-            ({"build-snaps": []}, None),
+            ({}, []),
+            ({"build-snaps": []}, []),
             ({"build-snaps": ["foo", "bar"]}, ["foo", "bar"]),
         ],
     )
     def test_part_build_snaps(self, tc_spec, tc_result):
         p = Part("foo", tc_spec)
-        x = p.build_snaps
-        assert x == tc_result
-
-        # should be immutable
-        if x is not None:
-            x.append("foobar")
-            assert p.build_snaps == tc_result
+        assert p.spec.build_snaps == tc_result
 
     @pytest.mark.parametrize(
         "tc_step,tc_content",
@@ -184,7 +217,7 @@ class TestPartBasics:
                 "override-prime": "prime",
             },
         )
-        assert p.get_scriptlet(tc_step) == tc_content
+        assert p.spec.get_scriptlet(tc_step) == tc_content
 
     @pytest.mark.parametrize(
         "step",
@@ -192,7 +225,7 @@ class TestPartBasics:
     )
     def test_part_get_scriptlet_none(self, step):
         p = Part("foo", {})
-        assert p.get_scriptlet(step) is None
+        assert p.spec.get_scriptlet(step) is None
 
 
 class TestPartOrdering:

--- a/tests/unit/test_unmarshal.py
+++ b/tests/unit/test_unmarshal.py
@@ -16,249 +16,112 @@
 
 import pytest
 
-from craft_parts import unmarshal
+from craft_parts.unmarshal import DataUnmarshaler
 
 
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, "", None],
-        [{"test": ""}, "", None],
-        [{"test": "foo"}, "foo", None],
-        [{"test": False}, "", "'test' must be a string"],
-    ],
-)
-def test_unmarshal_string(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
+class TestUnmarshalConsume:
+    """Verify the data consumption switch."""
+
+    def test_unmarshal(self):
+        data = {"test": "foobar"}
+        udata = DataUnmarshaler(data)
+        test = udata.get_string("test")
+        assert test == "foobar"
+        assert data == {"test": "foobar"}
+
+    def test_unmarshal_consume(self):
+        data = {"test": "foobar"}
+        udata = DataUnmarshaler(data, consume=True)
+        test = udata.get_string("test")
+        assert test == "foobar"
+        assert data == {}
+
+
+# pylint: disable=line-too-long
+
+
+class TestUnmarshalData:
+    """Check data retrieval and type correctness."""
+
+    def test_unmarshal_string(self):
+        assert DataUnmarshaler({}).get_string("test") == ""
+        assert DataUnmarshaler({"test": ""}).get_string("test") == ""
+        assert DataUnmarshaler({"test": "a"}).get_string("test") == "a"
+        assert DataUnmarshaler({}).get_string("test", "b") == "b"
+        assert DataUnmarshaler({"test": "a"}).get_string("test", "b") == "a"
+
         with pytest.raises(ValueError) as raised:
-            udata.pop_string("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_string("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": False}).get_string("test")
+        assert str(raised.value) == "'test' must be a string"
 
+    def test_unmarshal_optional_string(self):
+        assert DataUnmarshaler({}).get_optional_string("test") is None
+        assert DataUnmarshaler({"test": "a"}).get_optional_string("test") == "a"
+        assert DataUnmarshaler({}).get_optional_string("test", "b") == "b"
+        assert DataUnmarshaler({"test": "a"}).get_optional_string("test", "b") == "a"
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, "", ""],
-        [{}, "foo", "foo"],
-        [{"test": "bar"}, "", "bar"],
-        [{"test": "bar"}, "foo", "bar"],
-    ],
-)
-def test_unmarshal_string_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_string("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, None, None],
-        [{"test": ""}, "", None],
-        [{"test": "foo"}, "foo", None],
-        [{"test": False}, "", "'test' must be a string"],
-    ],
-)
-def test_unmarshal_optional_string(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_optional_string("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_optional_string("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": False}).get_optional_string("test")
+        assert str(raised.value) == "'test' must be a string"
 
+    def test_unmarshal_integer(self):
+        assert DataUnmarshaler({}).get_integer("test") == 0
+        assert DataUnmarshaler({"test": 42}).get_integer("test") == 42
+        assert DataUnmarshaler({}).get_integer("test", 50) == 50
+        assert DataUnmarshaler({"test": 42}).get_integer("test", 50) == 42
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, None, None],
-        [{}, "foo", "foo"],
-        [{"test": "bar"}, "", "bar"],
-        [{"test": "bar"}, "foo", "bar"],
-    ],
-)
-def test_unmarshal_optional_string_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_optional_string("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, 0, None],
-        [{"test": 42}, 42, None],
-        [{"test": -42}, -42, None],
-        [{"test": "42"}, "", "'test' must be an integer"],
-        [{"test": 42.5}, "", "'test' must be an integer"],
-    ],
-)
-def test_unmarshal_integer(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_integer("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_integer("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": "0"}).get_integer("test")
+        assert str(raised.value) == "'test' must be an integer"
 
+    def test_unmarshal_boolean(self):
+        assert DataUnmarshaler({}).get_boolean("test") is False
+        assert DataUnmarshaler({"test": True}).get_boolean("test") is True
+        assert DataUnmarshaler({}).get_boolean("test", True) is True
+        assert DataUnmarshaler({"test": False}).get_boolean("test", True) is False
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, 5, 5],
-        [{"test": 42}, 50, 42],
-    ],
-)
-def test_unmarshal_integer_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_integer("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, False, None],
-        [{"test": False}, False, None],
-        [{"test": True}, True, None],
-        [{"test": 0}, False, "'test' must be a boolean"],
-    ],
-)
-def test_unmarshal_boolean(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_boolean("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_boolean("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": 0}).get_boolean("test")
+        assert str(raised.value) == "'test' must be a boolean"
 
+    def test_unmarshal_list_str(self):
+        assert DataUnmarshaler({}).get_list_str("test") == []
+        assert DataUnmarshaler({"test": ["a"]}).get_list_str("test") == ["a"]
+        assert DataUnmarshaler({}).get_list_str("test", ["bar"]) == ["bar"]
+        assert DataUnmarshaler({"test": ["a"]}).get_list_str("test", ["bar"]) == ["a"]
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, False, False],
-        [{}, True, True],
-        [{"test": True}, False, True],
-    ],
-)
-def test_unmarshal_boolean_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_boolean("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, [], None],
-        [{"test": ["foo", "bar"]}, ["foo", "bar"], None],
-        [{"test": False}, [], "'test' must be a list of strings"],
-        [{"test": ["foo", 42]}, [], "'test' must be a list of strings"],
-    ],
-)
-def test_unmarshal_list_str(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_list_str("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_list_str("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": 0}).get_list_str("test")
+        assert str(raised.value) == "'test' must be a list of strings"
 
-
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, ["a", "b"], ["a", "b"]],
-        [{"test": ["foo", "bar"]}, ["a", "b"], ["foo", "bar"]],
-    ],
-)
-def test_unmarshal_list_str_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_list_str("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, [], None],
-        [{"test": [{}, {}]}, [{}, {}], None],
-        [{"test": [{"foo": "bar"}]}, [{"foo": "bar"}], None],
-        [{"test": False}, [], "'test' must be a list of dictionaries"],
-        [{"test": [{}, 42]}, [], "'test' must be a list of dictionaries"],
-    ],
-)
-def test_unmarshal_list_dict(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_list_dict("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_list_dict("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": [0]}).get_list_str("test")
+        assert str(raised.value) == "'test' must be a list of strings"
 
+    def test_unmarshal_list_dict(self):
+        # fmt: off
+        assert DataUnmarshaler({}).get_list_dict("test") == []
+        assert DataUnmarshaler({"test": [{"a": "b"}]}).get_list_dict("test") == [{"a": "b"}]
+        assert DataUnmarshaler({}).get_list_dict("test", [{"c": "d"}]) == [{"c": "d"}]
+        assert DataUnmarshaler({"test": [{"a": "b"}]}).get_list_dict("test", [{"c": "d"}]) == [{"a": "b"}]
+        # fmt: on
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, [{"a": "b"}], [{"a": "b"}]],
-        [{"test": [{"foo": "bar"}]}, [{"a": "b"}], [{"foo": "bar"}]],
-    ],
-)
-def test_unmarshal_list_dict_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_list_dict("test", default)
-    assert test == value
-
-
-@pytest.mark.parametrize(
-    "data,value,error",
-    [
-        [{}, {}, None],
-        [{"test": {}}, {}, None],
-        [{"test": {"foo": "bar"}}, {"foo": "bar"}, None],
-        [{"test": False}, {}, "'test' must be a dictionary"],
-    ],
-)
-def test_unmarshal_dict(data, value, error):
-    udata = unmarshal.DataUnmarshaler(data)
-    if error:
         with pytest.raises(ValueError) as raised:
-            udata.pop_dict("test")
-        assert str(raised.value) == error
-    else:
-        test = udata.pop_dict("test")
-        assert "test" not in data
-        assert test == value
+            DataUnmarshaler({"test": 0}).get_list_dict("test")
+        assert str(raised.value) == "'test' must be a list of dictionaries"
 
+        with pytest.raises(ValueError) as raised:
+            DataUnmarshaler({"test": [0]}).get_list_dict("test")
+        assert str(raised.value) == "'test' must be a list of dictionaries"
 
-@pytest.mark.parametrize(
-    "data,default,value",
-    [
-        [{}, {"a": "b"}, {"a": "b"}],
-        [{"test": {"foo": "bar"}}, {"a": "b"}, {"foo": "bar"}],
-    ],
-)
-def test_unmarshal_dict_default(data, default, value):
-    udata = unmarshal.DataUnmarshaler(data)
-    test = udata.pop_dict("test", default)
-    assert test == value
+    def test_unmarshal_dict(self):
+        # fmt: off
+        assert DataUnmarshaler({}).get_dict("test") == {}
+        assert DataUnmarshaler({"test": {"a": "b"}}).get_dict("test") == {"a": "b"}
+        assert DataUnmarshaler({}).get_dict("test", {"c": "d"}) == {"c": "d"}
+        assert DataUnmarshaler({"test": {"a": "b"}}).get_dict("test", {"c": "d"}) == {"a": "b"}
+        # fmt: on
+
+        with pytest.raises(ValueError) as raised:
+            DataUnmarshaler({"test": []}).get_dict("test")
+        assert str(raised.value) == "'test' must be a dictionary"

--- a/tests/unit/test_unmarshal.py
+++ b/tests/unit/test_unmarshal.py
@@ -1,0 +1,264 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import unmarshal
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, "", None],
+        [{"test": ""}, "", None],
+        [{"test": "foo"}, "foo", None],
+        [{"test": False}, "", "'test' must be a string"],
+    ],
+)
+def test_unmarshal_string(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_string("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_string("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, "", ""],
+        [{}, "foo", "foo"],
+        [{"test": "bar"}, "", "bar"],
+        [{"test": "bar"}, "foo", "bar"],
+    ],
+)
+def test_unmarshal_string_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_string("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, None, None],
+        [{"test": ""}, "", None],
+        [{"test": "foo"}, "foo", None],
+        [{"test": False}, "", "'test' must be a string"],
+    ],
+)
+def test_unmarshal_optional_string(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_optional_string("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_optional_string("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, None, None],
+        [{}, "foo", "foo"],
+        [{"test": "bar"}, "", "bar"],
+        [{"test": "bar"}, "foo", "bar"],
+    ],
+)
+def test_unmarshal_optional_string_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_optional_string("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, 0, None],
+        [{"test": 42}, 42, None],
+        [{"test": -42}, -42, None],
+        [{"test": "42"}, "", "'test' must be an integer"],
+        [{"test": 42.5}, "", "'test' must be an integer"],
+    ],
+)
+def test_unmarshal_integer(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_integer("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_integer("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, 5, 5],
+        [{"test": 42}, 50, 42],
+    ],
+)
+def test_unmarshal_integer_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_integer("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, False, None],
+        [{"test": False}, False, None],
+        [{"test": True}, True, None],
+        [{"test": 0}, False, "'test' must be a boolean"],
+    ],
+)
+def test_unmarshal_boolean(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_boolean("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_boolean("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, False, False],
+        [{}, True, True],
+        [{"test": True}, False, True],
+    ],
+)
+def test_unmarshal_boolean_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_boolean("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, [], None],
+        [{"test": ["foo", "bar"]}, ["foo", "bar"], None],
+        [{"test": False}, [], "'test' must be a list of strings"],
+        [{"test": ["foo", 42]}, [], "'test' must be a list of strings"],
+    ],
+)
+def test_unmarshal_list_str(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_list_str("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_list_str("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, ["a", "b"], ["a", "b"]],
+        [{"test": ["foo", "bar"]}, ["a", "b"], ["foo", "bar"]],
+    ],
+)
+def test_unmarshal_list_str_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_list_str("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, [], None],
+        [{"test": [{}, {}]}, [{}, {}], None],
+        [{"test": [{"foo": "bar"}]}, [{"foo": "bar"}], None],
+        [{"test": False}, [], "'test' must be a list of dictionaries"],
+        [{"test": [{}, 42]}, [], "'test' must be a list of dictionaries"],
+    ],
+)
+def test_unmarshal_list_dict(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_list_dict("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_list_dict("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, [{"a": "b"}], [{"a": "b"}]],
+        [{"test": [{"foo": "bar"}]}, [{"a": "b"}], [{"foo": "bar"}]],
+    ],
+)
+def test_unmarshal_list_dict_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_list_dict("test", default)
+    assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,value,error",
+    [
+        [{}, {}, None],
+        [{"test": {}}, {}, None],
+        [{"test": {"foo": "bar"}}, {"foo": "bar"}, None],
+        [{"test": False}, {}, "'test' must be a dictionary"],
+    ],
+)
+def test_unmarshal_dict(data, value, error):
+    udata = unmarshal.DataUnmarshaler(data)
+    if error:
+        with pytest.raises(ValueError) as raised:
+            udata.pop_dict("test")
+        assert str(raised.value) == error
+    else:
+        test = udata.pop_dict("test")
+        assert "test" not in data
+        assert test == value
+
+
+@pytest.mark.parametrize(
+    "data,default,value",
+    [
+        [{}, {"a": "b"}, {"a": "b"}],
+        [{"test": {"foo": "bar"}}, {"a": "b"}, {"foo": "bar"}],
+    ],
+)
+def test_unmarshal_dict_default(data, default, value):
+    udata = unmarshal.DataUnmarshaler(data)
+    test = udata.pop_dict("test", default)
+    assert test == value

--- a/tests/unit/utils/test_formatting_utils.py
+++ b/tests/unit/utils/test_formatting_utils.py
@@ -1,0 +1,52 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.utils import formatting_utils
+
+
+@pytest.mark.parametrize(
+    "items,result",
+    [
+        [[], ""],
+        [["foo"], "'foo'"],
+        [["foo", "bar"], "'bar' & 'foo'"],
+        [[3, 2, 1], "1, 2, & 3"],
+    ],
+)
+def test_humanize_list(items, result):
+    hl = formatting_utils.humanize_list(iter(items), "&")
+    assert hl == result
+
+
+@pytest.mark.parametrize(
+    "items,item_format,result",
+    [
+        [["foo"], "{!r}", "'foo'"],
+        [[1], "{!r}", "1"],
+        [[42], "{:2x}", "2a"],
+    ],
+)
+def test_humanize_list_item_format(items, item_format, result):
+    hl = formatting_utils.humanize_list(iter(items), "&", item_format)
+    assert hl == result
+
+
+def test_pluraize():
+    assert formatting_utils.pluralize([], "a", "b") == "a"
+    assert formatting_utils.pluralize([1], "a", "b") == "a"
+    assert formatting_utils.pluralize([1, 2], "a", "b") == "b"


### PR DESCRIPTION
Refactor the parts definition to unmarshal parts specification data
instead of storing it. Validation should be done before populating the
spec object instead of relying on jsonschema validation.

This PR conflicts with PR #6.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
