### PR TITLE
plugins: add make plugin

### DIFF
--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -17,7 +17,9 @@
 """Plugin base class and definitions."""
 
 import abc
-from typing import Dict, List, Set, Type
+from typing import Any, Dict, List, Set, Type
+
+from pydantic import BaseModel
 
 from craft_parts.infos import PartInfo
 
@@ -60,3 +62,40 @@ class Plugin(abc.ABC):
     @abc.abstractmethod
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
+
+
+class PluginModel(BaseModel):
+    """Model for plugins using pydantic validation.
+
+    Plugins with configuration properties can use pydantic validation to unmarshal
+    data from part specs. In this case, extract plugin-specific properties using
+    the :func:`extract_plugin_properties` helper.
+    """
+
+    class Config:
+        """Pydantic model configuration."""
+
+        validate_assignment = True
+        extra = "forbid"
+        allow_mutation = False
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+
+def extract_plugin_properties(
+    data: Dict[str, Any], *, plugin_name: str
+) -> Dict[str, Any]:
+    """Obtain plugin-specifc entries from part properties.
+
+    :param data: A dictionary containing all part properties.
+    :plugin_name: The name of the plugin.
+
+    :return: A dictionary with plugin properties.
+    """
+    plugin_data: Dict[str, Any] = {}
+    prefix = f"{plugin_name}-"
+
+    for key, value in data.items():
+        if key.startswith(prefix):
+            plugin_data[key] = value
+
+    return plugin_data

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -1,0 +1,97 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The make plugin implementation."""
+
+from typing import Any, Dict, List, Set, cast
+
+from .base import Plugin, PluginModel, extract_plugin_properties
+from .properties import PluginProperties
+
+
+class MakePluginProperties(PluginProperties, PluginModel):
+    """The part properties used by the make plugin."""
+
+    make_parameters: List[str] = []
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        """Populate dump properties from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+
+        :raise pydantic.ValidationError: If validation fails.
+        """
+        plugin_data = extract_plugin_properties(data, plugin_name="make")
+        return cls(**plugin_data)
+
+
+class MakePlugin(Plugin):
+    """A plugin useful for building make-based parts.
+
+    Make-based projects are projects that have a Makefile that drives the
+    build.
+
+    This plugin always runs 'make' followed by 'make install', except when
+    the 'artifacts' keyword is used.
+
+    This plugin uses the common plugin keywords as well as those for "sources".
+    For more information check the 'plugins' topic for the former and the
+    'sources' topic for the latter.
+
+    Additionally, this plugin uses the following plugin-specific keywords:
+
+        - make-parameters
+          (list of strings)
+          Pass the given parameters to the make command.
+    """
+
+    properties_class = MakePluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+        return {"gcc", "make"}
+
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+        return dict()
+
+    def _get_make_command(self, target: str = "") -> str:
+        cmd = ["make", f'-j"{self._part_info.parallel_build_count}"']
+
+        if target:
+            cmd.append(target)
+
+        options = cast(MakePluginProperties, self._options)
+        cmd.extend(options.make_parameters)
+
+        return " ".join(cmd)
+
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        return [
+            self._get_make_command(),
+            '{} DESTDIR="{}"'.format(
+                self._get_make_command(target="install"),
+                self._part_info.part_install_dir,
+            ),
+        ]

--- a/tests/integration/plugins/test_make.py
+++ b/tests/integration/plugins/test_make.py
@@ -1,0 +1,1 @@
+# TODO: add make plugin integration test after executor lands

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -22,6 +22,7 @@ import pytest
 from craft_parts.infos import PartInfo, ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.plugins import Plugin, PluginProperties
+from craft_parts.plugins.base import extract_plugin_properties
 
 
 @dataclass
@@ -85,3 +86,16 @@ def test_abstract_methods():
         "Can't instantiate abstract class FaultyPlugin with abstract methods "
         "get_build_commands, get_build_environment, get_build_packages, get_build_snaps"
     )
+
+
+def test_extract_plugin_properties():
+    data = {
+        "foo": True,
+        "test": "yes",
+        "test-one": 1,
+        "test-two": 2,
+        "not-test-three": 3,
+    }
+
+    plugin_data = extract_plugin_properties(data, plugin_name="test")
+    assert plugin_data == {"test-one": 1, "test-two": 2}

--- a/tests/unit/plugins/test_make_plugin.py
+++ b/tests/unit/plugins/test_make_plugin.py
@@ -1,0 +1,85 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins.make_plugin import MakePlugin
+
+# pylint: disable=attribute-defined-outside-init
+
+
+class TestPluginMake:
+    """Make plugin tests."""
+
+    def setup_method(self):
+        properties = MakePlugin.properties_class.unmarshal({})
+        part = Part("foo", {})
+
+        project_info = ProjectInfo()
+        project_info._parallel_build_count = 42
+
+        part_info = PartInfo(project_info=project_info, part=part)
+        part_info._part_install_dir = Path("install/dir")
+
+        self._plugin = MakePlugin(properties=properties, part_info=part_info)
+
+    def test_get_build_packages(self):
+        assert self._plugin.get_build_packages() == {
+            "gcc",
+            "make",
+        }
+        assert self._plugin.get_build_snaps() == set()
+
+    def test_get_build_environment(self):
+        assert self._plugin.get_build_environment() == dict()
+
+    def test_get_build_commands(self):
+        assert self._plugin.get_build_commands() == [
+            'make -j"42"',
+            'make -j"42" install DESTDIR="install/dir"',
+        ]
+
+    def test_get_build_commands_with_parameters(self):
+        props = MakePlugin.properties_class.unmarshal(
+            {"make-parameters": ["FLAVOR=gtk3"]}
+        )
+        part = Part("foo", {})
+
+        project_info = ProjectInfo()
+        project_info._parallel_build_count = 8
+
+        part_info = PartInfo(project_info=project_info, part=part)
+        part_info._part_install_dir = Path("/tmp")
+
+        plugin = MakePlugin(properties=props, part_info=part_info)
+
+        assert plugin.get_build_commands() == [
+            'make -j"8" FLAVOR=gtk3',
+            'make -j"8" install FLAVOR=gtk3 DESTDIR="/tmp"',
+        ]
+
+    def test_invalid_parameters(self):
+        with pytest.raises(ValidationError) as raised:
+            MakePlugin.properties_class.unmarshal({"make-invalid": True})
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("make-invalid",)
+        assert err[0]["type"] == "value_error.extra"


### PR DESCRIPTION
The make plugin is useful to build make-based parts.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
