### PR TITLE
metadata: add support for extended attributes

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -115,3 +115,36 @@ class PartSpecificationError(PartsError):
             formatted_errors.append(f"{fields}: {msg}")
 
         return cls(part_name=part_name, message="\n".join(formatted_errors))
+
+
+class XAttributeError(PartsError):
+    """Failed to read or write an extended attribute.
+
+    :param action: The action being performed.
+    :param key: The extended attribute key.
+    :param path: The file path.
+    """
+
+    def __init__(self, key: str, path: str, is_write: bool = False):
+        self.key = key
+        self.path = path
+        self.is_write = is_write
+        action = "write" if is_write else "read"
+        brief = f"Unable to {action} extended attribute."
+        details = f"Failed to {action} attribute {key!r} on {path!r}."
+        resolution = "Make sure your filesystem supports extended attributes."
+
+        super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class XAttributeTooLong(PartsError):
+    """Failed to write an extended attribute because key and/or value is too long."""
+
+    def __init__(self, key: str, value: str, path: str):
+        self.key = key
+        self.value = value
+        self.path = path
+        brief = "Failed to write attribute: key and/or value is too long."
+        details = f"key={key!r}, value={value!r}"
+
+        super().__init__(brief=brief, details=details)

--- a/craft_parts/xattrs.py
+++ b/craft_parts/xattrs.py
@@ -1,0 +1,84 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to read and write filesystem extended attributes."""
+
+import os
+import sys
+from typing import Optional
+
+from craft_parts import errors
+
+_STAGE_PACKAGE_KEY = "origin_stage_package"
+
+
+def _get_xattr_key(key: str) -> str:
+    return f"user.craft_parts.{key}"
+
+
+def _read_xattr(path: str, key: str) -> Optional[str]:
+    if sys.platform != "linux":
+        raise RuntimeError("xattr support only available for Linux")
+
+    # Extended attributes do not apply to symlinks.
+    if os.path.islink(path):
+        return None
+
+    key = _get_xattr_key(key)
+    try:
+        value = os.getxattr(path, key)
+    except OSError as error:
+        # No label present with:
+        # OSError: [Errno 61] No data available: b'<path>'
+        if error.errno == 61:
+            return None
+
+        # Chain unknown variants of OSError.
+        raise errors.XAttributeError(key=key, path=path) from error
+
+    return value.decode().strip()
+
+
+def _write_xattr(path: str, key: str, value: str) -> None:
+    if sys.platform != "linux":
+        raise RuntimeError("xattr support only available for Linux")
+
+    # Extended attributes do not apply to symlinks.
+    if os.path.islink(path):
+        return
+
+    key = _get_xattr_key(key)
+
+    try:
+        os.setxattr(path, key, value.encode())
+    except OSError as error:
+        # Label is too long for filesystem:
+        # OSError: [Errno 7] Argument list too long: b'<path>'
+        if error.errno == 7:
+            raise errors.XAttributeTooLong(path=path, key=key, value=value)
+
+        # Chain unknown variants of OSError.
+        raise errors.XAttributeError(key=key, path=path, is_write=True) from error
+
+
+def read_origin_stage_package(path: str) -> Optional[str]:
+    """Read origin stage package."""
+    return _read_xattr(path, _STAGE_PACKAGE_KEY)
+
+
+def write_origin_stage_package(path: str, value: str) -> None:
+    """Write origin stage package."""
+    _write_xattr(path, _STAGE_PACKAGE_KEY, value)

--- a/craft_parts/xattrs.py
+++ b/craft_parts/xattrs.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from craft_parts import errors
 
+# TODO: this might be a separations of concern leak, improve this handling.
 _STAGE_PACKAGE_KEY = "origin_stage_package"
 
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -100,3 +100,23 @@ def test_part_specification_error_from_bad_validation_error():
     assert err.brief == "Part 'foo' validation failed."
     assert err.details == ""
     assert err.resolution == "Review part 'foo' and make sure it's correct."
+
+
+def test_xattribute_read_error():
+    err = errors.XAttributeError(key="name", path="path")
+    assert err.key == "name"
+    assert err.path == "path"
+    assert err.is_write is False
+    assert err.brief == "Unable to read extended attribute."
+    assert err.details == "Failed to read attribute 'name' on 'path'."
+    assert err.resolution == "Make sure your filesystem supports extended attributes."
+
+
+def test_xattribute_write_error():
+    err = errors.XAttributeError(key="name", path="path", is_write=True)
+    assert err.key == "name"
+    assert err.path == "path"
+    assert err.is_write is True
+    assert err.brief == "Unable to write extended attribute."
+    assert err.details == "Failed to write attribute 'name' on 'path'."
+    assert err.resolution == "Make sure your filesystem supports extended attributes."

--- a/tests/unit/test_xattrs.py
+++ b/tests/unit/test_xattrs.py
@@ -1,0 +1,106 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2019-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import os
+import sys
+
+import pytest
+
+from craft_parts import errors, xattrs
+
+
+class TestXattrs:
+    """Extended attribute tests."""
+
+    def setup_method(self):
+        # These tests don't work on tmpfs
+        self._test_file = (  # pylint: disable=attribute-defined-outside-init
+            ".tests-xattr-test-file"
+        )
+
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(self._test_file)
+
+        open(self._test_file, "w").close()
+
+    def teardown_method(self):
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(self._test_file)
+            os.remove(self._test_file + "-symlink")
+
+    def test_read_origin_stage_package(self):
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self._test_file)
+            assert result is None
+        else:
+            with pytest.raises(RuntimeError):
+                xattrs.read_origin_stage_package(self._test_file)
+
+    def test_write_origin_stage_package(self):
+        package = "foo-1.0"
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self._test_file)
+            assert result is None
+
+            xattrs.write_origin_stage_package(self._test_file, package)
+            result = xattrs.read_origin_stage_package(self._test_file)
+            assert result == package
+        else:
+            with pytest.raises(RuntimeError):
+                xattrs.write_origin_stage_package(self._test_file, package)
+
+    def test_write_origin_stage_package_long(self):
+        package = "a" * 100000
+        if sys.platform == "linux":
+            result = xattrs.read_origin_stage_package(self._test_file)
+            assert result is None
+
+            with pytest.raises(errors.XAttributeTooLong) as raised:
+                xattrs.write_origin_stage_package(self._test_file, package)
+            assert raised.value.key == "user.craft_parts.origin_stage_package"
+            assert raised.value.path == self._test_file
+
+            result = xattrs.read_origin_stage_package(self._test_file)
+            assert result is None
+        else:
+            with pytest.raises(RuntimeError) as raised:
+                xattrs.write_origin_stage_package(self._test_file, package)
+            assert str(raised.value) == "xattr support only available for Linux"
+
+    def test_symlink(self):
+        test_symlink = self._test_file + "-symlink"
+        os.symlink(self._test_file, test_symlink)
+
+        if sys.platform != "linux":
+            return
+
+        result = xattrs._read_xattr(test_symlink, "attr")
+        assert result is None
+
+        xattrs._write_xattr(test_symlink, "attr", "value")
+        result = xattrs._read_xattr(test_symlink, "attr")
+        assert result is None
+
+    def test_read_non_linux(self, mocker):
+        mocker.patch("sys.platform", return_value="win32")
+        with pytest.raises(RuntimeError):
+            xattrs._read_xattr(self._test_file, "attr")
+
+    def test_write_non_linux(self, mocker):
+        mocker.patch("sys.platform", return_value="win32")
+        with pytest.raises(RuntimeError):
+            xattrs._write_xattr(self._test_file, "attr", "value")


### PR DESCRIPTION
Extended attributes are used to track the origin of primed files.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
