### PR TITLE
plugins: add plugin and plugin properties base classes

### DIFF
--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -1,0 +1,20 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Craft Parts plugins subsystem."""
+
+from .base import Plugin  # noqa: F401
+from .properties import PluginProperties  # noqa: F401

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -17,7 +17,7 @@
 """Plugin base class and definitions."""
 
 import abc
-from typing import Dict, List, Optional, Set, Type
+from typing import Dict, List, Set, Type
 
 from craft_parts.infos import PartInfo
 
@@ -29,20 +29,15 @@ class Plugin(abc.ABC):
 
     :cvar properties_class: The plugin properties class.
 
-    :param part_info: the part information for the applicable part.
-    :param options: an object representing part defined properties.
+    :param part_info: The part information for the applicable part.
+    :param properties: Part-defined properties.
     """
 
     properties_class: Type[PluginProperties]
 
-    def __init__(
-        self, *, options: Optional[PluginProperties], part_info: PartInfo
-    ) -> None:
-        if not options:
-            options = PluginProperties()
-
+    def __init__(self, *, properties: PluginProperties, part_info: PartInfo) -> None:
         self._name = part_info.part_name
-        self._options = options
+        self._options = properties
         self._part_info = part_info
 
     @abc.abstractmethod

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -29,7 +29,7 @@ class Plugin(abc.ABC):
 
     :cvar properties_class: The plugin properties class.
 
-    :param part_name: the name of the part this plugin is instantiated to.
+    :param part_info: the part information for the applicable part.
     :param options: an object representing part defined properties.
     """
 
@@ -58,7 +58,7 @@ class Plugin(abc.ABC):
         """Return a dictionary with the environment to use in the build step."""
 
     @property
-    def out_of_source_build(self):
+    def out_of_source_build(self) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return False
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Plugin base class and definitions."""
+
+import abc
+from typing import Dict, List, Optional, Set, Type
+
+from craft_parts.infos import PartInfo
+
+from .properties import PluginProperties
+
+
+class Plugin(abc.ABC):
+    """The base class for plugins.
+
+    :cvar properties_class: The plugin properties class.
+
+    :param part_name: the name of the part this plugin is instantiated to.
+    :param options: an object representing part defined properties.
+    """
+
+    properties_class: Type[PluginProperties]
+
+    def __init__(
+        self, *, options: Optional[PluginProperties], part_info: PartInfo
+    ) -> None:
+        if not options:
+            options = PluginProperties()
+
+        self._name = part_info.part_name
+        self._options = options
+        self._part_info = part_info
+
+    @abc.abstractmethod
+    def get_build_snaps(self) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+
+    @abc.abstractmethod
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+
+    @abc.abstractmethod
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+
+    @property
+    def out_of_source_build(self):
+        """Return whether the plugin performs out-of-source-tree builds."""
+        return False
+
+    @abc.abstractmethod
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -1,0 +1,37 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definitions and helpers for plugin options."""
+
+from typing import Any, Dict
+
+
+class PluginProperties:
+    """Options specific to a plugin.
+
+    PluginProperties should be subclassed into plugin-specific property
+    classes and populated from a dictionary containing part properties.
+    """
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "PluginProperties":
+        """Populate class attributes from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+        """
+        return cls()

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -26,6 +26,8 @@ class PluginProperties:
     classes and populated from a dictionary containing part properties.
     """
 
+    # pylint: disable=unused-argument
+
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "PluginProperties":
         """Populate class attributes from the part specification.

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -1,0 +1,66 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Set, cast
+
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins import Plugin, PluginProperties
+
+
+@dataclass
+class FooPluginProperties(PluginProperties):
+
+    name: str
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        return cls(name=data.get("foo-name", "nothing"))
+
+
+class FooPlugin(Plugin):
+
+    properties_class = FooPluginProperties.unmarshal({})
+
+    def get_build_snaps(self) -> Set[str]:
+        return {"build_snap"}
+
+    def get_build_packages(self) -> Set[str]:
+        return {"build_package"}
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {"ENV": "value"}
+
+    def get_build_commands(self) -> List[str]:
+        options = cast(FooPluginProperties, self._options)
+        return ["hello", options.name]
+
+
+def test_plugin():
+    part = Part("p1", {})
+    project_info = ProjectInfo()
+    part_info = PartInfo(project_info=project_info, part=part)
+
+    props = FooPluginProperties.unmarshal({"foo-name": "world"})
+    plugin = FooPlugin(properties=props, part_info=part_info)
+
+    assert isinstance(plugin.properties_class, PluginProperties)
+    assert plugin.get_build_snaps() == {"build_snap"}
+    assert plugin.get_build_packages() == {"build_package"}
+    assert plugin.get_build_environment() == {"ENV": "value"}
+    assert plugin.out_of_source_build is False
+    assert plugin.get_build_commands() == ["hello", "world"]

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -17,6 +17,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Set, cast
 
+import pytest
+
 from craft_parts.infos import PartInfo, ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.plugins import Plugin, PluginProperties
@@ -64,3 +66,19 @@ def test_plugin():
     assert plugin.get_build_environment() == {"ENV": "value"}
     assert plugin.out_of_source_build is False
     assert plugin.get_build_commands() == ["hello", "world"]
+
+
+def test_abstract_methods():
+    class FaultyPlugin(Plugin):
+        pass
+
+    part = Part("p1", {})
+    project_info = ProjectInfo()
+    part_info = PartInfo(project_info=project_info, part=part)
+
+    with pytest.raises(TypeError) as raised:
+        FaultyPlugin(properties=None, part_info=part_info)  # type: ignore
+    assert str(raised.value) == (
+        "Can't instantiate abstract class FaultyPlugin with abstract methods "
+        "get_build_commands, get_build_environment, get_build_packages, get_build_snaps"
+    )

--- a/tests/unit/plugins/test_properties.py
+++ b/tests/unit/plugins/test_properties.py
@@ -1,0 +1,22 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.plugins import PluginProperties
+
+
+def test_properties_unmarshal():
+    prop = PluginProperties.unmarshal({})
+    assert isinstance(prop, PluginProperties)


### PR DESCRIPTION
The plugin subsystem defines how part sources will be built, using
optional plugin-specific properties defined in the part specification.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
