### PR TITLE
sequencer: handle step run, rerun and update

### DIFF
--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -140,13 +140,16 @@ class Sequencer:
                 directories=set(),
             )
 
-        else:
+        elif step == Step.PRIME:
             state = states.PrimeState(
                 part_properties=part_properties,
                 project_options=self._project_info.project_options,
                 files=set(),
                 directories=set(),
             )
+
+        else:
+            raise RuntimeError(f"invalid step {step!r}")
 
         self._sm.set_state(part, step, state=state)
 

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -17,11 +17,13 @@
 """Determine the sequence of lifecycle actions to be executed."""
 
 import logging
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
-from craft_parts.actions import Action
+from craft_parts import parts, steps
+from craft_parts.actions import Action, ActionType
 from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part, part_list_by_name, sort_parts
+from craft_parts.state_manager import StateManager, states
 from craft_parts.steps import Step
 
 logger = logging.getLogger(__name__)
@@ -37,6 +39,7 @@ class Sequencer:
     def __init__(self, *, part_list: List[Part], project_info: ProjectInfo):
         self._part_list = sort_parts(part_list)
         self._project_info = project_info
+        self._sm = StateManager(project_info=project_info, part_list=part_list)
         self._actions: List[Action] = []
 
     def plan(self, target_step: Step, part_names: Sequence[str] = None) -> List[Action]:
@@ -81,3 +84,103 @@ class Sequencer:
     ) -> None:
         # TODO: implement this stub
         pass
+
+    def _process_dependencies(self, part: Part, step: Step) -> None:
+        prerequisite_step = steps.dependency_prerequisite_step(step)
+        if not prerequisite_step:
+            return
+
+        all_deps = parts.part_dependencies(part.name, part_list=self._part_list)
+
+        deps = {p for p in all_deps if self._sm.should_step_run(p, prerequisite_step)}
+        for dep in deps:
+            self._add_all_actions(
+                target_step=prerequisite_step,
+                part_names=[dep.name],
+                reason=f"required to {_step_verb[step]} {part.name!r}",
+            )
+
+    def _run_step(
+        self,
+        part: Part,
+        step: Step,
+        *,
+        reason: Optional[str] = None,
+        rerun: bool = False,
+    ) -> None:
+        self._process_dependencies(part, step)
+
+        if rerun:
+            self._add_action(part, step, action_type=ActionType.RERUN, reason=reason)
+        else:
+            self._add_action(part, step, reason=reason)
+
+        state: states.StepState
+        part_properties = part.spec.marshal()
+
+        if step == Step.PULL:
+            state = states.PullState(
+                part_properties=part_properties,
+                project_options=self._project_info.project_options,
+                assets={},  # TODO: obtain pull assets
+            )
+
+        elif step == Step.BUILD:
+            state = states.BuildState(
+                part_properties=part_properties,
+                project_options=self._project_info.project_options,
+                assets={},  # TODO: obtain build assets
+            )
+
+        elif step == Step.STAGE:
+            state = states.StageState(
+                part_properties=part_properties,
+                project_options=self._project_info.project_options,
+                files=set(),
+                directories=set(),
+            )
+
+        else:
+            state = states.PrimeState(
+                part_properties=part_properties,
+                project_options=self._project_info.project_options,
+                files=set(),
+                directories=set(),
+            )
+
+        self._sm.set_state(part, step, state=state)
+
+    def _rerun_step(
+        self, part: Part, step: Step, *, reason: Optional[str] = None
+    ) -> None:
+        logger.debug("rerun step %s:%s", part.name, step)
+
+        # clean the step and later steps for this part, then run it again
+        self._sm.clean_part(part, step)
+        self._run_step(part, step, reason=reason, rerun=True)
+
+    def _update_step(self, part: Part, step: Step, *, reason: Optional[str] = None):
+        logger.debug("update step %s:%s", part.name, step)
+        self._add_action(part, step, action_type=ActionType.UPDATE, reason=reason)
+        self._sm.update_state_timestamp(part, step)
+
+    def _add_action(
+        self,
+        part: Part,
+        step: Step,
+        *,
+        action_type: ActionType = ActionType.RUN,
+        reason: Optional[str] = None,
+    ) -> None:
+        logger.debug("add action %s:%s(%s)", part.name, step, action_type)
+        self._actions.append(
+            Action(part.name, step, action_type=action_type, reason=reason)
+        )
+
+
+_step_verb: Dict[Step, str] = {
+    Step.PULL: "pull",
+    Step.BUILD: "build",
+    Step.STAGE: "stage",
+    Step.PRIME: "prime",
+}

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -41,6 +41,8 @@ def load_state(part: Part, step: Step) -> Optional[StepState]:
     :param step: The step corresponding to the state to load.
 
     :return: The step state.
+
+    :raise RuntimeError: If step is invalid.
     """
     filename = state_file_path(part, step)
     if not filename.is_file():
@@ -56,8 +58,10 @@ def load_state(part: Part, step: Step) -> Optional[StepState]:
         state_class = BuildState
     elif step == Step.STAGE:
         state_class = StageState
-    else:
+    elif step == Step.PRIME:
         state_class = PrimeState
+    else:
+        raise RuntimeError(f"invalid step {step!r}")
 
     return state_class.unmarshal(state_data)
 

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -1,0 +1,171 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from craft_parts.actions import Action, ActionType
+from craft_parts.infos import ProjectInfo
+from craft_parts.parts import Part, PartSpec
+from craft_parts.sequencer import Sequencer
+from craft_parts.state_manager import states
+from craft_parts.steps import Step
+
+
+def test_sequencer_add_actions():
+    info = ProjectInfo()
+    p1 = Part("p1", {})
+
+    seq = Sequencer(part_list=[p1], project_info=info)
+    seq._add_action(p1, Step.BUILD, reason="some reason")
+    seq._add_action(p1, Step.STAGE)
+
+    assert seq._actions == [
+        Action(
+            part_name="p1",
+            step=Step.BUILD,
+            action_type=ActionType.RUN,
+            reason="some reason",
+        ),
+        Action(part_name="p1", step=Step.STAGE, action_type=ActionType.RUN),
+    ]
+
+
+@pytest.mark.parametrize(
+    "step,state_class",
+    [
+        (Step.PULL, states.PullState),
+        (Step.BUILD, states.BuildState),
+        (Step.STAGE, states.StageState),
+        (Step.PRIME, states.PrimeState),
+    ],
+)
+def test_sequencer_run_step(step, state_class):
+    info = ProjectInfo(arch="aarch64", application_name="test")
+    p1 = Part("p1", {"stage": ["pkg"]})
+
+    seq = Sequencer(part_list=[p1], project_info=info)
+    seq._run_step(p1, step)
+
+    stw = seq._sm._state_db.get(part_name="p1", step=step)
+    state = stw.state
+    assert isinstance(state, state_class)
+
+    # check if action was created
+    assert seq._actions == [
+        Action(part_name="p1", action_type=ActionType.RUN, step=step)
+    ]
+
+    # check if states were updated
+    props = PartSpec.unmarshal({"stage": ["pkg"]})
+    assert state.part_properties == props.marshal()
+    assert state.project_options == {
+        "application_name": "test",
+        "arch_triplet": "aarch64-linux-gnu",
+        "target_arch": "arm64",
+    }
+
+
+@pytest.mark.parametrize(
+    "step,state_class",
+    [
+        (Step.PULL, states.PullState),
+        (Step.BUILD, states.BuildState),
+        (Step.STAGE, states.StageState),
+        (Step.PRIME, states.PrimeState),
+    ],
+)
+def test_sequencer_rerun_step(mocker, step, state_class):
+    info = ProjectInfo(arch="aarch64", application_name="test")
+    p1 = Part("p1", {"stage": ["pkg"]})
+
+    seq = Sequencer(part_list=[p1], project_info=info)
+    mock_clean_part = mocker.spy(seq._sm, "clean_part")
+
+    seq._rerun_step(p1, step)
+
+    # check if clean_part ran
+    mock_clean_part.assert_called_once_with(p1, step)
+
+    stw = seq._sm._state_db.get(part_name="p1", step=step)
+    state = stw.state
+    assert isinstance(state, state_class)
+
+    # check if action was created
+    assert seq._actions == [
+        Action(part_name="p1", action_type=ActionType.RERUN, step=step)
+    ]
+
+    # check if states were updated
+    props = PartSpec.unmarshal({"stage": ["pkg"]})
+    assert state.part_properties == props.marshal()
+    assert state.project_options == {
+        "application_name": "test",
+        "arch_triplet": "aarch64-linux-gnu",
+        "target_arch": "arm64",
+    }
+
+
+@pytest.mark.usefixtures("new_dir")
+@pytest.mark.parametrize(
+    "step,state_class",
+    [
+        (Step.PULL, states.PullState),
+        (Step.BUILD, states.BuildState),
+        (Step.STAGE, states.StageState),
+        (Step.PRIME, states.PrimeState),
+    ],
+)
+def test_sequencer_update_step(mocker, step, state_class):
+    info = ProjectInfo(arch="aarch64", application_name="test")
+    p1 = Part("p1", {})
+    s1 = state_class()
+    s1.write(Path("parts/p1/state") / step.name.lower())
+
+    seq = Sequencer(part_list=[p1], project_info=info)
+
+    stw = seq._sm._state_db.get(part_name="p1", step=step)
+    assert stw is not None
+
+    seq._update_step(p1, step)
+
+    new_stw = seq._sm._state_db.get(part_name="p1", step=step)
+    assert new_stw is not None
+
+    # check if action was created
+    assert seq._actions == [
+        Action(part_name="p1", action_type=ActionType.UPDATE, step=step)
+    ]
+
+    # check if serial updated
+    assert new_stw.is_newer_than(stw)
+
+
+def test_sequencer_process_dependencies(mocker):
+    info = ProjectInfo(arch="aarch64", application_name="test")
+    p1 = Part("p1", {"after": ["p2"]})
+    p2 = Part("p2", {})
+
+    seq = Sequencer(part_list=[p1, p2], project_info=info)
+
+    mock_add_all_actions = mocker.patch.object(seq, "_add_all_actions")
+
+    # process p1 dependencies
+    seq._process_dependencies(p1, Step.BUILD)
+    mock_add_all_actions.assert_called_once_with(
+        target_step=Step.STAGE, part_names=["p2"], reason="required to build 'p1'"
+    )

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -80,6 +80,16 @@ def test_sequencer_run_step(step, state_class):
     }
 
 
+def test_sequencer_run_step_invalid():
+    info = ProjectInfo(arch="aarch64", application_name="test")
+    p1 = Part("p1", {"stage": ["pkg"]})
+
+    seq = Sequencer(part_list=[p1], project_info=info)
+    with pytest.raises(RuntimeError) as raised:
+        seq._run_step(p1, 999)  # type: ignore
+    assert str(raised.value) == "invalid step 999"
+
+
 @pytest.mark.parametrize(
     "step,state_class",
     [


### PR DESCRIPTION
Lifecycle planning requires updating step states and emmiting the
appropriate actions to be executed later. This is done in different
ways depending if we're running a step for the first time, re-running
it, or updating it. This change adds the appropriate handlers for
each case.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
