### PR TITLE
infos: add part information class

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -163,6 +163,8 @@ class PartInfo:
         self._part_state_dir = part.part_state_dir
 
     def __getattr__(self, name):
+        # Use composition and attribute cascading to avoid setting attributes cumulatively
+        # in the init method.
         if hasattr(self._project_info, name):
             return getattr(self._project_info, name)
 

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -18,10 +18,12 @@
 
 import logging
 import platform
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from craft_parts import errors, utils
 from craft_parts.dirs import ProjectDirs
+from craft_parts.parts import Part
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +139,69 @@ class ProjectInfo:
 
         self._arch = arch
         self._machine = machine
+
+
+class PartInfo:
+    """Part-level information containing project and part fields.
+
+    :param project_info: The project information.
+    :param part: The part we want to obtain information from.
+    """
+
+    def __init__(
+        self,
+        project_info: ProjectInfo,
+        part: Part,
+    ):
+        self._project_info = project_info
+        self._part_name = part.name
+        self._part_src_dir = part.part_src_dir
+        self._part_src_subdir = part.part_src_subdir
+        self._part_build_dir = part.part_build_dir
+        self._part_build_subdir = part.part_build_subdir
+        self._part_install_dir = part.part_install_dir
+        self._part_state_dir = part.part_state_dir
+
+    def __getattr__(self, name):
+        if hasattr(self._project_info, name):
+            return getattr(self._project_info, name)
+
+        raise AttributeError(f"{self.__class__.__name__!r} has no attribute {name!r}")
+
+    @property
+    def part_name(self) -> str:
+        """Return the name of the part we're providing information about."""
+        return self._part_name
+
+    @property
+    def part_src_dir(self) -> Path:
+        """Return the subdirectory containing the part's source code."""
+        return self._part_src_dir
+
+    @property
+    def part_src_subdir(self) -> Path:
+        """Return the subdirectory in source containing the source subtree (if any)."""
+        return self._part_src_subdir
+
+    @property
+    def part_build_dir(self) -> Path:
+        """Return the subdirectory containing the part's build tree."""
+        return self._part_build_dir
+
+    @property
+    def part_build_subdir(self) -> Path:
+        """Return the subdirectory in build containing the source subtree (if any)."""
+        return self._part_build_subdir
+
+    @property
+    def part_install_dir(self) -> Path:
+        """Return the subdirectory to install the part's build artifacts."""
+        return self._part_install_dir
+
+    @property
+    def part_state_dir(self) -> Path:
+        """Return the subdirectory containing this part's lifecycle state."""
+        return self._part_state_dir
 
 
 def _get_host_architecture() -> str:

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -18,7 +18,8 @@ import pytest
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
-from craft_parts.infos import ProjectInfo
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
 
 _MOCK_NATIVE_ARCH = "aarch64"
 
@@ -99,3 +100,36 @@ def test_invalid_arch():
     with pytest.raises(errors.InvalidArchitecture) as raised:
         ProjectInfo(arch="invalid")
     assert raised.value.arch_name == "invalid"
+
+
+def test_part_info(new_dir):
+    info = ProjectInfo(custom1="foobar", custom2=[1, 2])
+    part = Part("foo", {})
+    x = PartInfo(project_info=info, part=part)
+
+    assert x.application_name == "craft_parts"
+    assert x.parallel_build_count == 1
+
+    assert x.part_name == "foo"
+    assert x.part_src_dir == new_dir / "parts/foo/src"
+    assert x.part_src_subdir == new_dir / "parts/foo/src"
+    assert x.part_build_dir == new_dir / "parts/foo/build"
+    assert x.part_build_subdir == new_dir / "parts/foo/build"
+    assert x.part_install_dir == new_dir / "parts/foo/install"
+    assert x.part_state_dir == new_dir / "parts/foo/state"
+    assert x.stage_dir == new_dir / "stage"
+    assert x.prime_dir == new_dir / "prime"
+
+    assert x.custom_args == ["custom1", "custom2"]
+    assert x.custom1 == "foobar"
+    assert x.custom2 == [1, 2]
+
+
+def test_part_info_invalid_custom_args():
+    info = ProjectInfo()
+    part = Part("foo", {})
+    x = PartInfo(project_info=info, part=part)
+
+    with pytest.raises(AttributeError) as raised:
+        print(x.custom1)
+    assert str(raised.value) == "'PartInfo' has no attribute 'custom1'"

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -102,7 +102,7 @@ class TestPartData:
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 
-    def test_part_src_build_subdir(self, new_dir):
+    def test_part_subdirs(self, new_dir):
         p = Part("foo", {"source-subdir": "foobar"})
         assert p.part_src_dir == new_dir / "parts/foo/src"
         assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"


### PR DESCRIPTION
The part information class holds information to be passed to pre and
post-step callbacks for user environment setup.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
