### PR TITLE
states: add pull state class

### DIFF
--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -1,0 +1,82 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""State definitions for the pull step."""
+
+from typing import Any, Dict
+
+from .step_state import StepState
+
+
+class PullState(StepState):
+    """Context information for the pull step."""
+
+    assets: Dict[str, Any] = {}
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "PullState":
+        """Create and populate a new ``PullState`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the state object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("state data is not a dictionary")
+
+        return cls(**data)
+
+    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Return relevant properties concerning this step.
+
+        :param part_properties: A dictionary containing all part properties.
+
+        :return: A dictionary containing properties of interest.
+        """
+        relevant_properties = [
+            "plugin",
+            "source",
+            "source-commit",
+            "source-depth",
+            "source-tag",
+            "source-type",
+            "source-branch",
+            "source-subdir",
+            "override-pull",
+            "stage-packages",
+        ]
+
+        properties: Dict[str, Any] = {}
+        for name in relevant_properties:
+            properties[name] = part_properties.get(name)
+
+        return properties
+
+    def project_options_of_interest(
+        self, project_options: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Return relevant project options concerning this step.
+
+        :param project_options: A dictionary containing all project options.
+
+        :return: A dictionary containing project options of interest.
+        """
+        return {"target-arch": project_options.get("target-arch")}

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -18,7 +18,7 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Hashable, Set
+from typing import Any, Dict, Set
 
 from pydantic_yaml import YamlModel  # type: ignore
 
@@ -103,18 +103,13 @@ class StepState(YamlModel, ABC):
         filepath.write_text(yaml_data)
 
 
-def _get_differing_keys(
-    dict1: Dict[str, Hashable], dict2: Dict[str, Hashable]
-) -> Set[str]:
+def _get_differing_keys(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Set[str]:
     """Return the keys of dictionary entries with different values.
 
     Given two dictionaries, return a set containing the keys for entries
     that don't have the same value in both dictionaries. Entries with value
     of None are equivalent to a non-existing entry.
     """
-    # TODO: refactor implementation
-    #       can we use something similar to what @cjp256 suggested in
-    #       https://github.com/canonical/craft-parts/pull/10/?
     differing_keys = set()
     for key, dict1_value in dict1.items():
         dict2_value = dict2.get(key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+PyYAML==5.4.1
 pydantic==1.8.1
 pydantic-yaml==0.2.3

--- a/tests/unit/state_manager/conftest.py
+++ b/tests/unit/state_manager/conftest.py
@@ -1,0 +1,57 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.fixture
+def properties() -> Dict[str, Any]:
+    return {
+        "plugin": "nil",
+        "source": "http://example.com/hello-2.3.tar.gz",
+        "source-checksum": "md5/d9210476aac5f367b14e513bdefdee08",
+        "source-branch": "release",
+        "source-commit": "2514f9533ec9b45d07883e10a561b248497a8e3c",
+        "source-depth": 3,
+        "source-subdir": "src",
+        "source-tag": "v2.3",
+        "source-type": "tar",
+        "disable-parallel": True,
+        "after": ["bar"],
+        "stage-snaps": ["stage-snap1", "stage-snap2"],
+        "stage-packages": ["stage-pkg1", "stage-pkg2"],
+        "build-snaps": ["build-snap1", "build-snap2"],
+        "build-packages": ["build-pkg1", "build-pkg2"],
+        "build-environment": [{"ENV1": "on"}, {"ENV2": "off"}],
+        "build-attributes": ["attr1", "attr2"],
+        "organize": {"src1": "dest1", "src2": "dest2"},
+        "stage": ["-usr/docs"],
+        "prime": ["*"],
+        "override-pull": "override-pull",
+        "override-build": "override-build",
+        "override-stage": "override-stage",
+        "override-prime": "override-prime",
+    }
+
+
+@pytest.fixture
+def project_options() -> Dict[str, Any]:
+    return {
+        "application-name": "test",
+        "target-arch": "amd64",
+    }

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -1,0 +1,119 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from craft_parts.state_manager.pull_state import PullState
+
+
+class TestPullState:
+    """Verify PullState initialization and marshaling."""
+
+    def test_marshal_empty(self):
+        state = PullState()
+        assert state.marshal() == {
+            "assets": {},
+            "part-properties": {},
+            "project-options": {},
+            "files": set(),
+            "directories": set(),
+        }
+
+    def test_marshal_unmarshal(self):
+        state_data = {
+            "assets": {"stage-packages": ["foo"]},
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+
+        state = PullState.unmarshal(state_data)
+        assert state.marshal() == state_data
+
+    def test_unmarshal_invalid(self):
+        with pytest.raises(TypeError) as raised:
+            PullState.unmarshal(False)  # type: ignore
+        assert str(raised.value) == "state data is not a dictionary"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestPullStatePersist:
+    """Verify writing StepState to file."""
+
+    def test_write(self, properties):
+        state = PullState(
+            assets={"stage-packages": ["foo"]},
+            part_properties=properties,
+            project_options={
+                "target_arch": "amd64",
+            },
+            files={"a"},
+            directories={"b"},
+        )
+
+        state.write(Path("state"))
+        with open("state") as f:
+            content = f.read()
+
+        new_state = yaml.safe_load(content)
+        assert new_state == state.marshal()
+
+
+class TestPullStateChanges:
+    """Verify state comparison methods."""
+
+    def test_property_changes(self, properties):
+        state = PullState(part_properties=properties)
+
+        relevant_properties = [
+            "plugin",
+            "source",
+            "source-commit",
+            "source-depth",
+            "source-tag",
+            "source-type",
+            "source-branch",
+            "source-subdir",
+            "override-pull",
+            "stage-packages",
+        ]
+
+        for prop in properties.keys():
+            other = properties.copy()
+            other[prop] = "new value"
+
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert state.diff_properties_of_interest(other) == {prop}
+            else:
+                # relevant properties didn't change
+                assert state.diff_properties_of_interest(other) == set()
+
+    def test_project_option_changes(self, project_options):
+        state = PullState(project_options=project_options)
+        assert (
+            state.diff_project_options_of_interest(
+                {"target-arch": "amd64", "application-name": "other"}
+            )
+            == set()
+        )
+        assert state.diff_project_options_of_interest(
+            {"target-arch": "m68k", "application-name": "test"}
+        ) == {"target-arch"}

--- a/tests/unit/state_manager/test_step_state.py
+++ b/tests/unit/state_manager/test_step_state.py
@@ -30,9 +30,9 @@ class SomeStepState(step_state.StepState):
         return {"name": part_properties.get("name")}
 
     def project_options_of_interest(
-        self, part_properties: Dict[str, Any]
+        self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {"number": part_properties.get("number")}
+        return {"number": project_options.get("number")}
 
 
 class TestStepState:
@@ -75,10 +75,11 @@ class TestStepState:
         }
 
 
+@pytest.mark.usefixtures("new_dir")
 class TestStepStatePersist:
     """Verify writing StepState to file."""
 
-    def test_write(self, new_dir):
+    def test_write(self):
         state = SomeStepState(
             part_properties={
                 "name": "foo",


### PR DESCRIPTION
The PullState class holds context information collected when the
pull step runs for a part.

This PR partially replaces PR #12.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
