### PR TITLE
states: add dirty step verification

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -154,8 +154,8 @@ class PartInfo:
         self._part_state_dir = part.part_state_dir
 
     def __getattr__(self, name):
-        # Use composition and attribute cascading to avoid setting attributes cumulatively
-        # in the init method.
+        # Use composition and attribute cascading to avoid setting attributes
+        # cumulatively in the init method.
         if hasattr(self._project_info, name):
             return getattr(self._project_info, name)
 

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -99,6 +99,7 @@ class DirtyReport:
         self.dirty_project_options = dirty_project_options
         self.changed_dependencies = changed_dependencies
 
+    # pylint: disable=too-many-branches
     def reason(self) -> str:
         """Get summarized report.
 
@@ -139,3 +140,5 @@ class DirtyReport:
             return ""
 
         return "{} changed".format(formatting_utils.humanize_list(reasons, "and", "{}"))
+
+    # pylint: enable=too-many-branches

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -16,8 +16,13 @@
 
 """Provide a report on why a step is outdated."""
 
+from collections import namedtuple
+from typing import List
+
 from craft_parts.steps import Step
 from craft_parts.utils import formatting_utils
+
+Dependency = namedtuple("Dependency", ["part_name", "step"])
 
 
 class OutdatedReport:
@@ -53,6 +58,76 @@ class OutdatedReport:
 
         if self.source_modified:
             reasons.append("source")
+
+        if not reasons:
+            return ""
+
+        return "{} changed".format(formatting_utils.humanize_list(reasons, "and", "{}"))
+
+
+class DirtyReport:
+    """The DirtyReport class explains why a given step is dirty.
+
+    A dirty step is defined to be a step that has run, but since doing so one
+    of the following things have happened:
+
+    - One or more properties used by the step have changed.
+    - One of more project options have changed.
+    - One of more of its dependencies have been re-staged.
+    """
+
+    def __init__(
+        self,
+        *,
+        dirty_properties: List[str] = None,
+        dirty_project_options: List[str] = None,
+        changed_dependencies: List[Dependency] = None,
+    ) -> None:
+        """Create a new DirtyReport.
+
+        :param dirty_properties: Properties that have changed.
+        :param dirty_project_options: Project options that have changed.
+        :param changed_dependencies: Dependencies that have changed.
+        """
+        self.dirty_properties = dirty_properties
+        self.dirty_project_options = dirty_project_options
+        self.changed_dependencies = changed_dependencies
+
+    def reason(self) -> str:
+        """Get summarized report.
+
+        :return: Short summary of why the part is dirty.
+        """
+        reasons = []
+
+        reasons_count = 0
+        if self.dirty_properties:
+            reasons_count += 1
+        if self.dirty_project_options:
+            reasons_count += 1
+        if self.changed_dependencies:
+            reasons_count += 1
+
+        if self.dirty_properties:
+            # Be specific only if this is the only reason
+            if reasons_count > 1 or len(self.dirty_properties) > 1:
+                reasons.append("properties")
+            else:
+                reasons.append(f"{self.dirty_properties[0]!r} property")
+
+        if self.dirty_project_options:
+            # Be specific only if this is the only reason
+            if reasons_count > 1 or len(self.dirty_project_options) > 1:
+                reasons.append("options")
+            else:
+                reasons.append(f"{self.dirty_project_options[0]!r} option")
+
+        if self.changed_dependencies:
+            # Be specific only if this is the only reason
+            if reasons_count > 1 or len(self.changed_dependencies) > 1:
+                reasons.append("dependencies")
+            else:
+                reasons.append(f"{self.changed_dependencies[0].part_name!r}")
 
         if not reasons:
             return ""

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -16,13 +16,19 @@
 
 """Provide a report on why a step is outdated."""
 
-from collections import namedtuple
+from dataclasses import dataclass
 from typing import List
 
 from craft_parts.steps import Step
 from craft_parts.utils import formatting_utils
 
-Dependency = namedtuple("Dependency", ["part_name", "step"])
+
+@dataclass(frozen=True)
+class Dependency:
+    """The part and step that are a prerequisite to another step."""
+
+    part_name: str
+    step: Step
 
 
 class OutdatedReport:

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -17,15 +17,19 @@
 """Part crafter step state management."""
 
 import itertools
+import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
+from craft_parts import parts, steps
 from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
-from .reports import OutdatedReport
+from .reports import Dependency, DirtyReport, OutdatedReport
 from .states import StepState, load_state, state_file_path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -211,7 +215,7 @@ class StateManager:
         if (
             not self.has_step_run(part, step)
             or self.check_if_outdated(part, step) is not None
-            # TODO: test dirty report
+            or self.check_if_dirty(part, step) is not None
         ):
             return True
 
@@ -230,10 +234,13 @@ class StateManager:
         the previous step. This is in contrast to a "dirty" step, which must
         be cleaned and run again.
 
+        :param part: The part the step to be checked belongs to.
         :param step: The step to be checked.
 
-        :return: An OutdatedReport if the step is outdated, None otherwise.
+        :return: An class:`OutdatedReport` if the step is outdated, None otherwise.
         """
+        logger.debug("check if %s:%s is outdated", part, step)
+
         if self._state_db.is_step_updated(part_name=part.name, step=step):
             return None
 
@@ -250,6 +257,78 @@ class StateManager:
 
             if previous_stw and previous_stw.is_newer_than(stw):
                 return OutdatedReport(previous_step_modified=previous_step)
+
+        return None
+
+    def check_if_dirty(self, part: Part, step: Step) -> Optional[DirtyReport]:
+        """Verify whether a step is dirty.
+
+        A step is considered to be dirty if relevant properties or project
+        options have changed since the step was executed. This means the step
+        needs to be cleaned and run again. This is in contrast to an "outdated"
+        step, which typically doesn't need to be cleaned, just updated with
+        files from an earlier step in the lifecycle.
+
+        :param part: The part the step to be checked belongs to.
+        :param step: The step to be checked.
+
+        :return: A class:`DirtyReport` if the step is outdated, None otherwise.
+        """
+        logger.debug("check if %s:%s is dirty", part, step)
+
+        # Retrieve the stored state for this step (assuming it has already run)
+        stw = self._state_db.get(part_name=part.name, step=step)
+        if not stw:
+            # step didn't run yet
+            return None
+
+        state = stw.state
+
+        # state contains the old state for this part and step, and we're
+        # comparing it to those same properties and options in the current
+        # state. If they've changed, then this step is dirty and needs to
+        # run again.
+        part_properties = part.spec.marshal()
+        properties = state.diff_properties_of_interest(part_properties)
+        options = state.diff_project_options_of_interest(
+            self._project_info.project_options
+        )
+
+        if properties or options:
+            return DirtyReport(
+                dirty_properties=list(properties),
+                dirty_project_options=list(options),
+            )
+
+        prerequisite_step = steps.dependency_prerequisite_step(step)
+        if not prerequisite_step:
+            return None
+
+        # The part is clean, check its dependencies
+
+        dependencies = parts.part_dependencies(
+            part.name, part_list=self._part_list, recursive=True
+        )
+
+        changed_dependencies: List[Dependency] = []
+        for dependency in dependencies:
+            prerequisite_stw = self._state_db.get(
+                part_name=dependency.name, step=prerequisite_step
+            )
+            if prerequisite_stw:
+                dependency_changed = prerequisite_stw.is_newer_than(stw)
+            else:
+                dependency_changed = True
+
+            if dependency_changed or self.should_step_run(
+                dependency, prerequisite_step
+            ):
+                changed_dependencies.append(
+                    Dependency(part_name=dependency.name, step=prerequisite_step)
+                )
+
+        if changed_dependencies:
+            return DirtyReport(changed_dependencies=changed_dependencies)
 
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ extension-pkg-whitelist = [
     "pydantic"
 ]
 load-plugins = "pylint_fixme_info"
-max-branches = 20
 
 [tool.black]
 exclude = '/((\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|parts|stage|prime)/|setup.py)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ extension-pkg-whitelist = [
     "pydantic"
 ]
 load-plugins = "pylint_fixme_info"
+max-branches = 20
 
 [tool.black]
 exclude = '/((\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|parts|stage|prime)/|setup.py)'

--- a/tests/unit/state_manager/test_reports.py
+++ b/tests/unit/state_manager/test_reports.py
@@ -17,6 +17,7 @@
 import pytest
 
 from craft_parts.state_manager import reports
+from craft_parts.state_manager.reports import Dependency
 from craft_parts.steps import Step
 
 
@@ -32,5 +33,48 @@ from craft_parts.steps import Step
 def test_outdated_report(step, source_modified, result):
     report = reports.OutdatedReport(
         previous_step_modified=step, source_modified=source_modified
+    )
+    assert report.reason() == result
+
+
+@pytest.mark.parametrize(
+    "props,opts,deps,result",
+    [
+        (None, None, None, ""),
+        (["a"], None, None, "'a' property changed"),
+        (["a", "b"], None, None, "properties changed"),
+        (None, ["c"], None, "'c' option changed"),
+        (None, ["c", "d"], None, "options changed"),
+        (["a"], ["c"], None, "options and properties changed"),
+        (None, None, [Dependency("e", Step.STAGE)], "'e' changed"),
+        (
+            None,
+            None,
+            [Dependency("e", Step.STAGE), Dependency("f", Step.STAGE)],
+            "dependencies changed",
+        ),
+        (
+            ["a"],
+            None,
+            [Dependency("e", Step.STAGE)],
+            "dependencies and properties changed",
+        ),
+        (
+            None,
+            ["b"],
+            [Dependency("e", Step.STAGE)],
+            "dependencies and options changed",
+        ),
+        (
+            ["a"],
+            ["b"],
+            [Dependency("e", Step.STAGE)],
+            "dependencies, options, and properties changed",
+        ),
+    ],
+)
+def test_dirty_report(props, opts, deps, result):
+    report = reports.DirtyReport(
+        dirty_properties=props, dirty_project_options=opts, changed_dependencies=deps
     )
     assert report.reason() == result

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -234,9 +234,10 @@ class TestStateManager:
     def test_should_step_run_step_already_ran(self):
         info = ProjectInfo()
         p1 = Part("p1", {})
+        part_properties = p1.spec.marshal()
 
         # p1 pull already ran
-        s1 = states.StageState()
+        s1 = states.StageState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/pull"))
 
         sm = StateManager(project_info=info, part_list=[p1])
@@ -247,14 +248,15 @@ class TestStateManager:
     def test_should_step_run_outdated(self):
         info = ProjectInfo()
         p1 = Part("p1", {})
+        part_properties = p1.spec.marshal()
 
         # p1 build already ran
-        s1 = states.BuildState()
+        s1 = states.BuildState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/build"))
 
         # but p1 pull ran more recently
         time.sleep(0.02)
-        s1 = states.StageState()
+        s1 = states.PullState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/pull"))
 
         sm = StateManager(project_info=info, part_list=[p1])
@@ -268,9 +270,35 @@ class TestStateManager:
         for step in list(Step):
             assert sm.should_step_run(p1, step) == (step >= Step.STAGE)
 
+    def test_should_step_run_dirty(self):
+        info = ProjectInfo()
+        p1 = Part("p1", {})
+        part_properties = p1.spec.marshal()
+
+        # p1 pull and build already ran
+        s1 = states.PullState(part_properties=part_properties)
+        s1.write(Path("parts/p1/state/pull"))
+        time.sleep(0.02)
+        s2 = states.BuildState(part_properties=part_properties)
+        s2.write(Path("parts/p1/state/build"))
+
+        sm = StateManager(project_info=info, part_list=[p1])
+
+        # we're clean, steps STAGE and PRIME should run
+        for step in list(Step):
+            assert sm.should_step_run(p1, step) == (step > Step.BUILD)
+
+        # make the build step dirty
+        stw = sm._state_db.get(part_name="p1", step=Step.BUILD)
+        stw.state.part_properties["build-packages"] = ["new_pkg"]
+
+        # now build should run again
+        for step in list(Step):
+            assert sm.should_step_run(p1, step) == (step >= Step.BUILD)
+
 
 @pytest.mark.usefixtures("new_dir")
-class TestOutdatedReport:
+class TestStepOutdated:
     """Verify outdated step checks."""
 
     def test_not_outdated(self):
@@ -310,6 +338,130 @@ class TestOutdatedReport:
 
         for step in list(Step):
             assert sm.check_if_outdated(p1, step) is None
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestStepDirty:
+    """Verify dirty step checks."""
+
+    def test_not_dirty(self):
+        info = ProjectInfo()
+        p1 = Part("p1", {})
+
+        sm = StateManager(project_info=info, part_list=[p1])
+
+        for step in list(Step):
+            assert sm.check_if_dirty(p1, step) is None
+
+    def test_dirty_property(self):
+        info = ProjectInfo()
+        p1 = Part("p1", {})
+        part_properties = p1.spec.marshal()
+
+        # p1 pull and build already ran
+        s1 = states.PullState(part_properties=part_properties)
+        s1.write(Path("parts/p1/state/pull"))
+        time.sleep(0.02)
+        s2 = states.BuildState(part_properties=part_properties)
+        s2.write(Path("parts/p1/state/build"))
+
+        sm = StateManager(project_info=info, part_list=[p1])
+
+        # check if dirty, all steps are clean
+        for step in list(Step):
+            assert sm.check_if_dirty(p1, step) is None
+
+        # make the build step dirty
+        stw = sm._state_db.get(part_name="p1", step=Step.BUILD)
+        stw.state.part_properties["build-packages"] = ["new_pkg"]
+
+        # now check again if dirty
+        for step in list(Step):
+            report = sm.check_if_dirty(p1, step)
+            if step == Step.BUILD:
+                assert report is not None
+                assert report.reason() == "'build-packages' property changed"
+            else:
+                assert report is None
+
+    def test_dirty_dependency(self):
+        info = ProjectInfo()
+        p1 = Part("p1", {"after": ["p2"]})
+        p1_properties = p1.spec.marshal()
+        p2 = Part("p2", {})
+        p2_properties = p2.spec.marshal()
+
+        # p2 pull/build/stage already ran
+        s2 = states.PullState(part_properties=p2_properties)
+        s2.write(Path("parts/p2/state/pull"))
+        time.sleep(0.02)
+        s2 = states.BuildState(part_properties=p2_properties)
+        s2.write(Path("parts/p2/state/build"))
+        time.sleep(0.02)
+        s2 = states.StageState(part_properties=p2_properties)
+        s2.write(Path("parts/p2/state/stage"))
+
+        # p1 pull/build already ran
+        time.sleep(0.02)
+        s1 = states.PullState(part_properties=p1_properties)
+        s1.write(Path("parts/p1/state/pull"))
+        time.sleep(0.02)
+        s1 = states.BuildState(part_properties=p1_properties)
+        s1.write(Path("parts/p1/state/build"))
+
+        sm = StateManager(project_info=info, part_list=[p1, p2])
+
+        # check if dirty, all steps are clean
+        for part in [p1, p2]:
+            for step in list(Step):
+                assert sm.check_if_dirty(part, step) is None
+
+        # make p2 stage step dirty
+        stw = sm._state_db.get(part_name="p2", step=Step.STAGE)
+        stw.state.part_properties["stage"] = ["new_entry"]
+
+        # now check if p1:build is dirty
+        for step in list(Step):
+            report = sm.check_if_dirty(p1, step)
+            if step == Step.BUILD:
+                assert report is not None
+                assert report.reason() == "'p2' changed"
+            else:
+                assert report is None
+
+        # and if p2:stage is also dirty
+        for step in list(Step):
+            report = sm.check_if_dirty(p2, step)
+            if step == Step.STAGE:
+                assert report is not None
+                assert report.reason() == "'stage' property changed"
+            else:
+                assert report is None
+
+    def test_dirty_dependency_didnt_run(self):
+        info = ProjectInfo()
+        p1 = Part("p1", {"after": ["p2"]})
+        p1_properties = p1.spec.marshal()
+        p2 = Part("p2", {})
+
+        # p1 pull/build already ran
+        time.sleep(0.02)
+        s1 = states.PullState(part_properties=p1_properties)
+        s1.write(Path("parts/p1/state/pull"))
+        time.sleep(0.02)
+        s1 = states.BuildState(part_properties=p1_properties)
+        s1.write(Path("parts/p1/state/build"))
+
+        sm = StateManager(project_info=info, part_list=[p1, p2])
+
+        # check if dirty
+        for step in list(Step):
+            report = sm.check_if_dirty(p1, step)
+            if step == Step.BUILD:
+                assert report is not None
+                assert report.reason() == "'p2' changed"
+            else:
+                assert report is None
 
 
 @pytest.mark.usefixtures("new_dir")


### PR DESCRIPTION
A part step is considered dirty if one of its state properties
or options have changed, or if one of its dependencies should run.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
