### PR TITLE
states: add state metadata and ephemeral state manager

### DIFF
--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -127,7 +127,7 @@ class _EphemeralStates:
             new_stw = self.wrap_state(stw.state, step_updated=step_updated)
             self.set(part_name=part_name, step=step, state=new_stw)
 
-    def step_updated(self, *, part_name: str, step: Step) -> bool:
+    def is_step_updated(self, *, part_name: str, step: Step) -> bool:
         """Verify whether the part and step was updated.
 
         The ``step_updated`` status is set when an outdated step is scheduled to

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -53,7 +53,9 @@ class _EphemeralStates:
         self._state: Dict[Tuple[str, Step], _StateWrapper] = {}
         self._serial_gen = itertools.count(1)
 
-    def wrap_state(self, state: StepState, step_updated: bool = False) -> _StateWrapper:
+    def wrap_state(
+        self, state: StepState, *, step_updated: bool = False
+    ) -> _StateWrapper:
         """Add metadata to step state.
 
         :param state: The part state to store.

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -86,7 +86,7 @@ class _StateDB:
         self._state[(part_name, step)] = state
 
     def get(self, *, part_name: str, step: Step) -> Optional[_StateWrapper]:
-        """Retrieve the state for a given part and step.
+        """Retrieve the wrapped state for a given part and step.
 
         :param part_name: The name of the part corresponding to the state
             to be retrieved.
@@ -122,6 +122,7 @@ class _StateDB:
         :param part_name: The name of the part corresponding to the state
             to be rewrapped.
         :param step: The step corresponding to the state to be rewrapped.
+        :param step_updated: Whether this step should be marked as updated.
         """
         stw = self.get(part_name=part_name, step=step)
         if stw:

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -1,0 +1,152 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Part crafter step state management."""
+
+import itertools
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from craft_parts.steps import Step
+
+from .states import StepState
+
+
+@dataclass(frozen=True)
+class _StateWrapper:
+    """A wrapper for the in-memory StepState class with extra metadata.
+
+    This is a wrapper class for StepState that adds additional metadata
+    such as the update sequence order to the data loaded from a previous
+    lifecycle run. Metadata is read-only to prevent unintentional changes.
+    """
+
+    state: StepState
+    serial: int
+    step_updated: bool = False
+
+    def is_newer_than(self, other: "_StateWrapper"):
+        """Verify if this state is newer than the specified state.
+
+        :param other: The wrapped state to compare this state to.
+        """
+        return self.serial > other.serial
+
+
+class _EphemeralStates:
+    """A dictionary-backed simple database manager for wrapped states."""
+
+    def __init__(self):
+        self._state: Dict[str, Dict[Step, _StateWrapper]] = {}
+        self._serial_gen = itertools.count(1)
+
+    def wrap_state(self, state: StepState, step_updated: bool = False) -> _StateWrapper:
+        """Add metadata to step state.
+
+        :param state: The part state to store.
+        :param step_updated: Whether this state was updated after an
+            outdated report.
+
+        :return: The wrapped state with additional metadata.
+        """
+        stw = _StateWrapper(
+            state, serial=next(self._serial_gen), step_updated=step_updated
+        )
+        return stw
+
+    def set(
+        self, *, part_name: str, step: Step, state: Optional[_StateWrapper]
+    ) -> None:
+        """Set a state for a given part and step.
+
+        :param part_name: The name of the part corresponding to the state
+            to be set.
+        :param step: The step corresponding to the state to be set.
+        :param state: The state to assign to the part name and step.
+        """
+        if not state:
+            self.remove(part_name=part_name, step=step)
+            return
+
+        if part_name not in self._state:
+            self._state[part_name] = dict()
+
+        self._state[part_name][step] = state
+
+    def get(self, *, part_name: str, step: Step) -> Optional[_StateWrapper]:
+        """Retrieve the state for a given part and step.
+
+        :param part_name: The name of the part corresponding to the state
+            to be retrieved.
+        :param step: The step corresponding to the state to be retrieved.
+
+        :return: The wrapped state assigned to the part name and step.
+        """
+        if self.test(part_name=part_name, step=step):
+            return self._state[part_name][step]
+        return None
+
+    def test(self, *, part_name: str, step: Step) -> bool:
+        """Verify if there is a state defined for a given part and step.
+
+        :param part_name: The name of the part corresponding to the state
+            to be tested.
+        :param step: The step corresponding to the state to be tested.
+
+        :return: Whether a state is defined for the part name and step.
+        """
+        if part_name not in self._state:
+            return False
+        return step in self._state[part_name]
+
+    def remove(self, *, part_name: str, step: Step) -> None:
+        """Remove the state for a given part and step.
+
+        :param part_name: The name of the part corresponding to the state
+            to be removed.
+        :param step: The step corresponding to the state to be removed.
+        """
+        if part_name in self._state:
+            self._state[part_name].pop(step, None)
+
+    def rewrap(self, *, part_name: str, step: Step, step_updated: bool = False) -> None:
+        """Rewrap an existing state, updating its metadata.
+
+        :param part_name: The name of the part corresponding to the state
+            to be rewrapped.
+        :param step: The step corresponding to the state to be rewrapped.
+        """
+        stw = self.get(part_name=part_name, step=step)
+        if stw:
+            # rewrap the state with new metadata
+            new_stw = self.wrap_state(stw.state, step_updated=step_updated)
+            self.set(part_name=part_name, step=step, state=new_stw)
+
+    def step_updated(self, *, part_name: str, step: Step) -> bool:
+        """Verify whether the part and step was updated.
+
+        The ``step_updated`` status is set when an outdated step is scheduled to
+        be updated. This is stored as state metadata because updating data on
+        disk only happens in the execution phase).
+
+        :param part_name: The name of the part whose step will be verified.
+        :param step: The step to verify.
+
+        :return: Whether the step was updated.
+        """
+        if self.test(part_name=part_name, step=step):
+            return self._state[part_name][step].step_updated
+        return False

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -46,7 +46,7 @@ class _StateWrapper:
         return self.serial > other.serial
 
 
-class _EphemeralStates:
+class _StateDB:
     """A dictionary-backed simple database manager for wrapped states."""
 
     def __init__(self):

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -147,7 +147,7 @@ class TestEphemeralStates:
         # insert and rewrap the existing state
         eph.set(part_name="foo", step=Step.PULL, state=stw)
         eph.rewrap(part_name="foo", step=Step.PULL)
-        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
         assert rewrapped_stw.serial == 3
@@ -160,15 +160,15 @@ class TestEphemeralStates:
         assert stw.serial == 1
 
         # checking update status of a non-existing state shouldn't fail
-        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         # insert a new state
         eph.set(part_name="foo", step=Step.PULL, state=stw)
-        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         # set the step updated flag
         eph.rewrap(part_name="foo", step=Step.PULL, step_updated=True)
-        assert eph.step_updated(part_name="foo", step=Step.PULL) is True
+        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is True
 
         rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
         assert rewrapped_stw.serial == 2

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -67,108 +67,108 @@ class TestStateWrapper:
             stw.step_updated = True  # type: ignore
 
 
-class TestEphemeralStates:
-    """Check _EphemeralStates initialization and methods."""
+class TestStateDB:
+    """Check _StateDB initialization and methods."""
 
     def test_wrap_state(self):
         state = states.PullState()
 
-        eph = state_manager._EphemeralStates()
-        stw = eph.wrap_state(state)
+        sdb = state_manager._StateDB()
+        stw = sdb.wrap_state(state)
         assert stw.state == state
         assert stw.serial == 1
         assert stw.step_updated is False
 
-        other = eph.wrap_state(state, step_updated=True)
+        other = sdb.wrap_state(state, step_updated=True)
         assert other.serial == 2
         assert other.step_updated is True
 
     def test_state_access(self):
         state = states.PullState()
-        eph = state_manager._EphemeralStates()
-        stw = eph.wrap_state(state)
+        sdb = state_manager._StateDB()
+        stw = sdb.wrap_state(state)
 
         # test & retrieve non-existing state
-        assert eph.test(part_name="foo", step=Step.PULL) is False
-        assert eph.get(part_name="foo", step=Step.PULL) is None
+        assert sdb.test(part_name="foo", step=Step.PULL) is False
+        assert sdb.get(part_name="foo", step=Step.PULL) is None
 
         # delete non-existing state shouldn't fail
-        eph.remove(part_name="foo", step=Step.PULL)
+        sdb.remove(part_name="foo", step=Step.PULL)
 
         # insert state
-        eph.set(part_name="foo", step=Step.PULL, state=stw)
-        assert eph.test(part_name="foo", step=Step.PULL) is True
-        assert eph.get(part_name="foo", step=Step.PULL) == stw
+        sdb.set(part_name="foo", step=Step.PULL, state=stw)
+        assert sdb.test(part_name="foo", step=Step.PULL) is True
+        assert sdb.get(part_name="foo", step=Step.PULL) == stw
 
         # delete state
-        eph.remove(part_name="foo", step=Step.PULL)
-        assert eph.test(part_name="foo", step=Step.PULL) is False
-        assert eph.get(part_name="foo", step=Step.PULL) is None
+        sdb.remove(part_name="foo", step=Step.PULL)
+        assert sdb.test(part_name="foo", step=Step.PULL) is False
+        assert sdb.get(part_name="foo", step=Step.PULL) is None
 
     def test_reinsert_state(self):
         state = states.PullState()
-        eph = state_manager._EphemeralStates()
-        stw = eph.wrap_state(state)
+        sdb = state_manager._StateDB()
+        stw = sdb.wrap_state(state)
 
         # insert a state
-        eph.set(part_name="foo", step=Step.PULL, state=stw)
-        assert eph.test(part_name="foo", step=Step.PULL) is True
-        assert eph.get(part_name="foo", step=Step.PULL) == stw
+        sdb.set(part_name="foo", step=Step.PULL, state=stw)
+        assert sdb.test(part_name="foo", step=Step.PULL) is True
+        assert sdb.get(part_name="foo", step=Step.PULL) == stw
 
         # insert a new state
-        new_stw = eph.wrap_state(state)
+        new_stw = sdb.wrap_state(state)
         assert stw != new_stw
 
-        eph.set(part_name="foo", step=Step.PULL, state=new_stw)
-        assert eph.test(part_name="foo", step=Step.PULL) is True
-        assert eph.get(part_name="foo", step=Step.PULL) == new_stw
+        sdb.set(part_name="foo", step=Step.PULL, state=new_stw)
+        assert sdb.test(part_name="foo", step=Step.PULL) is True
+        assert sdb.get(part_name="foo", step=Step.PULL) == new_stw
 
         # insert None is equivalent to delete
-        eph.set(part_name="foo", step=Step.PULL, state=None)
-        assert eph.test(part_name="foo", step=Step.PULL) is False
-        assert eph.get(part_name="foo", step=Step.PULL) is None
+        sdb.set(part_name="foo", step=Step.PULL, state=None)
+        assert sdb.test(part_name="foo", step=Step.PULL) is False
+        assert sdb.get(part_name="foo", step=Step.PULL) is None
 
     def test_rewrap_state(self):
         state = states.PullState()
-        eph = state_manager._EphemeralStates()
-        stw = eph.wrap_state(state)
+        sdb = state_manager._StateDB()
+        stw = sdb.wrap_state(state)
 
         assert stw.serial == 1
 
         # rewrap a non-existing state shouldn't fail
-        assert eph.test(part_name="foo", step=Step.PULL) is False
-        eph.rewrap(part_name="foo", step=Step.PULL)
-        assert eph.test(part_name="foo", step=Step.PULL) is False
+        assert sdb.test(part_name="foo", step=Step.PULL) is False
+        sdb.rewrap(part_name="foo", step=Step.PULL)
+        assert sdb.test(part_name="foo", step=Step.PULL) is False
 
         # a new state is created
-        new_stw = eph.wrap_state(state)
+        new_stw = sdb.wrap_state(state)
         assert new_stw.serial == 2
 
         # insert and rewrap the existing state
-        eph.set(part_name="foo", step=Step.PULL, state=stw)
-        eph.rewrap(part_name="foo", step=Step.PULL)
-        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
+        sdb.set(part_name="foo", step=Step.PULL, state=stw)
+        sdb.rewrap(part_name="foo", step=Step.PULL)
+        assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is False
 
-        rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
+        rewrapped_stw = sdb.get(part_name="foo", step=Step.PULL)
         assert rewrapped_stw.serial == 3
 
     def test_set_step_updated(self):
         state = states.PullState()
-        eph = state_manager._EphemeralStates()
-        stw = eph.wrap_state(state)
+        sdb = state_manager._StateDB()
+        stw = sdb.wrap_state(state)
 
         assert stw.serial == 1
 
         # checking update status of a non-existing state shouldn't fail
-        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
+        assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         # insert a new state
-        eph.set(part_name="foo", step=Step.PULL, state=stw)
-        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is False
+        sdb.set(part_name="foo", step=Step.PULL, state=stw)
+        assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         # set the step updated flag
-        eph.rewrap(part_name="foo", step=Step.PULL, step_updated=True)
-        assert eph.is_step_updated(part_name="foo", step=Step.PULL) is True
+        sdb.rewrap(part_name="foo", step=Step.PULL, step_updated=True)
+        assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is True
 
-        rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
+        rewrapped_stw = sdb.get(part_name="foo", step=Step.PULL)
         assert rewrapped_stw.serial == 2

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -1,0 +1,174 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import dataclasses
+
+import pytest
+
+from craft_parts.state_manager import state_manager, states
+from craft_parts.steps import Step
+
+
+class TestStateWrapper:
+    """Check _StateWrapper initialization and methods."""
+
+    def test_state_wrapping(self, properties):
+        state = states.PullState(part_properties=properties)
+        stw = state_manager._StateWrapper(state=state, serial=500)
+        assert stw.state == state
+        assert stw.serial == 500
+        assert stw.step_updated is False
+
+    def test_step_updated(self, properties):
+        state = states.PullState(part_properties=properties)
+        stw = state_manager._StateWrapper(state=state, serial=42, step_updated=True)
+        assert stw.state == state
+        assert stw.serial == 42
+        assert stw.step_updated is True
+
+    @pytest.mark.parametrize(
+        "s1,s2,result",
+        [
+            (0, 0, False),
+            (0, 1, False),
+            (1, 0, True),
+        ],
+    )
+    def test_newer_comparison(self, s1, s2, result):
+        state = states.PullState()
+        stw = state_manager._StateWrapper(state=state, serial=s1)
+        other = state_manager._StateWrapper(state=state, serial=s2)
+        assert stw.is_newer_than(other) == result
+
+    def test_frozen_data(self, properties):
+        state = states.PullState(part_properties=properties)
+        stw = state_manager._StateWrapper(state=state, serial=500)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            stw.state = states.PullState()  # type: ignore
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            stw.serial = 5  # type: ignore
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            stw.step_updated = True  # type: ignore
+
+
+class TestEphemeralStates:
+    """Check _EphemeralStates initialization and methods."""
+
+    def test_wrap_state(self):
+        state = states.PullState()
+
+        eph = state_manager._EphemeralStates()
+        stw = eph.wrap_state(state)
+        assert stw.state == state
+        assert stw.serial == 1
+        assert stw.step_updated is False
+
+        other = eph.wrap_state(state, step_updated=True)
+        assert other.serial == 2
+        assert other.step_updated is True
+
+    def test_state_access(self):
+        state = states.PullState()
+        eph = state_manager._EphemeralStates()
+        stw = eph.wrap_state(state)
+
+        # test & retrieve non-existing state
+        assert eph.test(part_name="foo", step=Step.PULL) is False
+        assert eph.get(part_name="foo", step=Step.PULL) is None
+
+        # delete non-existing state shouldn't fail
+        eph.remove(part_name="foo", step=Step.PULL)
+
+        # insert state
+        eph.set(part_name="foo", step=Step.PULL, state=stw)
+        assert eph.test(part_name="foo", step=Step.PULL) is True
+        assert eph.get(part_name="foo", step=Step.PULL) == stw
+
+        # delete state
+        eph.remove(part_name="foo", step=Step.PULL)
+        assert eph.test(part_name="foo", step=Step.PULL) is False
+        assert eph.get(part_name="foo", step=Step.PULL) is None
+
+    def test_reinsert_state(self):
+        state = states.PullState()
+        eph = state_manager._EphemeralStates()
+        stw = eph.wrap_state(state)
+
+        # insert a state
+        eph.set(part_name="foo", step=Step.PULL, state=stw)
+        assert eph.test(part_name="foo", step=Step.PULL) is True
+        assert eph.get(part_name="foo", step=Step.PULL) == stw
+
+        # insert a new state
+        new_stw = eph.wrap_state(state)
+        assert stw != new_stw
+
+        eph.set(part_name="foo", step=Step.PULL, state=new_stw)
+        assert eph.test(part_name="foo", step=Step.PULL) is True
+        assert eph.get(part_name="foo", step=Step.PULL) == new_stw
+
+        # insert None is equivalent to delete
+        eph.set(part_name="foo", step=Step.PULL, state=None)
+        assert eph.test(part_name="foo", step=Step.PULL) is False
+        assert eph.get(part_name="foo", step=Step.PULL) is None
+
+    def test_rewrap_state(self):
+        state = states.PullState()
+        eph = state_manager._EphemeralStates()
+        stw = eph.wrap_state(state)
+
+        assert stw.serial == 1
+
+        # rewrap a non-existing state shouldn't fail
+        assert eph.test(part_name="foo", step=Step.PULL) is False
+        eph.rewrap(part_name="foo", step=Step.PULL)
+        assert eph.test(part_name="foo", step=Step.PULL) is False
+
+        # a new state is created
+        new_stw = eph.wrap_state(state)
+        assert new_stw.serial == 2
+
+        # insert and rewrap the existing state
+        eph.set(part_name="foo", step=Step.PULL, state=stw)
+        eph.rewrap(part_name="foo", step=Step.PULL)
+        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+
+        rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
+        assert rewrapped_stw.serial == 3
+
+    def test_set_step_updated(self):
+        state = states.PullState()
+        eph = state_manager._EphemeralStates()
+        stw = eph.wrap_state(state)
+
+        assert stw.serial == 1
+
+        # checking update status of a non-existing state shouldn't fail
+        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+
+        # insert a new state
+        eph.set(part_name="foo", step=Step.PULL, state=stw)
+        assert eph.step_updated(part_name="foo", step=Step.PULL) is False
+
+        # set the step updated flag
+        eph.rewrap(part_name="foo", step=Step.PULL, step_updated=True)
+        assert eph.step_updated(part_name="foo", step=Step.PULL) is True
+
+        rewrapped_stw = eph.get(part_name="foo", step=Step.PULL)
+        assert rewrapped_stw.serial == 2


### PR DESCRIPTION
Wrap step states with metadata used in lifecycle action sequencing,
and implement a dictionary-backed database of wrapped states indexed
by part name and step.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
