### PR TITLE
plugins: add autotools plugin

### DIFF
--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -23,13 +23,13 @@ from .properties import PluginProperties
 
 
 class AutotoolsPluginProperties(PluginProperties, PluginModel):
-    """The part properties used by the make plugin."""
+    """The part properties used by the autotools plugin."""
 
     autotools_configure_parameters: List[str] = []
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
-        """Populate dump properties from the part specification.
+        """Populate autotools properties from the part specification.
 
         :param data: A dictionary containing part properties.
 
@@ -48,7 +48,8 @@ class AutotoolsPlugin(Plugin):
     `./configure && make && make install` instruction set.
 
     This plugin will check for the existence of a 'configure' file, if one
-    cannot be found, it will run 'autoconf --install'.
+    cannot be found, it will first try to run 'autogen.sh' or 'bootstrap'
+    to generate one.
 
     This plugin uses the common plugin keywords as well as those for "sources".
     For more information check the 'plugins' topic for the former and the

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -1,0 +1,95 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The autotools plugin implementation."""
+
+from typing import Any, Dict, List, Set, cast
+
+from .base import Plugin, PluginModel, extract_plugin_properties
+from .properties import PluginProperties
+
+
+class AutotoolsPluginProperties(PluginProperties, PluginModel):
+    """The part properties used by the make plugin."""
+
+    autotools_configure_parameters: List[str] = []
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        """Populate dump properties from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+
+        :raise pydantic.ValidationError: If validation fails.
+        """
+        plugin_data = extract_plugin_properties(data, plugin_name="autotools")
+        return cls(**plugin_data)
+
+
+class AutotoolsPlugin(Plugin):
+    """The autotools plugin is used for autotools-based parts.
+
+    Autotools-based projects are the ones that have the usual
+    `./configure && make && make install` instruction set.
+
+    This plugin will check for the existence of a 'configure' file, if one
+    cannot be found, it will run 'autoconf --install'.
+
+    This plugin uses the common plugin keywords as well as those for "sources".
+    For more information check the 'plugins' topic for the former and the
+    'sources' topic for the latter.
+
+    In addition, this plugin uses the following plugin-specific keywords:
+
+        - autotools-configure-parameters
+          (list of strings)
+          configure flags to pass to the build such as those shown by running
+          './configure --help'
+    """
+
+    properties_class = AutotoolsPluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+        return {"autoconf", "automake", "autopoint", "gcc", "libtool"}
+
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+        return dict()
+
+    def _get_configure_command(self) -> str:
+        options = cast(AutotoolsPluginProperties, self._options)
+        cmd = ["./configure"] + options.autotools_configure_parameters
+        return " ".join(cmd)
+
+    # pylint: disable=line-too-long
+
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        return [
+            "[ ! -f ./configure ] && [ -f ./autogen.sh ] && env NOCONFIGURE=1 ./autogen.sh",
+            "[ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap",
+            "[ ! -f ./configure ] && autoreconf --install",
+            self._get_configure_command(),
+            "make -j{}".format(self._part_info.parallel_build_count),
+            'make install DESTDIR="{}"'.format(self._part_info.part_install_dir),
+        ]

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -29,7 +29,7 @@ class MakePluginProperties(PluginProperties, PluginModel):
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
-        """Populate dump properties from the part specification.
+        """Populate make properties from the part specification.
 
         :param data: A dictionary containing part properties.
 

--- a/tests/integration/plugins/test_autotools.py
+++ b/tests/integration/plugins/test_autotools.py
@@ -1,0 +1,1 @@
+# TODO: add autotools plugin integration test after executor lands

--- a/tests/unit/plugins/test_autotools_plugin.py
+++ b/tests/unit/plugins/test_autotools_plugin.py
@@ -1,0 +1,97 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins.autotools_plugin import AutotoolsPlugin
+
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=line-too-long
+
+
+class TestPluginAutotools:
+    """Autotools plugin tests."""
+
+    def setup_method(self):
+        properties = AutotoolsPlugin.properties_class.unmarshal({})
+        part = Part("foo", {})
+
+        project_info = ProjectInfo()
+        project_info._parallel_build_count = 42
+
+        part_info = PartInfo(project_info=project_info, part=part)
+        part_info._part_install_dir = Path("install/dir")
+
+        self._plugin = AutotoolsPlugin(properties=properties, part_info=part_info)
+
+    def test_get_build_packages(self):
+        assert self._plugin.get_build_packages() == {
+            "autoconf",
+            "automake",
+            "autopoint",
+            "gcc",
+            "libtool",
+        }
+        assert self._plugin.get_build_snaps() == set()
+
+    def test_get_build_environment(self):
+        assert self._plugin.get_build_environment() == dict()
+
+    def test_get_build_commands(self):
+        assert self._plugin.get_build_commands() == [
+            "[ ! -f ./configure ] && [ -f ./autogen.sh ] && env NOCONFIGURE=1 ./autogen.sh",
+            "[ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap",
+            "[ ! -f ./configure ] && autoreconf --install",
+            "./configure",
+            "make -j42",
+            'make install DESTDIR="install/dir"',
+        ]
+
+    def test_get_build_commands_with_configure_parameters(self):
+        properties = AutotoolsPlugin.properties_class.unmarshal(
+            {"autotools-configure-parameters": ["--with-foo=true", "--prefix=/foo"]},
+        )
+
+        project_info = ProjectInfo()
+        project_info._parallel_build_count = 8
+
+        part = Part("bar", {})
+        part_info = PartInfo(project_info=project_info, part=part)
+        part_info._part_install_dir = Path("/tmp")
+
+        plugin = AutotoolsPlugin(properties=properties, part_info=part_info)
+
+        assert plugin.get_build_commands() == [
+            "[ ! -f ./configure ] && [ -f ./autogen.sh ] && env NOCONFIGURE=1 ./autogen.sh",
+            "[ ! -f ./configure ] && [ -f ./bootstrap ] && env NOCONFIGURE=1 ./bootstrap",
+            "[ ! -f ./configure ] && autoreconf --install",
+            "./configure --with-foo=true --prefix=/foo",
+            "make -j8",
+            'make install DESTDIR="/tmp"',
+        ]
+
+    def test_invalid_parameters(self):
+        with pytest.raises(ValidationError) as raised:
+            AutotoolsPlugin.properties_class.unmarshal({"autotools-invalid": True})
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("autotools-invalid",)
+        assert err[0]["type"] == "value_error.extra"


### PR DESCRIPTION
The autotools plugin is used for parts using the autotools `./configure` script.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
