### PR TITLE
sources: add the local source handler

### DIFF
--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -1,0 +1,145 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The local source handler and helpers."""
+
+import functools
+import glob
+import os
+from typing import List, Optional
+
+from craft_parts.utils import file_utils
+
+from .base import SourceHandler
+
+
+class LocalSource(SourceHandler):
+    """The local source handler."""
+
+    def __init__(self, *args, copy_function=file_utils.link_or_copy, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.source_abspath = os.path.abspath(self.source)
+        self.copy_function = copy_function
+
+        patterns = [
+            self._dirs.parts_dir.name,
+            self._dirs.stage_dir.name,
+            self._dirs.prime_dir.name,
+            "*.snap",  # FIXME: this should be specified by the application
+        ]
+        self._ignore = functools.partial(
+            _ignore, self.source_abspath, os.getcwd(), patterns
+        )
+        self._updated_files = set()
+        self._updated_directories = set()
+
+    def pull(self):
+        """Retrieve the local source files."""
+        file_utils.link_or_copy_tree(
+            self.source_abspath,
+            self.part_src_dir,
+            ignore=self._ignore,
+            copy_function=self.copy_function,
+        )
+
+    def check_if_outdated(
+        self, target: str, *, ignore_files: Optional[List[str]] = None
+    ) -> bool:
+        """Check if pulled sources have changed since target was created.
+
+        :param target: Path to target file.
+        :param ignore_files: Files excluded from verification.
+
+        :return: Whether the sources are outdated.
+        """
+        try:
+            target_mtime = os.lstat(target).st_mtime
+        except FileNotFoundError:
+            return False
+
+        self._updated_files = set()
+        self._updated_directories = set()
+
+        for (root, directories, files) in os.walk(self.source_abspath, topdown=True):
+            ignored = set(
+                self._ignore(root, directories + files, also_ignore=ignore_files)
+            )
+            if ignored:
+                # Prune our search appropriately given an ignore list, i.e.
+                # don't walk into directories that are ignored.
+                directories[:] = [d for d in directories if d not in ignored]
+
+            for file_name in set(files) - ignored:
+                path = os.path.join(root, file_name)
+                if os.lstat(path).st_mtime >= target_mtime:
+                    self._updated_files.add(os.path.relpath(path, self.source))
+
+            for directory in directories:
+                path = os.path.join(root, directory)
+                if os.lstat(path).st_mtime >= target_mtime:
+                    # Don't descend into this directory-- we'll just copy it
+                    # entirely.
+                    directories.remove(directory)
+
+                    # os.walk will include symlinks to directories here, but we
+                    # want to treat those as files
+                    relpath = os.path.relpath(path, self.source)
+                    if os.path.islink(path):
+                        self._updated_files.add(relpath)
+                    else:
+                        self._updated_directories.add(relpath)
+
+        return len(self._updated_files) > 0 or len(self._updated_directories) > 0
+
+    def update(self):
+        """Update pulled source."""
+        # First, copy the directories
+        for directory in self._updated_directories:
+            file_utils.link_or_copy_tree(
+                os.path.join(self.source, directory),
+                os.path.join(self.part_src_dir, directory),
+                ignore=self._ignore,
+                copy_function=self.copy_function,
+            )
+
+        # Now, copy files
+        for file_path in self._updated_files:
+            self.copy_function(
+                os.path.join(self.source, file_path),
+                os.path.join(self.part_src_dir, file_path),
+            )
+
+
+def _ignore(
+    source: str,
+    current_directory: str,
+    patterns: List[str],
+    directory,
+    files,
+    also_ignore: List[str] = None,
+) -> List[str]:
+    if also_ignore:
+        patterns.extend(also_ignore)
+
+    ignored = []
+    if directory in (source, current_directory):
+        for pattern in patterns:
+            files = glob.glob(os.path.join(directory, pattern))
+            if files:
+                files = [os.path.basename(f) for f in files]
+                ignored += files
+
+    return ignored

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -25,6 +25,8 @@ from craft_parts.utils import file_utils
 
 from .base import SourceHandler
 
+# TODO: change file operations to use pathlib
+
 
 class LocalSource(SourceHandler):
     """The local source handler."""
@@ -34,14 +36,14 @@ class LocalSource(SourceHandler):
         self.source_abspath = os.path.abspath(self.source)
         self.copy_function = copy_function
 
-        patterns = [
+        ignore_patterns = [
             self._dirs.parts_dir.name,
             self._dirs.stage_dir.name,
             self._dirs.prime_dir.name,
             "*.snap",  # FIXME: this should be specified by the application
         ]
         self._ignore = functools.partial(
-            _ignore, self.source_abspath, os.getcwd(), patterns
+            _ignore, self.source_abspath, os.getcwd(), ignore_patterns
         )
         self._updated_files = set()
         self._updated_directories = set()

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -1,0 +1,84 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Source handle utilities.
+
+Unless the part plugin overrides this behaviour, a part can use these
+'source' keys in its definition. They tell Craft Parts where to pull source
+code for that part, and how to unpack it if necessary.
+
+  - source: url-or-path
+
+    A URL or path to some source tree to build. It can be local
+    ('./src/foo') or remote ('https://foo.org/...'), and can refer to a
+    directory tree or a tarball or a revision control repository
+    ('git:...').
+
+  - source-type: git, bzr, hg, svn, tar, deb, rpm, or zip
+
+    In some cases the source string is not enough to identify the version
+    control system or compression algorithm. The source-type key can tell
+    Craft Parts exactly how to treat that content.
+
+  - source-checksum: <algorithm>/<digest>
+
+    Craft Parts will use the digest specified to verify the integrity of the
+    source. The source-type needs to be a file (tar, zip, deb or rpm) and
+    the algorithm either md5, sha1, sha224, sha256, sha384, sha512, sha3_256,
+    sha3_384 or sha3_512.
+
+  - source-depth: <integer>
+
+    By default clones or branches with full history, specifying a depth
+    will truncate the history to the specified number of commits.
+
+  - source-branch: <branch-name>
+
+    Craft Parts will checkout a specific branch from the source tree. This
+    only works on multi-branch repositories from git and hg (mercurial).
+
+  - source-commit: <commit>
+
+    Craft Parts will checkout the specific commit from the source tree revision
+    control system.
+
+  - source-tag: <tag>
+
+    Craft Parts will checkout the specific tag from the source tree revision
+    control system.
+
+  - source-subdir: path
+
+    When building, Snapcraft will set the working directory to be this
+    subdirectory within the source.
+
+Note that plugins might well define their own semantics for the 'source'
+keywords, because they handle specific build systems, and many languages
+have their own built-in packaging systems (think CPAN, PyPI, NPM). In those
+cases you want to refer to the documentation for the specific plugin.
+"""
+
+from typing import Dict, Type
+
+from .base import SourceHandler
+from .local_source import LocalSource
+
+SourceHandlerType = Type[SourceHandler]
+
+
+_source_handler: Dict[str, SourceHandlerType] = {
+    "local": LocalSource,
+}

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -1,0 +1,291 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.sources import sources
+from craft_parts.sources.local_source import LocalSource
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestLocal:
+    """Various tests for the local source handler."""
+
+    def test_pull_with_existing_empty_source_dir_creates_hardlinks(self):
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        os.mkdir("destination")
+
+        local = LocalSource("src", "destination")
+        local.pull()
+
+        # Verify that the directories are not symlinks, but the file is a
+        # hardlink.
+        assert os.path.islink("destination") is False
+        assert os.path.islink(os.path.join("destination", "dir")) is False
+        assert os.stat(os.path.join("destination", "dir", "file")).st_nlink > 1
+
+    def test_pull_with_existing_source_tree_creates_hardlinks(self):
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        os.mkdir("destination")
+        open(os.path.join("destination", "existing-file"), "w").close()
+
+        local = LocalSource("src", "destination")
+        local.pull()
+
+        # Verify that the directories are not symlinks, but the file is a
+        # hardlink. Also verify that existing-file still exists.
+        assert os.path.islink("destination") is False
+        assert os.path.islink(os.path.join("destination", "dir")) is False
+        assert os.path.isfile(os.path.join("destination", "existing-file"))
+        assert os.stat(os.path.join("destination", "dir", "file")).st_nlink > 1
+
+    def test_pull_with_existing_source_link_error(self):
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        # Note that this is a symlink now instead of a directory
+        os.symlink("dummy", "destination")
+
+        local = LocalSource("src", "destination")
+
+        with pytest.raises(errors.CopyTreeError):
+            local.pull()
+
+    def test_pull_with_existing_source_file_error(self):
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        # Note that this is a file now instead of a directory
+        open("destination", "w").close()
+
+        local = LocalSource("src", "destination")
+        with pytest.raises(errors.CopyTreeError):
+            local.pull()
+
+    def test_pulling_twice_with_existing_source_dir_recreates_hardlinks(self):
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        os.mkdir("destination")
+
+        local = LocalSource("src", "destination")
+        local.pull()
+        local.pull()
+
+        # Verify that the directories are not symlinks, but the file is a
+        # hardlink.
+        assert os.path.islink("destination") is False
+        assert os.path.islink(os.path.join("destination", "dir")) is False
+        assert os.stat(os.path.join("destination", "dir", "file")).st_nlink > 1
+
+    def test_pull_ignores_own_work_data(self):
+        # Make the snapcraft-specific directories
+        os.makedirs(os.path.join("src", "parts"))
+        os.makedirs(os.path.join("src", "stage"))
+        os.makedirs(os.path.join("src", "prime"))
+        os.makedirs(os.path.join("src", ".snapcraft"))
+        os.makedirs(os.path.join("src", "snap"))
+
+        # Make the snapcraft.yaml (and hidden one) and a built snap
+        open(os.path.join("src", "snapcraft.yaml"), "w").close()
+        open(os.path.join("src", ".snapcraft.yaml"), "w").close()
+        open(os.path.join("src", "foo.snap"), "w").close()
+
+        # Make the global state cache
+        open(os.path.join("src", ".snapcraft", "state"), "w").close()
+
+        # Now make some real files
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+
+        os.mkdir("destination")
+
+        local = LocalSource("src", "destination")
+        local.pull()
+
+        # Verify that the snapcraft-specific stuff got filtered out
+        assert os.path.isdir(os.path.join("destination", "parts")) is False
+        assert os.path.isdir(os.path.join("destination", "stage")) is False
+        assert os.path.isdir(os.path.join("destination", "prime")) is False
+
+        assert os.path.isdir(os.path.join("destination", "snap"))
+        assert os.path.isfile(os.path.join("destination", ".snapcraft.yaml"))
+        assert os.path.isfile(os.path.join("destination", "snapcraft.yaml"))
+
+        assert os.path.isfile(os.path.join("destination", "foo.snap")) is False
+
+        # Verify that the real stuff made it in.
+        assert os.path.islink("destination") is False
+        assert os.path.islink(os.path.join("destination", "dir")) is False
+        assert os.stat(os.path.join("destination", "dir", "file")).st_nlink > 1
+
+    def test_pull_keeps_symlinks(self):
+        # Create a source containing a directory, a file and symlinks to both.
+        os.makedirs(os.path.join("src", "dir"))
+        open(os.path.join("src", "dir", "file"), "w").close()
+        os.symlink("dir", os.path.join("src", "dir_symlink"))
+        os.symlink("file", os.path.join("src", "dir", "file_symlink"))
+
+        local = LocalSource("src", "destination")
+        local.pull()
+
+        # Verify that both the file and the directory symlinks were kept.
+        assert os.path.isdir(os.path.join("destination", "dir"))
+        dir_symlink = os.path.join("destination", "dir_symlink")
+        assert os.path.islink(dir_symlink) and os.readlink(dir_symlink) == "dir"
+        assert os.path.isfile(os.path.join("destination", "dir", "file"))
+        file_symlink = os.path.join("destination", "dir", "file_symlink")
+        assert os.path.islink(file_symlink) and os.readlink(file_symlink) == "file"
+
+    def test_has_source_handler_entry(self):
+        assert sources._source_handler["local"] is LocalSource
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestLocalUpdate:
+    """Verify that the local source can detect changes and update."""
+
+    def test_file_modified(self):
+        source = "source"
+        destination = "destination"
+        os.mkdir(source)
+        os.mkdir(destination)
+
+        with open(os.path.join(source, "file"), "w") as f:
+            f.write("1")
+
+        # Now make a reference file with a timestamp later than the file was
+        # created. We'll ensure this by setting it ourselves
+        shutil.copy2(os.path.join(source, "file"), "reference")
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime("reference", (access_time, modify_time + 1))
+
+        local = LocalSource(source, destination)
+        local.pull()
+
+        # Update check on non-existent files should return False
+        assert local.check_if_outdated("invalid") is False
+
+        # Expect no updates to be available
+        assert local.check_if_outdated("reference") is False
+
+        with open(os.path.join(destination, "file")) as f:
+            assert f.read() == "1"
+
+        # Now update the file in source, and make sure it has a timestamp
+        # later than our reference (this whole test happens too fast)
+        with open(os.path.join(source, "file"), "w") as f:
+            f.write("2")
+
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime(os.path.join(source, "file"), (access_time, modify_time + 1))
+
+        # Expect update to be available
+        assert local.check_if_outdated("reference")
+
+        local.update()
+
+        with open(os.path.join(destination, "file")) as f:
+            assert f.read() == "2"
+
+    def test_file_added(self):
+        source = "source"
+        destination = "destination"
+        os.mkdir(source)
+        os.mkdir(destination)
+
+        with open(os.path.join(source, "file1"), "w") as f:
+            f.write("1")
+
+        # Now make a reference file with a timestamp later than the file was
+        # created. We'll ensure this by setting it ourselves
+        shutil.copy2(os.path.join(source, "file1"), "reference")
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime("reference", (access_time, modify_time + 1))
+
+        local = LocalSource(source, destination)
+        local.pull()
+
+        # Expect no updates to be available
+        assert local.check_if_outdated("reference") is False
+
+        assert os.path.isfile(os.path.join(destination, "file1"))
+
+        # Now add a new file, and make sure it has a timestamp
+        # later than our reference (this whole test happens too fast)
+        with open(os.path.join(source, "file2"), "w") as f:
+            f.write("2")
+
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime(os.path.join(source, "file2"), (access_time, modify_time + 1))
+
+        # Expect update to be available
+        assert local.check_if_outdated("reference")
+
+        local.update()
+        assert os.path.isfile(os.path.join(destination, "file2"))
+
+    def test_directory_modified(self):
+        source = "source"
+        source_dir = os.path.join(source, "dir")
+        destination = "destination"
+        os.makedirs(source_dir)
+        os.mkdir(destination)
+
+        with open(os.path.join(source_dir, "file1"), "w") as f:
+            f.write("1")
+
+        # Now make a reference file with a timestamp later than the file was
+        # created. We'll ensure this by setting it ourselves
+        shutil.copy2(os.path.join(source_dir, "file1"), "reference")
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime("reference", (access_time, modify_time + 1))
+
+        local = LocalSource(source, destination)
+        local.pull()
+
+        # Expect no updates to be available
+        assert local.check_if_outdated("reference") is False
+
+        assert os.path.isfile(os.path.join(destination, "dir", "file1"))
+
+        # Now add a new file to the directory, and make sure it has a timestamp
+        # later than our reference (this whole test happens too fast)
+        with open(os.path.join(source_dir, "file2"), "w") as f:
+            f.write("2")
+
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime(os.path.join(source_dir, "file2"), (access_time, modify_time + 1))
+
+        # Expect update to be available
+        assert local.check_if_outdated("reference")
+
+        local.update()
+        assert os.path.isfile(os.path.join(destination, "dir", "file2"))


### PR DESCRIPTION
The local source handler implements pull and update for sources that
are already in the host filesystem.

Note: the source handler implementation and accompanying tests are a
direct port of the corresponding files in snapcraft and may be revisited and
refactored in the future.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
