### PR TITLE
states: add outdated step verification

### DIFF
--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -1,0 +1,61 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Provide a report on why a step is outdated."""
+
+from craft_parts.steps import Step
+from craft_parts.utils import formatting_utils
+
+
+class OutdatedReport:
+    """The OutdatedReport class explains why a given step is outdated.
+
+    An outdated step is defined to be a step that has run, but since doing so
+    one of the following things have happened:
+
+    - A step earlier in the lifecycle has run again.
+    - The source on disk has been updated.
+    """
+
+    def __init__(
+        self, *, previous_step_modified: Step = None, source_updated: bool = False
+    ) -> None:
+        """Create a new OutdatedReport.
+
+        :param previous_step_modified: Step earlier in the lifecycle that has changed.
+        :param source_updated: Whether or not the source changed on disk.
+        """
+        self.previous_step_modified = previous_step_modified
+        self.source_updated = source_updated
+
+    def reason(self) -> str:
+        """Get summarized report.
+
+        :return: Short summary of why the step is dirty.
+        :rtype: str
+        """
+        reasons = []
+
+        if self.previous_step_modified:
+            reasons.append("{!r} step".format(self.previous_step_modified.name))
+
+        if self.source_updated:
+            reasons.append("source")
+
+        if not reasons:
+            return ""
+
+        return "{} changed".format(formatting_utils.humanize_list(reasons, "and", "{}"))

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -31,28 +31,27 @@ class OutdatedReport:
     """
 
     def __init__(
-        self, *, previous_step_modified: Step = None, source_updated: bool = False
+        self, *, previous_step_modified: Step = None, source_modified: bool = False
     ) -> None:
         """Create a new OutdatedReport.
 
         :param previous_step_modified: Step earlier in the lifecycle that has changed.
-        :param source_updated: Whether or not the source changed on disk.
+        :param source_modified: Whether the source changed on disk.
         """
         self.previous_step_modified = previous_step_modified
-        self.source_updated = source_updated
+        self.source_modified = source_modified
 
     def reason(self) -> str:
         """Get summarized report.
 
-        :return: Short summary of why the step is dirty.
-        :rtype: str
+        :return: Short summary of why the step is outdated.
         """
         reasons = []
 
         if self.previous_step_modified:
             reasons.append("{!r} step".format(self.previous_step_modified.name))
 
-        if self.source_updated:
+        if self.source_modified:
             reasons.append("source")
 
         if not reasons:

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -210,7 +210,7 @@ class StateManager:
         """
         if (
             not self.has_step_run(part, step)
-            or self.outdated_report(part, step) is not None
+            or self.check_if_outdated(part, step) is not None
             # TODO: test dirty report
         ):
             return True
@@ -221,8 +221,8 @@ class StateManager:
 
         return False
 
-    def outdated_report(self, part: Part, step: Step) -> Optional[OutdatedReport]:
-        """Return an OutdatedReport class describing why the step is outdated.
+    def check_if_outdated(self, part: Part, step: Step) -> Optional[OutdatedReport]:
+        """Verify whether a step is outdated.
 
         A step is considered to be outdated if an earlier step in the lifecycle
         has been run more recently, or if the source code changed on disk.
@@ -230,8 +230,9 @@ class StateManager:
         the previous step. This is in contrast to a "dirty" step, which must
         be cleaned and run again.
 
-        :param steps.Step step: The step to be checked.
-        :returns: OutdatedReport if the step is outdated, None otherwise.
+        :param step: The step to be checked.
+
+        :return: An OutdatedReport if the step is outdated, None otherwise.
         """
         if self._state_db.is_step_updated(part_name=part.name, step=step):
             return None

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -24,6 +24,7 @@ from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
+from .reports import OutdatedReport
 from .states import StepState, load_state, state_file_path
 
 
@@ -191,6 +192,65 @@ class StateManager:
         :return: Whether the step has already run.
         """
         return self._state_db.test(part_name=part.name, step=step)
+
+    def should_step_run(self, part: Part, step: Step) -> bool:
+        """Determine if a given step of a given part should run.
+
+        A given step should run if:
+            1. it hasn't already run
+            2. it's dirty
+            3. it's outdated
+            4. either (1), (2), or (3) apply to any earlier steps in the
+               part's lifecycle.
+
+        :param part: The part the step to be verified belongs to.
+        :param step: The step to verify.
+
+        :return: Whether the step should run.
+        """
+        if (
+            not self.has_step_run(part, step)
+            or self.outdated_report(part, step) is not None
+            # TODO: test dirty report
+        ):
+            return True
+
+        previous_steps = step.previous_steps()
+        if previous_steps:
+            return self.should_step_run(part, previous_steps[-1])
+
+        return False
+
+    def outdated_report(self, part: Part, step: Step) -> Optional[OutdatedReport]:
+        """Return an OutdatedReport class describing why the step is outdated.
+
+        A step is considered to be outdated if an earlier step in the lifecycle
+        has been run more recently, or if the source code changed on disk.
+        This means the step needs to be updated by taking modified files from
+        the previous step. This is in contrast to a "dirty" step, which must
+        be cleaned and run again.
+
+        :param steps.Step step: The step to be checked.
+        :returns: OutdatedReport if the step is outdated, None otherwise.
+        """
+        if self._state_db.is_step_updated(part_name=part.name, step=step):
+            return None
+
+        stw = self._state_db.get(part_name=part.name, step=step)
+        if not stw:
+            return None
+
+        # TODO: verify if the source is outdated according to the source handler
+
+        for previous_step in reversed(step.previous_steps()):
+            # Has a previous step run since this one ran? Then this
+            # step needs to be updated.
+            previous_stw = self._state_db.get(part_name=part.name, step=previous_step)
+
+            if previous_stw and previous_stw.is_newer_than(stw):
+                return OutdatedReport(previous_step_modified=previous_step)
+
+        return None
 
 
 def _sort_steps_by_state_timestamp(

--- a/craft_parts/utils/formatting_utils.py
+++ b/craft_parts/utils/formatting_utils.py
@@ -1,0 +1,44 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+"""Text formatting utilities."""
+
+from typing import Iterable
+
+
+def humanize_list(
+    items: Iterable[str], conjunction: str, item_format: str = "{!r}"
+) -> str:
+    """Format a list into a human-readable string.
+
+    :param items: List to humanize.
+    :param conjunction: The conjunction used to join the final element to
+        the rest of the list (e.g. 'and').
+    :param item_format: Format string to use per item.
+    """
+    if not items:
+        return ""
+
+    quoted_items = [item_format.format(item) for item in sorted(items)]
+    if len(quoted_items) == 1:
+        return quoted_items[0]
+
+    humanized = ", ".join(quoted_items[:-1])
+
+    if len(quoted_items) > 2:
+        humanized += ","
+
+    return "{} {} {}".format(humanized, conjunction, quoted_items[-1])

--- a/tests/unit/state_manager/test_reports.py
+++ b/tests/unit/state_manager/test_reports.py
@@ -21,7 +21,7 @@ from craft_parts.steps import Step
 
 
 @pytest.mark.parametrize(
-    "step,source_updated,result",
+    "step,source_modified,result",
     [
         (None, False, ""),
         (Step.BUILD, False, "'BUILD' step changed"),
@@ -29,8 +29,8 @@ from craft_parts.steps import Step
         (Step.STAGE, True, "'STAGE' step and source changed"),
     ],
 )
-def test_outdated_report(step, source_updated, result):
+def test_outdated_report(step, source_modified, result):
     report = reports.OutdatedReport(
-        previous_step_modified=step, source_updated=source_updated
+        previous_step_modified=step, source_modified=source_modified
     )
     assert report.reason() == result

--- a/tests/unit/state_manager/test_reports.py
+++ b/tests/unit/state_manager/test_reports.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.state_manager import reports
+from craft_parts.steps import Step
+
+
+@pytest.mark.parametrize(
+    "step,source_updated,result",
+    [
+        (None, False, ""),
+        (Step.BUILD, False, "'BUILD' step changed"),
+        (None, True, "source changed"),
+        (Step.STAGE, True, "'STAGE' step and source changed"),
+    ],
+)
+def test_outdated_report(step, source_updated, result):
+    report = reports.OutdatedReport(
+        previous_step_modified=step, source_updated=source_updated
+    )
+    assert report.reason() == result

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -280,7 +280,7 @@ class TestOutdatedReport:
         sm = StateManager(project_info=info, part_list=[p1])
 
         for step in list(Step):
-            assert sm.outdated_report(p1, step) is None
+            assert sm.check_if_outdated(p1, step) is None
 
     def test_outdated(self):
         info = ProjectInfo()
@@ -298,8 +298,9 @@ class TestOutdatedReport:
         sm = StateManager(project_info=info, part_list=[p1])
 
         for step in list(Step):
-            report = sm.outdated_report(p1, step)
+            report = sm.check_if_outdated(p1, step)
             if step == Step.BUILD:
+                assert report is not None
                 assert report.reason() == "'PULL' step changed"
             else:
                 assert report is None
@@ -308,7 +309,7 @@ class TestOutdatedReport:
         sm._state_db.rewrap(part_name="p1", step=Step.BUILD, step_updated=True)
 
         for step in list(Step):
-            assert sm.outdated_report(p1, step) is None
+            assert sm.check_if_outdated(p1, step) is None
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -253,7 +253,7 @@ class TestStateManager:
         s1.write(Path("parts/p1/state/build"))
 
         # but p1 pull ran more recently
-        time.sleep(0.1)
+        time.sleep(0.02)
         s1 = states.StageState()
         s1.write(Path("parts/p1/state/pull"))
 
@@ -291,7 +291,7 @@ class TestOutdatedReport:
         s1.write(Path("parts/p1/state/build"))
 
         # but p1 pull ran more recently
-        time.sleep(0.1)
+        time.sleep(0.02)
         s1 = states.StageState()
         s1.write(Path("parts/p1/state/pull"))
 
@@ -326,12 +326,14 @@ class TestHelpers:
         s4 = states.PrimeState()
 
         # create state files
+        # use 20ms interval to avoid creating files with the same timestamp on
+        # systems with low ticks resolution
         s4.write(Path("parts/bar/state/prime"))
-        time.sleep(0.1)
+        time.sleep(0.02)
         s3.write(Path("parts/bar/state/pull"))
-        time.sleep(0.1)
+        time.sleep(0.02)
         s1.write(Path("parts/foo/state/pull"))
-        time.sleep(0.1)
+        time.sleep(0.02)
         s2.write(Path("parts/foo/state/build"))
 
         slist = state_manager._sort_steps_by_state_timestamp([p1, p2])

--- a/tests/unit/utils/test_formatting_utils.py
+++ b/tests/unit/utils/test_formatting_utils.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.utils import formatting_utils
+
+
+@pytest.mark.parametrize(
+    "items,result",
+    [
+        [None, ""],
+        [[], ""],
+        [["foo"], "'foo'"],
+        [["foo", "bar"], "'bar' & 'foo'"],
+        [[3, 2, 1], "1, 2, & 3"],
+    ],
+)
+def test_humanize_list(items, result):
+    hl = formatting_utils.humanize_list(items, "&")
+    assert hl == result
+
+
+@pytest.mark.parametrize(
+    "items,item_format,result",
+    [
+        [["foo"], "", ""],
+        [["foo"], "{!r}", "'foo'"],
+        [[1], "{!r}", "1"],
+        [[42], "{:2x}", "2a"],
+    ],
+)
+def test_humanize_list_item_format(items, item_format, result):
+    hl = formatting_utils.humanize_list(iter(items), "&", item_format)
+    assert hl == result


### PR DESCRIPTION
A part step is considered outdated if one of previous steps ran more
recently, or if logic in the source handler for that part says so.
This change implements the step execution order verification,
leaving source checks to be added later (after source handlers are
added to the codebase).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
