### PR TITLE
utils: add helpers to link or copy files and trees

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -115,3 +115,30 @@ class PartSpecificationError(PartsError):
             formatted_errors.append(f"{fields}: {msg}")
 
         return cls(part_name=part_name, message="\n".join(formatted_errors))
+
+
+class CopyTreeError(PartsError):
+    """Failed to copy or link a file tree.
+
+    :param message: The error message.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = f"Failed to copy or link file tree: {message}."
+        resolution = "Make sure paths and permissions are correct."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class CopyFileNotFound(PartsError):
+    """An attempt was made to copy a file that doesn't exist.
+
+    :param name: The file name.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        brief = f"Failed to copy {name!r}: no such file or directory."
+
+        super().__init__(brief=brief)

--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -16,8 +16,198 @@
 
 """File-related utilities."""
 
+import contextlib
+import errno
 import hashlib
-from typing import Generator
+import logging
+import os
+import shutil
+import sys
+from typing import Callable, Generator, List, Set
+
+from craft_parts import errors
+
+logger = logging.getLogger(__name__)
+
+
+def link_or_copy(source: str, destination: str, follow_symlinks: bool = False) -> None:
+    """Hard-link source and destination files. Copy if it fails to link.
+
+    Hard-linking may fail (e.g. a cross-device link, or permission denied), so
+    as a backup plan we just copy it.
+
+    :param source: The source to which destination will be linked.
+    :param destination: The destination to be linked to source.
+    :param follow_symlinks: Whether or not symlinks should be followed.
+    """
+    try:
+        if not follow_symlinks and os.path.islink(source):
+            copy(source, destination)
+        else:
+            link(source, destination, follow_symlinks=follow_symlinks)
+    except OSError as err:
+        if err.errno == errno.EEXIST and not os.path.isdir(destination):
+            # os.link will fail if the destination already exists, so let's
+            # remove it and try again.
+            os.remove(destination)
+            link_or_copy(source, destination, follow_symlinks)
+        else:
+            copy(source, destination, follow_symlinks=follow_symlinks)
+
+
+def link(source: str, destination: str, *, follow_symlinks: bool = False) -> None:
+    """Hard-link source and destination files.
+
+    :param source: The source to which destination will be linked.
+    :param destination: The destination to be linked to source.
+    :param follow_symlinks: Whether or not symlinks should be followed.
+
+    :raises CopyFileNotFound: If source doesn't exist.
+    """
+    # Note that follow_symlinks doesn't seem to work for os.link, so we'll
+    # implement this logic ourselves using realpath.
+    source_path = source
+    if follow_symlinks:
+        source_path = os.path.realpath(source)
+
+    if not os.path.exists(os.path.dirname(destination)):
+        create_similar_directory(
+            os.path.dirname(source_path), os.path.dirname(destination)
+        )
+
+    # Setting follow_symlinks=False in case this bug is ever fixed
+    # upstream-- we want this function to continue supporting NOT following
+    # symlinks.
+    try:
+        os.link(source_path, destination, follow_symlinks=False)
+    except FileNotFoundError as err:
+        raise errors.CopyFileNotFound(source) from err
+
+
+def copy(source: str, destination: str, *, follow_symlinks: bool = False) -> None:
+    """Copy source and destination files.
+
+    This function overwrites the destination if it already exists, and also
+    tries to copy ownership information.
+
+    :param source: The source to be copied to destination.
+    :param destination: Where to put the copy.
+    :param follow_symlinks: Whether or not symlinks should be followed.
+
+    :raises CopyFileNotFound: If source doesn't exist.
+    """
+    # If os.link raised an I/O error, it may have left a file behind. Skip on
+    # OSError in case it doesn't exist or is a directory.
+    with contextlib.suppress(OSError):
+        os.unlink(destination)
+
+    try:
+        shutil.copy2(source, destination, follow_symlinks=follow_symlinks)
+    except FileNotFoundError as err:
+        raise errors.CopyFileNotFound(source) from err
+
+    uid = os.stat(source, follow_symlinks=follow_symlinks).st_uid
+    gid = os.stat(source, follow_symlinks=follow_symlinks).st_gid
+
+    try:
+        os.chown(destination, uid, gid, follow_symlinks=follow_symlinks)
+    except PermissionError as err:
+        logger.debug("Unable to chown %s: %s", destination, err)
+
+
+def link_or_copy_tree(
+    source_tree: str,
+    destination_tree: str,
+    ignore: Callable[[str, List[str]], List[str]] = None,
+    copy_function: Callable[..., None] = link_or_copy,
+) -> None:
+    """Copy a source tree into a destination, hard-linking if possible.
+
+    :param source_tree: Source directory to be copied.
+    :param destination_tree: Destination directory. If this directory
+        already exists, the files in `source_tree` will take precedence.
+    :param ignore: If given, called with two params, source dir and dir contents,
+        for every dir copied. Should return list of contents to NOT copy.
+    :param copy_function: Callable that actually copies.
+    """
+    if not os.path.isdir(source_tree):
+        raise errors.CopyTreeError(f"{source_tree!r} is not a directory")
+
+    if not os.path.isdir(destination_tree) and (
+        os.path.exists(destination_tree) or os.path.islink(destination_tree)
+    ):
+        raise errors.CopyTreeError(
+            f"cannot overwrite non-directory {destination_tree!r} with "
+            f"directory {source_tree!r}"
+        )
+
+    create_similar_directory(source_tree, destination_tree)
+
+    destination_basename = os.path.basename(destination_tree)
+
+    for root, directories, files in os.walk(source_tree, topdown=True):
+        ignored: Set[str] = set()
+        if ignore is not None:
+            ignored = set(ignore(root, directories + files))
+
+        # Don't recurse into destination tree if it's a subdirectory of the
+        # source tree.
+        if os.path.relpath(destination_tree, root) == destination_basename:
+            ignored.add(destination_basename)
+
+        if ignored:
+            # Prune our search appropriately given an ignore list, i.e. don't
+            # walk into directories that are ignored.
+            directories[:] = [d for d in directories if d not in ignored]
+
+        for directory in directories:
+            source = os.path.join(root, directory)
+            # os.walk doesn't by default follow symlinks (which is good), but
+            # it includes symlinks that are pointing to directories in the
+            # directories list. We want to treat it as a file, here.
+            if os.path.islink(source):
+                files.append(directory)
+                continue
+
+            destination = os.path.join(
+                destination_tree, os.path.relpath(source, source_tree)
+            )
+
+            create_similar_directory(source, destination)
+
+        for file_name in set(files) - ignored:
+            source = os.path.join(root, file_name)
+            destination = os.path.join(
+                destination_tree, os.path.relpath(source, source_tree)
+            )
+
+            copy_function(source, destination)
+
+
+def create_similar_directory(source: str, destination: str) -> None:
+    """Create a directory with the same permission bits and owner information.
+
+    :param source: Directory from which to copy name, permission bits, and
+         owner information.
+    :param destination: Directory to create and to which the `source`
+         information will be copied.
+    """
+    stat = os.stat(source, follow_symlinks=False)
+    uid = stat.st_uid
+    gid = stat.st_gid
+    os.makedirs(destination, exist_ok=True)
+
+    # Windows does not have "os.chown" implementation and copystat
+    # is unlikely to be useful, so just bail after creating directory.
+    if sys.platform == "win32":
+        return
+
+    try:
+        os.chown(destination, uid, gid, follow_symlinks=False)
+    except PermissionError as exception:
+        logger.debug("Unable to chown %s: %s", destination, exception)
+
+    shutil.copystat(source, destination, follow_symlinks=False)
 
 
 def calculate_hash(filename: str, *, algorithm: str) -> str:

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -100,3 +100,19 @@ def test_part_specification_error_from_bad_validation_error():
     assert err.brief == "Part 'foo' validation failed."
     assert err.details == ""
     assert err.resolution == "Review part 'foo' and make sure it's correct."
+
+
+def test_copy_tree_error():
+    err = errors.CopyTreeError("something bad happened")
+    assert err.message == "something bad happened"
+    assert err.brief == "Failed to copy or link file tree: something bad happened."
+    assert err.details is None
+    assert err.resolution == "Make sure paths and permissions are correct."
+
+
+def test_copy_file_not_found():
+    err = errors.CopyFileNotFound("filename")
+    assert err.name == "filename"
+    assert err.brief == "Failed to copy 'filename': no such file or directory."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Copying or linking files and trees is a frequent operation as we progress
through lifecycle steps. Add helpers for such operations.

Note: the functions are mostly copies from their snapcraft counterparts and
may be revisited/refactored in the future.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
