### PR TITLE
infos: remove plugin version from project properties

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -35,8 +35,6 @@ class ProjectInfo:
         architecture.
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
-    :param plugin_version: The plugin API version. Currently only ``v2`` is
-        supported.
     :param project_dirs: The project work directories.
     :param custom_args: Any additional arguments defined by the application
         when creating a :class:`LifecycleManager`.
@@ -48,7 +46,6 @@ class ProjectInfo:
         application_name: str = utils.package_name(),
         arch: str = "",
         parallel_build_count: int = 1,
-        plugin_version: str = "v2",
         project_dirs: ProjectDirs = None,
         **custom_args,  # custom passthrough args
     ):
@@ -57,7 +54,6 @@ class ProjectInfo:
 
         self._application_name = application_name
         self._set_machine(arch)
-        self._plugin_version = plugin_version
         self._parallel_build_count = parallel_build_count
         self._dirs = project_dirs
         self._custom_args = custom_args
@@ -90,11 +86,6 @@ class ProjectInfo:
     def is_cross_compiling(self) -> bool:
         """Whether the target and host architectures are different."""
         return self._arch != self._host_arch
-
-    @property
-    def plugin_version(self) -> str:
-        """Return the plugin API version used in this project."""
-        return self._plugin_version
 
     @property
     def parallel_build_count(self) -> int:

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -66,12 +66,10 @@ class LifecycleManager:
         # TODO: validate or slugify application name
 
         project_dirs = ProjectDirs(work_dir=work_dir)
-        plugin_version = "v2"
 
         project_info = ProjectInfo(
             application_name=application_name,
             arch=arch,
-            plugin_version=plugin_version,
             parallel_build_count=parallel_build_count,
             project_dirs=project_dirs,
             **custom_args,

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -50,7 +50,6 @@ def test_project_info(mocker, new_dir, tc_arch, tc_target_arch, tc_triplet, tc_c
     assert x.application_name == "test"
     assert x.arch_triplet == tc_triplet
     assert x.is_cross_compiling == tc_cross
-    assert x.plugin_version == "v2"
     assert x.parallel_build_count == 16
     assert x.target_arch == tc_target_arch
     assert x.project_options == {

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -63,7 +63,6 @@ class TestLifecycleManager:
         assert info.application_name == "test_manager"
         assert info.target_arch == "arm64"
         assert info.arch_triplet == "aarch64-linux-gnu"
-        assert info.plugin_version == "v2"
         assert info.parallel_build_count == 16
         assert info.dirs.parts_dir == self._dir / "work_dir" / "parts"
         assert info.dirs.stage_dir == self._dir / "work_dir" / "stage"


### PR DESCRIPTION
Don't implement support for plugin API versions until we have a practical
use for that feature. It adds unnecessary complexity at this point.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
