### PR TITLE
utils: add url parsing and downloading helpers

### DIFF
--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -1,0 +1,31 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities related to the operating system."""
+
+import os
+
+# TODO:stdmsg: replace/remove terminal-related utilities
+
+
+def is_dumb_terminal() -> bool:
+    """Verify whether the caller is running on a dumb terminal.
+
+    :return: True if on a dumb terminal.
+    """
+    is_stdout_tty = os.isatty(1)
+    is_term_dumb = os.environ.get("TERM", "") == "dumb"
+    return not is_stdout_tty or is_term_dumb

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -1,0 +1,143 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""URL parsing and downloading helpers."""
+
+import os
+import urllib.parse
+import urllib.request
+
+# TODO:stdmsg: refactor to use the standard message library once available
+import progressbar  # type: ignore
+
+from craft_parts.utils import os_utils
+
+
+def get_url_scheme(url: str) -> str:
+    """Return the given URL's scheme."""
+    return urllib.parse.urlparse(url).scheme
+
+
+def is_url(url: str) -> bool:
+    """Verify whether the given string is a valid URL."""
+    return get_url_scheme(url) != ""
+
+
+def download_request(
+    request, destination: str, message: str = None, total_read: int = 0
+):
+    """Download a request with nice progress bars.
+
+    :param request: The URL download request.
+    :param destination: The destination file name.
+    :param message: The message shown in the progress bar.
+    """
+    # Doing len(request.content) may defeat the purpose of a
+    # progress bar
+    total_length = 0
+    if not request.headers.get("Content-Encoding", ""):
+        total_length = int(request.headers.get("Content-Length", "0"))
+        # Content-Length in the case of resuming will be
+        # Content-Length - total_read so we add back up to have the feel of
+        # resuming
+        if os.path.exists(destination):
+            total_length += total_read
+
+    progress_bar = _init_progress_bar(total_length, destination, message)
+    progress_bar.start()
+
+    if os.path.exists(destination):
+        mode = "ab"
+    else:
+        mode = "wb"
+    with open(destination, mode) as destination_file:
+        for buf in request.iter_content(1024):
+            destination_file.write(buf)
+            if not os_utils.is_dumb_terminal():
+                total_read += len(buf)
+                progress_bar.update(total_read)
+    progress_bar.finish()
+
+
+def download_ftp(uri, destination, message=None):
+    """Download from the given URI.
+
+    :param uri: the URI to download from.
+    :param destination: the file to download to."
+    :param message: the progress bar message."
+    """
+    _UrllibDownloader(uri, destination, message).download()
+
+
+def _init_progress_bar(
+    total_length: int, destination: str, message=None
+) -> progressbar.ProgressBar:
+    if not message:
+        message = "Downloading {!r}".format(os.path.basename(destination))
+
+    valid_length = total_length and total_length > 0
+    dumb_terminal = os_utils.is_dumb_terminal()
+
+    if valid_length and dumb_terminal:
+        widgets = [message, " ", progressbar.Percentage()]
+        maxval = total_length
+    elif valid_length and not dumb_terminal:
+        widgets = [
+            message,
+            progressbar.Bar(marker="=", left="[", right="]"),
+            " ",
+            progressbar.Percentage(),
+        ]
+        maxval = total_length
+    elif not valid_length and dumb_terminal:
+        widgets = [message]
+        maxval = progressbar.UnknownLength
+    else:
+        widgets = [message, progressbar.AnimatedMarker()]
+        maxval = progressbar.UnknownLength
+
+    return progressbar.ProgressBar(widgets=widgets, maxval=maxval)
+
+
+# XXX: maybe refactor to use ftplib
+class _UrllibDownloader:
+    """Download an URI with nice progress bars."""
+
+    def __init__(self, uri, destination, message=None):
+        self.uri = uri
+        self.destination = destination
+        self.message = message
+        self.progress_bar = None
+
+    def download(self):
+        """Download from this URL."""
+        urllib.request.urlretrieve(self.uri, self.destination, self._progress_callback)
+
+        if self.progress_bar:
+            self.progress_bar.finish()
+
+    # TODO:stdmsg: use a standard ui progress bar instead
+    def _progress_callback(self, block_num, block_size, total_length):
+        if not self.progress_bar:
+            self.progress_bar = _init_progress_bar(
+                total_length, self.destination, self.message
+            )
+            self.progress_bar.start()
+
+        total_read = block_num * block_size
+        self.progress_bar.update(
+            min(total_read, total_length) if total_length > 0 else total_read
+        )

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -72,16 +72,6 @@ def download_request(
     progress_bar.finish()
 
 
-def download_ftp(uri, destination, message=None):
-    """Download from the given URI.
-
-    :param uri: the URI to download from.
-    :param destination: the file to download to."
-    :param message: the progress bar message."
-    """
-    _UrllibDownloader(uri, destination, message).download()
-
-
 def _init_progress_bar(
     total_length: int, destination: str, message=None
 ) -> progressbar.ProgressBar:
@@ -110,34 +100,3 @@ def _init_progress_bar(
         maxval = progressbar.UnknownLength
 
     return progressbar.ProgressBar(widgets=widgets, maxval=maxval)
-
-
-# XXX: maybe refactor to use ftplib
-class _UrllibDownloader:
-    """Download an URI with nice progress bars."""
-
-    def __init__(self, uri, destination, message=None):
-        self.uri = uri
-        self.destination = destination
-        self.message = message
-        self.progress_bar = None
-
-    def download(self):
-        """Download from this URL."""
-        urllib.request.urlretrieve(self.uri, self.destination, self._progress_callback)
-
-        if self.progress_bar:
-            self.progress_bar.finish()
-
-    # TODO:stdmsg: use a standard ui progress bar instead
-    def _progress_callback(self, block_num, block_size, total_length):
-        if not self.progress_bar:
-            self.progress_bar = _init_progress_bar(
-                total_length, self.destination, self.message
-            )
-            self.progress_bar.start()
-
-        total_read = block_num * block_size
-        self.progress_bar.update(
-            min(total_read, total_length) if total_length > 0 else total_read
-        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pylint
 pylint-fixme-info
 pytest
 pytest-mock
+requests-mock
 sphinx
 sphinx-autodoc-typehints
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==5.4.1
+progressbar==2.5
 pydantic==1.8.1
 pydantic-yaml==0.2.3
 pyxdg==0.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==5.4.1
 pydantic==1.8.1
 pydantic-yaml==0.2.3
 pyxdg==0.27
+requests==2.25.1

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -1,0 +1,40 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import pytest
+
+from craft_parts.utils import os_utils
+
+
+class TestTerminal:
+    """Tests for terminal-related utilities."""
+
+    @pytest.mark.parametrize(
+        "isatty,term,result",
+        [
+            (False, "xterm", True),
+            (False, "dumb", True),
+            (True, "xterm", False),
+            (True, "dumb", True),
+        ],
+    )
+    def test_is_dumb_terminal(self, mocker, isatty, term, result):
+        mocker.patch("os.isatty", return_value=isatty)
+        mocker.patch.dict(os.environ, {"TERM": term})
+
+        assert os_utils.is_dumb_terminal() == result

--- a/tests/unit/utils/test_url_utils.py
+++ b/tests/unit/utils/test_url_utils.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+import requests
+
+from craft_parts.utils import url_utils
+
+
+@pytest.mark.parametrize(
+    "url,result",
+    [
+        ("", ""),
+        ("not an url", ""),
+        ("/stll/not/an/url", ""),
+        ("scheme://some/location", "scheme"),
+    ],
+)
+def test_get_url_scheme(url, result):
+    assert url_utils.get_url_scheme(url) == result
+
+
+@pytest.mark.parametrize(
+    "url,result",
+    [
+        ("", False),
+        ("not an url", False),
+        ("/stll/not/an/url", False),
+        ("scheme://some/location", True),
+    ],
+)
+def test_is_url(url, result):
+    assert url_utils.is_url(url) == result
+
+
+# TODO:stdmsg: add better download test after refactoring
+@pytest.mark.usefixtures("new_dir")
+def test_download_request(requests_mock):
+    source_url = "http://test.com/source"
+    requests_mock.get(source_url, text="content")
+
+    test_file = Path("test_file")
+
+    request = requests.get(source_url, stream=True)
+    url_utils.download_request(request, "test_file")
+
+    assert test_file.is_file()
+    assert test_file.read_bytes() == b"content"


### PR DESCRIPTION
File sources need to parse and download files from given URLs. Add such
helpers to `url_utils` using code from snapcraft.

**Note to reviewers:** Only minimal testing was added -- the helpers will be
refactored later to use the standard messages library.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
