### PR TITLE
sources: add support for source checksum

### DIFF
--- a/craft_parts/sources/__init__.py
+++ b/craft_parts/sources/__init__.py
@@ -1,0 +1,17 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Source handler definitions and helpers."""

--- a/craft_parts/sources/checksum.py
+++ b/craft_parts/sources/checksum.py
@@ -1,0 +1,62 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to compute and verify file checksums."""
+
+from typing import Tuple
+
+from craft_parts.utils import file_utils
+
+from . import errors
+
+
+def split_checksum(source_checksum: str) -> Tuple:
+    """Split the given source checksum into algorithm and hash.
+
+    :param source_checksum: Source checksum in algorithm/hash format.
+
+    :return: a tuple consisting of the algorithm and the hash.
+
+    :raise ValueError: If the checksum is not in the expected format.
+    """
+    try:
+        algorithm, digest = source_checksum.split("/", 1)
+    except ValueError as err:
+        raise ValueError(f"invalid checksum format: {source_checksum!r}") from err
+
+    return (algorithm, digest)
+
+
+def verify_checksum(source_checksum: str, checkfile: str) -> Tuple:
+    """Verify that checkfile corresponds to the given source checksum.
+
+    :param source_checksum: Source checksum in algorithm/hash format.
+    :param checkfile: The file to calculate the sum for with the algorithm
+        defined in source_checksum.
+
+    :return: A tuple consisting of the algorithm and the hash.
+
+    :raise ValueError: If source_checksum is not of the form algorithm/hash.
+    :raise ChecksumMismatch: If checkfile does not match the expected hash
+        calculated with the algorithm defined in source_checksum.
+    """
+    algorithm, digest = split_checksum(source_checksum)
+
+    calculated_digest = file_utils.calculate_hash(checkfile, algorithm=algorithm)
+    if digest != calculated_digest:
+        raise errors.ChecksumMismatch(expected=digest, obtained=calculated_digest)
+
+    return (algorithm, digest)

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -1,0 +1,34 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Source handler error definitions."""
+
+from craft_parts import errors
+
+
+class SourceError(errors.PartsError):
+    """Base class for source handler errors."""
+
+
+class ChecksumMismatch(SourceError):
+    """A checksum doesn't match the expected value."""
+
+    def __init__(self, *, expected: str, obtained: str):
+        self.expected = expected
+        self.obtained = obtained
+        brief = f"Expected digest {expected}, obtained {obtained}."
+
+        super().__init__(brief=brief)

--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -25,9 +25,15 @@ def calculate_hash(filename: str, *, algorithm: str) -> str:
 
     :param filename: The path to the file to digest.
     :param algorithm: The algorithm to use, as defined by ``hashlib``.
+
+    :return: The file hash.
+
+    :raise ValueError: If the algorithm is unsupported.
     """
-    # This will raise an AttributeError if algorithm is unsupported
-    hasher = getattr(hashlib, algorithm)()
+    if algorithm not in hashlib.algorithms_available:
+        raise ValueError(f"unsupported algorithm {algorithm!r}")
+
+    hasher = hashlib.new(algorithm)
 
     for block in _file_reader_iter(filename):
         hasher.update(block)

--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""File-related utilities."""
+
+import hashlib
+from typing import Generator
+
+
+def calculate_hash(filename: str, *, algorithm: str) -> str:
+    """Calculate the hash of the given file.
+
+    :param filename: The path to the file to digest.
+    :param algorithm: The algorithm to use, as defined by ``hashlib``.
+    """
+    # This will raise an AttributeError if algorithm is unsupported
+    hasher = getattr(hashlib, algorithm)()
+
+    for block in _file_reader_iter(filename):
+        hasher.update(block)
+    return hasher.hexdigest()
+
+
+def _file_reader_iter(
+    path: str, block_size: int = 2 ** 20
+) -> Generator[bytes, None, None]:
+    """Read a file in blocks.
+
+    :param path: The path to the file to read.
+    :param block_size: The size of the block to read, default is 1MiB.
+    """
+    with open(path, "rb") as file:
+        block = file.read(block_size)
+        while len(block) > 0:
+            yield block
+            block = file.read(block_size)

--- a/tests/unit/sources/test_checksum.py
+++ b/tests/unit/sources/test_checksum.py
@@ -61,9 +61,9 @@ def test_verify_checksum_happy(tc_checksum, tc_checkfile):
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_invalid_algorithm():
     Path("checkfile").write_text("content")
-    with pytest.raises(AttributeError) as raised:
+    with pytest.raises(ValueError) as raised:
         checksum.verify_checksum("invalid/digest", "checkfile")
-    assert str(raised.value) == "module 'hashlib' has no attribute 'invalid'"
+    assert str(raised.value) == "unsupported algorithm 'invalid'"
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/sources/test_checksum.py
+++ b/tests/unit/sources/test_checksum.py
@@ -1,0 +1,83 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from craft_parts.sources import checksum, errors
+
+
+@pytest.mark.parametrize(
+    "tc_checksum,tc_algorithm,tc_digest",
+    [
+        ("algorithm/digest", "algorithm", "digest"),
+        ("algorithm/dig/est", "algorithm", "dig/est"),
+        ("algorithm/", "algorithm", ""),
+        ("/digest", "", "digest"),
+        ("//", "", "/"),
+        ("/", "", ""),
+    ],
+)
+def test_split_checksum_happy(tc_checksum, tc_algorithm, tc_digest):
+    algorithm, digest = checksum.split_checksum(tc_checksum)
+    assert algorithm == tc_algorithm
+    assert digest == tc_digest
+
+
+@pytest.mark.parametrize("tc_checksum", ["", "something"])
+def test_split_checksum_error(tc_checksum):
+    with pytest.raises(ValueError) as raised:
+        checksum.split_checksum(tc_checksum)
+    assert str(raised.value) == f"invalid checksum format: '{tc_checksum}'"
+
+
+@pytest.mark.parametrize(
+    "tc_checksum,tc_checkfile",
+    [
+        ("md5/9a0364b9e99bb480dd25e1f0284c8555", "content"),
+        ("sha1/040f06fd774092478d450774f5ba30c5da78acc8", "content"),
+    ],
+)
+@pytest.mark.usefixtures("new_dir")
+def test_verify_checksum_happy(tc_checksum, tc_checkfile):
+    Path("checkfile").write_text(tc_checkfile)
+    checksum.verify_checksum(tc_checksum, "checkfile")
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_verify_checksum_invalid_algorithm():
+    Path("checkfile").write_text("content")
+    with pytest.raises(AttributeError) as raised:
+        checksum.verify_checksum("invalid/digest", "checkfile")
+    assert str(raised.value) == "module 'hashlib' has no attribute 'invalid'"
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_verify_checksum_value_error():
+    Path("checkfile").write_text("content")
+    with pytest.raises(ValueError) as raised:
+        checksum.verify_checksum("invalid", "checkfile")
+    assert str(raised.value) == "invalid checksum format: 'invalid'"
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_verify_checksum_digest_error():
+    Path("checkfile").write_text("content")
+    with pytest.raises(errors.ChecksumMismatch) as raised:
+        checksum.verify_checksum("md5/digest", "checkfile")
+    assert raised.value.expected == "digest"
+    assert raised.value.obtained == "9a0364b9e99bb480dd25e1f0284c8555"

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -1,0 +1,26 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.sources import errors
+
+
+def test_checksum_mismatch():
+    err = errors.ChecksumMismatch(expected="1234", obtained="5678")
+    assert err.expected == "1234"
+    assert err.obtained == "5678"
+    assert err.brief == "Expected digest 1234, obtained 5678."
+    assert err.details is None
+    assert err.resolution is None

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -1,0 +1,44 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from craft_parts.utils import file_utils
+
+
+@pytest.fixture(autouse=True)
+def setup_module_fixture(new_dir):
+    pass
+
+
+@pytest.mark.parametrize(
+    "algo,digest",
+    [
+        ("md5", "9a0364b9e99bb480dd25e1f0284c8555"),
+        ("sha1", "040f06fd774092478d450774f5ba30c5da78acc8"),
+    ],
+)
+def test_calculate_hash(algo, digest):
+    Path("test_file").write_text("content")
+    assert file_utils.calculate_hash("test_file", algorithm=algo) == digest
+
+
+def test_file_reader_iter():
+    Path("test_file").write_text("content")
+    gen = file_utils._file_reader_iter("test_file", block_size=4)
+    assert [x for x in gen] == [b"cont", b"ent"]


### PR DESCRIPTION
Add support to computing file checksum to validate the source-checksum
part property.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
