### PR TITLE
tests: configure pylint to issue fixme-info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ test-pydocstyle:
 
 .PHONY: test-pylint
 test-pylint:
-	pylint --fail-under=9.0 craft_parts
-	pylint tests --fail-under=9.0 --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name,no-self-use,duplicate-code,protected-access,too-few-public-methods
+	pylint craft_parts
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access
 
 .PHONY: test-pyright
 test-pyright:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.pylint.messages_control]
-disable = "bad-continuation,bad-whitespace,too-many-ancestors,too-few-public-methods"
+disable = "bad-continuation,bad-whitespace,too-many-ancestors,too-few-public-methods,fixme"
 
 [tool.pylint.similarities]
 min-similarity-lines=13
@@ -20,8 +20,10 @@ max-locals = 16
 
 [tool.pylint.MASTER]
 extension-pkg-whitelist = [
-    "apt_pkg"
+    "apt_pkg",
+    "pydantic"
 ]
+load-plugins = "pylint_fixme_info"
 
 [tool.black]
 exclude = '/((\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|parts|stage|prime)/|setup.py)'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ isort
 mypy
 pydocstyle
 pylint
+pylint-fixme-info
 pytest
 pytest-mock
 sphinx


### PR DESCRIPTION
Use the pylint_fixme_info plugin to make TODO/FIXME messages informational
rather than warnings or errors. This allows us to remove the --fail-under
switch when running pylint on CI.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
