### PR TITLE
states: add stage state class

### DIFF
--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""State definitions for the stage step."""
+
+from typing import Any, Dict
+
+from .step_state import StepState
+
+
+class StageState(StepState):
+    """Context information for the stage step."""
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "StageState":
+        """Create and populate a new ``StageState`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the state object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("state data is not a dictionary")
+
+        return cls(**data)
+
+    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Return relevant properties concerning this step.
+
+        :param part_properties: A dictionary containing all part properties.
+
+        :return: A dictionary containing properties of interest.
+        """
+        return {
+            "filesets": part_properties.get("filesets", {}) or {},
+            "override-stage": part_properties.get("override-stage"),
+            "stage": part_properties.get("stage", ["*"]) or ["*"],
+        }
+
+    def project_options_of_interest(
+        self, project_options: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Return relevant project options concerning this step.
+
+        :param project_options: A dictionary containing all project options.
+
+        :return: A dictionary containing project options of interest.
+        """
+        return {}

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -1,0 +1,101 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from craft_parts.state_manager.stage_state import StageState
+
+
+class TestStageState:
+    """Verify StageState initialization and marshaling."""
+
+    def test_marshal_empty(self):
+        state = StageState()
+        assert state.marshal() == {
+            "part-properties": {},
+            "project-options": {},
+            "files": set(),
+            "directories": set(),
+        }
+
+    def test_marshal_unmarshal(self):
+        state_data = {
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+
+        state = StageState.unmarshal(state_data)
+        assert state.marshal() == state_data
+
+    def test_unmarshal_invalid(self):
+        with pytest.raises(TypeError) as raised:
+            StageState.unmarshal(False)  # type: ignore
+        assert str(raised.value) == "state data is not a dictionary"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestStageStatePersist:
+    """Verify writing StepState to file."""
+
+    def test_write(self, properties):
+        state = StageState(
+            part_properties=properties,
+            project_options={
+                "target_arch": "amd64",
+            },
+            files={"a"},
+            directories={"b"},
+        )
+
+        state.write(Path("state"))
+        with open("state") as f:
+            content = f.read()
+
+        new_state = yaml.safe_load(content)
+        assert new_state == state.marshal()
+
+
+class TestStageStateChanges:
+    """Verify state comparison methods."""
+
+    def test_property_changes(self, properties):
+        state = StageState(part_properties=properties)
+
+        relevant_properties = [
+            "filesets",
+            "override-stage",
+            "stage",
+        ]
+
+        for prop in properties.keys():
+            other = properties.copy()
+            other[prop] = "new value"
+
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert state.diff_properties_of_interest(other) == {prop}
+            else:
+                # relevant properties didn't change
+                assert state.diff_properties_of_interest(other) == set()
+
+    def test_project_option_changes(self, project_options):
+        state = StageState(project_options=project_options)
+        assert state.diff_project_options_of_interest({}) == set()


### PR DESCRIPTION
The StageState class holds context information collected when the
stage step runs for a part.

This PR partially replaces PR #12.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
