### PR TITLE
sources: add simple file cache

### DIFF
--- a/craft_parts/sources/cache.py
+++ b/craft_parts/sources/cache.py
@@ -16,7 +16,6 @@
 
 """Cache base and file cache."""
 
-import abc
 import logging
 import os
 import shutil
@@ -27,16 +26,7 @@ from xdg import BaseDirectory  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-class Cache(abc.ABC):
-    """Generic cache base class."""
-
-    def __init__(self, name: str):
-        self.cache_root = os.path.join(
-            BaseDirectory.xdg_cache_home, name, "craft-parts"
-        )
-
-
-class FileCache(Cache):
+class FileCache:
     """Cache files based on the supplied key."""
 
     def __init__(self, name: str, *, namespace: str = "files") -> None:
@@ -44,7 +34,9 @@ class FileCache(Cache):
 
         :param str namespace: The namespace for the cache (default is "files").
         """
-        super().__init__(name)
+        self.cache_root = os.path.join(
+            BaseDirectory.xdg_cache_home, name, "craft-parts"
+        )
         self.file_cache = os.path.join(self.cache_root, namespace)
 
     def cache(self, *, filename: str, key: str) -> Optional[str]:

--- a/craft_parts/sources/cache.py
+++ b/craft_parts/sources/cache.py
@@ -1,0 +1,85 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Cache base and file cache."""
+
+import abc
+import logging
+import os
+import shutil
+from typing import Optional
+
+from xdg import BaseDirectory  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class Cache(abc.ABC):
+    """Generic cache base class."""
+
+    def __init__(self, name: str):
+        self.cache_root = os.path.join(
+            BaseDirectory.xdg_cache_home, name, "craft-parts"
+        )
+
+
+class FileCache(Cache):
+    """Cache files based on the supplied key."""
+
+    def __init__(self, name: str, *, namespace: str = "files") -> None:
+        """Create a FileCache under namespace.
+
+        :param str namespace: The namespace for the cache (default is "files").
+        """
+        super().__init__(name)
+        self.file_cache = os.path.join(self.cache_root, namespace)
+
+    def cache(self, *, filename: str, key: str) -> Optional[str]:
+        """Cache a file revision with hash in XDG cache, unless it already exists.
+
+        :param filename: The path to the file to cache.
+        :param key: The key to cache the file under.
+
+        :return: The path to the cached file, or None if the file was not cached.
+        """
+        cached_file_path = os.path.join(self.file_cache, key)
+        os.makedirs(os.path.dirname(cached_file_path), exist_ok=True)
+
+        try:
+            if not os.path.isfile(cached_file_path):
+                shutil.copyfile(filename, cached_file_path)
+        except OSError:
+            logger.warning("Unable to cache file %s.", cached_file_path)
+            return None
+        return cached_file_path
+
+    def get(self, *, key: str) -> Optional[str]:
+        """Get the filepath which matches the hash calculated with algorithm.
+
+        :param key: The key used to cache the file.
+
+        :return: The path to cached file, or None if the file is not cached.
+        """
+        cached_file_path = os.path.join(self.file_cache, key)
+        if os.path.exists(cached_file_path):
+            logger.debug("Cache hit for key %s", key)
+            return cached_file_path
+
+        return None
+
+    def clean(self):
+        """Remove all files from the cache namespace."""
+        shutil.rmtree(self.file_cache)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==5.4.1
 pydantic==1.8.1
 pydantic-yaml==0.2.3
+pyxdg==0.27

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@
 import os
 
 import pytest
+import xdg  # type: ignore
 
 
 @pytest.fixture
@@ -29,3 +30,21 @@ def new_dir(tmpdir):
     yield tmpdir
 
     os.chdir(cwd)
+
+
+@pytest.fixture(autouse=True)
+def temp_xdg(tmpdir, mocker):
+    """Use a temporary locaction for XDG directories."""
+
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_config_home", new=os.path.join(tmpdir, ".config")
+    )
+    mocker.patch("xdg.BaseDirectory.xdg_data_home", new=os.path.join(tmpdir, ".local"))
+    mocker.patch("xdg.BaseDirectory.xdg_cache_home", new=os.path.join(tmpdir, ".cache"))
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_config_dirs", new=[xdg.BaseDirectory.xdg_config_home]
+    )
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_data_dirs", new=[xdg.BaseDirectory.xdg_data_home]
+    )
+    mocker.patch.dict(os.environ, {"XDG_CONFIG_HOME": os.path.join(tmpdir, ".config")})

--- a/tests/unit/sources/test_cache.py
+++ b/tests/unit/sources/test_cache.py
@@ -1,0 +1,87 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+from craft_parts.sources.cache import FileCache
+from craft_parts.utils import file_utils
+
+
+def test_file_cache(new_dir):
+    digest = "algo/12345678"
+    x = FileCache(name="test")
+
+    # make sure file is not cached
+    assert x.get(key=digest) is None
+
+    test_file = Path("test_file")
+    test_file.write_text("content")
+
+    # cache it
+    result = x.cache(filename="test_file", key=digest)
+    assert result is not None
+
+    cached_file = x.get(key=digest)
+    assert result == cached_file
+
+    cached_path = Path(result)
+    assert cached_path == Path(
+        new_dir, ".cache", "test", "craft-parts", "files", digest
+    )
+
+    # cache entry shouldn't be a hard link
+    assert cached_path.stat().st_ino != test_file.stat().st_ino
+
+    # but they must have the same contents
+    test_hash = file_utils.calculate_hash("test_file", algorithm="sha1")
+    cached_hash = file_utils.calculate_hash(result, algorithm="sha1")
+    assert test_hash == cached_hash
+
+
+def test_file_cache_clean(new_dir):
+    digest = "algo/12345678"
+    x = FileCache(name="test")
+
+    test_file = Path("test_file")
+    test_file.write_text("content")
+
+    result = x.cache(filename="test_file", key=digest)
+    assert result is not None
+
+    cached_path = Path(result)
+    assert cached_path.is_file()
+
+    x.clean()
+    assert not cached_path.is_file()
+
+
+def test_file_cache_nonfile(new_dir):
+    digest = "algo/12345678"
+    x = FileCache(name="test")
+
+    test_dir = Path("test_dir")
+    test_dir.mkdir()
+
+    result = x.cache(filename="test_dir", key=digest)
+    assert result is None
+
+
+def test_file_cache_non_existent(new_dir):
+    digest = "algo/12345678"
+    x = FileCache(name="test")
+
+    result = x.cache(filename="test_file", key=digest)
+    assert result is None


### PR DESCRIPTION
Sources with the `source-checksum` property are cached so they won't
be re-downloaded. This change implements a simple file cache that
stores such files under their digest key.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
