### PR TITLE
states: add build state class

### DIFF
--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -1,0 +1,78 @@
+# -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""State definitions for the build step."""
+
+from typing import Any, Dict
+
+from .step_state import StepState
+
+
+class BuildState(StepState):
+    """Context information for the build step."""
+
+    assets: Dict[str, Any] = {}
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "BuildState":
+        """Create and populate a new ``BuildState`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the state object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("state data is not a dictionary")
+
+        return cls(**data)
+
+    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Return relevant properties concerning this step.
+
+        :param part_properties: A dictionary containing all part properties.
+
+        :return: A dictionary containing properties of interest.
+        """
+        relevant_properties = [
+            "after",
+            "build-attributes",
+            "build-packages",
+            "disable-parallel",
+            "organize",
+            "override-build",
+        ]
+
+        properties: Dict[str, Any] = {}
+        for name in relevant_properties:
+            properties[name] = part_properties.get(name)
+
+        return properties
+
+    def project_options_of_interest(
+        self, project_options: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Return relevant project options concerning this step.
+
+        :param project_options: A dictionary containing all project options.
+
+        :return: A dictionary containing project options of interest.
+        """
+        return {"target-arch": project_options.get("target-arch")}

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -75,4 +75,4 @@ class BuildState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {"target-arch": project_options.get("target-arch")}
+        return {}

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -79,4 +79,4 @@ class PullState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {"target-arch": project_options.get("target-arch")}
+        return {}

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -104,12 +104,4 @@ class TestBuildStateChanges:
 
     def test_project_option_changes(self, project_options):
         state = BuildState(project_options=project_options)
-        assert (
-            state.diff_project_options_of_interest(
-                {"target-arch": "amd64", "application-name": "other"}
-            )
-            == set()
-        )
-        assert state.diff_project_options_of_interest(
-            {"target-arch": "m68k", "application-name": "test"}
-        ) == {"target-arch"}
+        assert state.diff_project_options_of_interest({}) == set()

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -1,0 +1,115 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from craft_parts.state_manager.build_state import BuildState
+
+
+class TestBuildState:
+    """Verify BuildState initialization and marshaling."""
+
+    def test_marshal_empty(self):
+        state = BuildState()
+        assert state.marshal() == {
+            "assets": {},
+            "part-properties": {},
+            "project-options": {},
+            "files": set(),
+            "directories": set(),
+        }
+
+    def test_marshal_unmarshal(self):
+        state_data = {
+            "assets": {"build-packages": ["foo"]},
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+
+        state = BuildState.unmarshal(state_data)
+        assert state.marshal() == state_data
+
+    def test_unmarshal_invalid(self):
+        with pytest.raises(TypeError) as raised:
+            BuildState.unmarshal(False)  # type: ignore
+        assert str(raised.value) == "state data is not a dictionary"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestBuildStatePersist:
+    """Verify writing StepState to file."""
+
+    def test_write(self, properties):
+        state = BuildState(
+            assets={"build-packages": ["foo"]},
+            part_properties=properties,
+            project_options={
+                "target_arch": "amd64",
+            },
+            files={"a"},
+            directories={"b"},
+        )
+
+        state.write(Path("state"))
+        with open("state") as f:
+            content = f.read()
+
+        new_state = yaml.safe_load(content)
+        assert new_state == state.marshal()
+
+
+class TestBuildStateChanges:
+    """Verify state comparison methods."""
+
+    def test_property_changes(self, properties):
+        state = BuildState(part_properties=properties)
+
+        relevant_properties = [
+            "after",
+            "build-attributes",
+            "build-packages",
+            "disable-parallel",
+            "organize",
+            "override-build",
+        ]
+
+        for prop in properties.keys():
+            other = properties.copy()
+            other[prop] = "new value"
+
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert state.diff_properties_of_interest(other) == {prop}
+            else:
+                # relevant properties didn't change
+                assert state.diff_properties_of_interest(other) == set()
+
+    def test_project_option_changes(self, project_options):
+        state = BuildState(project_options=project_options)
+        assert (
+            state.diff_project_options_of_interest(
+                {"target-arch": "amd64", "application-name": "other"}
+            )
+            == set()
+        )
+        assert state.diff_project_options_of_interest(
+            {"target-arch": "m68k", "application-name": "test"}
+        ) == {"target-arch"}

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -108,12 +108,4 @@ class TestPullStateChanges:
 
     def test_project_option_changes(self, project_options):
         state = PullState(project_options=project_options)
-        assert (
-            state.diff_project_options_of_interest(
-                {"target-arch": "amd64", "application-name": "other"}
-            )
-            == set()
-        )
-        assert state.diff_project_options_of_interest(
-            {"target-arch": "m68k", "application-name": "test"}
-        ) == {"target-arch"}
+        assert state.diff_project_options_of_interest({}) == set()


### PR DESCRIPTION
The BuildState class holds context information collected when the
build step runs for a part.

This PR partially replaces PR #12.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
