### PR TITLE
states: add prime state class and state loader

### DIFF
--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""State definitions for the prime state."""
+
+from typing import Any, Dict, Set
+
+from .step_state import StepState
+
+
+class PrimeState(StepState):
+    """Context information for the prime step."""
+
+    dependency_paths: Set[str] = set()
+    primed_stage_packages: Set[str] = set()
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "PrimeState":
+        """Create and populate a new ``PrimeState`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the state object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("state data is not a dictionary")
+
+        return cls(**data)
+
+    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+        """Return relevant properties concerning this step.
+
+        :param part_properties: A dictionary containing all part properties.
+
+        :return: A dictionary containing properties of interest.
+        """
+        return {
+            "override-prime": part_properties.get("override-prime"),
+            "prime": part_properties.get("prime", ["*"]) or ["*"],
+        }
+
+    def project_options_of_interest(
+        self, project_options: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Return relevant project options concerning this step.
+
+        :param project_options: A dictionary containing all project options.
+
+        :return: A dictionary containing project options of interest.
+        """
+        return {}

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -51,15 +51,15 @@ def load_state(part: Part, step: Step) -> Optional[StepState]:
         state_data = yaml.safe_load(f)
 
     if step == Step.PULL:
-        state = PullState.unmarshal(state_data)
+        state_class = PullState
     elif step == Step.BUILD:
-        state = BuildState.unmarshal(state_data)
+        state_class = BuildState
     elif step == Step.STAGE:
-        state = StageState.unmarshal(state_data)
+        state_class = StageState
     else:
-        state = PrimeState.unmarshal(state_data)
+        state_class = PrimeState
 
-    return state
+    return state_class.unmarshal(state_data)
 
 
 def state_file_path(part: Part, step: Step) -> Path:

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers and definitions for lifecycle states."""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+from .build_state import BuildState
+from .prime_state import PrimeState
+from .pull_state import PullState
+from .stage_state import StageState
+from .step_state import StepState
+
+logger = logging.getLogger(__name__)
+
+
+def load_state(part: Part, step: Step) -> Optional[StepState]:
+    """Retrieve the persistent state for the given part and step.
+
+    :param part: The part corresponding to the state to load.
+    :param step: The step corresponding to the state to load.
+
+    :return: The step state.
+    """
+    filename = state_file_path(part, step)
+    if not filename.is_file():
+        return None
+
+    logger.debug("load state file: %s", filename)
+    with open(filename) as f:
+        state_data = yaml.safe_load(f)
+
+    if step == Step.PULL:
+        state = PullState.unmarshal(state_data)
+    elif step == Step.BUILD:
+        state = BuildState.unmarshal(state_data)
+    elif step == Step.STAGE:
+        state = StageState.unmarshal(state_data)
+    else:
+        state = PrimeState.unmarshal(state_data)
+
+    return state
+
+
+def state_file_path(part: Part, step: Step) -> Path:
+    """Return the path to the state file for the give part and step."""
+    return part.part_state_dir / step.name.lower()

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -47,8 +47,8 @@ def load_state(part: Part, step: Step) -> Optional[StepState]:
         return None
 
     logger.debug("load state file: %s", filename)
-    with open(filename) as f:
-        state_data = yaml.safe_load(f)
+    with open(filename) as yaml_file:
+        state_data = yaml.safe_load(yaml_file)
 
     if step == Step.PULL:
         state_class = PullState

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ max-line-length = "88"
 max-attributes = 15
 max-args= 6
 max-locals = 16
+good-names = "f"
 
 [tool.pylint.MASTER]
 extension-pkg-whitelist = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ max-line-length = "88"
 max-attributes = 15
 max-args= 6
 max-locals = 16
-good-names = "f"
 
 [tool.pylint.MASTER]
 extension-pkg-whitelist = [

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -1,0 +1,106 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from craft_parts.state_manager.states import PrimeState
+
+
+class TestPrimeState:
+    """Verify PrimeState initialization and marshaling."""
+
+    def test_marshal_empty(self):
+        state = PrimeState()
+        assert state.marshal() == {
+            "part-properties": {},
+            "project-options": {},
+            "files": set(),
+            "directories": set(),
+            "dependency-paths": set(),
+            "primed-stage-packages": set(),
+        }
+
+    def test_marshal_unmarshal(self):
+        state_data = {
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+            "dependency-paths": {"c"},
+            "primed-stage-packages": {"d"},
+        }
+
+        state = PrimeState.unmarshal(state_data)
+        assert state.marshal() == state_data
+
+    def test_unmarshal_invalid(self):
+        with pytest.raises(TypeError) as raised:
+            PrimeState.unmarshal(False)  # type: ignore
+        assert str(raised.value) == "state data is not a dictionary"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestPrimeStatePersist:
+    """Verify writing StepState to file."""
+
+    def test_write(self, properties):
+        state = PrimeState(
+            part_properties=properties,
+            project_options={
+                "target_arch": "amd64",
+            },
+            files={"a"},
+            directories={"b"},
+            dependency_paths={"c"},
+            primed_stage_packages={"d"},
+        )
+
+        state.write(Path("state"))
+        with open("state") as f:
+            content = f.read()
+
+        new_state = yaml.safe_load(content)
+        assert new_state == state.marshal()
+
+
+class TestPrimeStateChanges:
+    """Verify state comparison methods."""
+
+    def test_property_changes(self, properties):
+        state = PrimeState(part_properties=properties)
+
+        relevant_properties = [
+            "override-prime",
+            "prime",
+        ]
+
+        for prop in properties.keys():
+            other = properties.copy()
+            other[prop] = "new value"
+
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert state.diff_properties_of_interest(other) == {prop}
+            else:
+                # relevant properties didn't change
+                assert state.diff_properties_of_interest(other) == set()
+
+    def test_project_option_changes(self, project_options):
+        state = PrimeState(project_options=project_options)
+        assert state.diff_project_options_of_interest({}) == set()

--- a/tests/unit/state_manager/test_states.py
+++ b/tests/unit/state_manager/test_states.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from craft_parts.parts import Part
+from craft_parts.state_manager import states
+from craft_parts.steps import Step
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestStates:
+    """Verify states definitions and helpers."""
+
+    @pytest.mark.parametrize("step", list(Step))
+    def test_load_missing_state(self, step):
+        state = states.load_state(Part("missing", {}), step)
+        assert state is None
+
+    def test_load_pull_state(self):
+        state_data = {
+            "assets": {"stage-packages": ["foo"]},
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+        state_file = Path("parts/foo/state/pull")
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(yaml.dump(state_data))
+
+        state = states.load_state(Part("foo", {}), Step.PULL)
+
+        assert isinstance(state, states.PullState)
+        assert state.marshal() == state_data
+
+    def test_load_build_state(self):
+        state_data = {
+            "assets": {"build-packages": ["foo"]},
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+        state_file = Path("parts/foo/state/build")
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(yaml.dump(state_data))
+
+        state = states.load_state(Part("foo", {}), Step.BUILD)
+
+        assert isinstance(state, states.BuildState)
+        assert state.marshal() == state_data
+
+    def test_load_stage_state(self):
+        state_data = {
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+        }
+        state_file = Path("parts/foo/state/stage")
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(yaml.dump(state_data))
+
+        state = states.load_state(Part("foo", {}), Step.STAGE)
+
+        assert isinstance(state, states.StageState)
+        assert state.marshal() == state_data
+
+    def test_load_prime_state(self):
+        state_data = {
+            "part-properties": {"plugin": "nil"},
+            "project-options": {"target_arch": "amd64"},
+            "files": {"a"},
+            "directories": {"b"},
+            "dependency-paths": {"c"},
+            "primed-stage-packages": {"d"},
+        }
+        state_file = Path("parts/foo/state/prime")
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(yaml.dump(state_data))
+
+        state = states.load_state(Part("foo", {}), Step.PRIME)
+
+        assert isinstance(state, states.PrimeState)
+        assert state.marshal() == state_data


### PR DESCRIPTION
The PrimeState class holds context information collected when the
prime step runs for a part. Also add a state loader helper that
reads persistent state based on part and state, unmarshaling data
into an appropriate state object.

This PR replaces PR #12.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
