### PR TITLE
states: add stage manager class

### DIFF
--- a/craft_parts/state_manager/__init__.py
+++ b/craft_parts/state_manager/__init__.py
@@ -15,3 +15,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Part state management."""
+
+from .state_manager import StateManager  # noqa: F401


### PR DESCRIPTION
The State Manager initializes and keeps track of states for each part
and step, telling the lifecycle sequencer whether a step should run
for any given part.

This PR starts the implementation of `StateManager`, more methods
will be added in future PRs.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
