### PR TITLE
plugins: add plugin registry and management helpers

### DIFF
--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -16,5 +16,12 @@
 
 """Craft Parts plugins subsystem."""
 
-from .base import Plugin  # noqa: F401
-from .properties import PluginProperties  # noqa: F401
+from .plugins import (  # noqa: F401
+    Plugin,
+    PluginProperties,
+    get_plugin,
+    get_plugin_class,
+    register,
+    strip_plugin_properties,
+    unregister_all,
+)

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -1,0 +1,107 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definitions and helpers to handle plugins."""
+
+import copy
+from typing import TYPE_CHECKING, Any, Dict, Type
+
+from .autotools_plugin import AutotoolsPlugin
+from .base import Plugin
+from .dump_plugin import DumpPlugin
+from .make_plugin import MakePlugin
+from .nil_plugin import NilPlugin
+from .properties import PluginProperties
+
+if TYPE_CHECKING:
+    from craft_parts.infos import PartInfo
+    from craft_parts.parts import Part
+
+
+PluginType = Type[Plugin]
+
+
+# Plugin registry by plugin API version
+_BUILTIN_PLUGINS: Dict[str, PluginType] = {
+    "autotools": AutotoolsPlugin,
+    "dump": DumpPlugin,
+    "make": MakePlugin,
+    "nil": NilPlugin,
+}
+
+_PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)
+
+
+def get_plugin(
+    *,
+    part: "Part",
+    part_info: "PartInfo",
+    properties: PluginProperties,
+) -> Plugin:
+    """Obtain a plugin instance for the specified part.
+
+    :param part: The part requesting the plugin.
+    :param part_info: The part information data.
+    :param properties: The plugin properties.
+
+    :return: The plugin instance.
+    """
+    plugin_name = part.plugin if part.plugin else part.name
+    plugin_class = get_plugin_class(plugin_name)
+
+    return plugin_class(properties=properties, part_info=part_info)
+
+
+def get_plugin_class(name: str) -> PluginType:
+    """Obtain a plugin class given the name.
+
+    :param name: The plugin name.
+
+    :return: The plugin class.
+
+    :raise ValueError: If the plugin name is invalid.
+    """
+    if name not in _PLUGINS:
+        raise ValueError(f"plugin not registered: {name!r}")
+
+    return _PLUGINS[name]
+
+
+def register(plugins: Dict[str, PluginType]) -> None:
+    """Register part handler plugins.
+
+    :param plugins: a dictionary where the keys are plugin names and values
+        are plugin classes. Valid plugins must subclass class:`Plugin`.
+    """
+    _PLUGINS.update(plugins)
+
+
+def unregister_all() -> None:
+    """Unregister all user-registered plugins."""
+    global _PLUGINS  # pylint: disable=global-statement
+    _PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)
+
+
+def strip_plugin_properties(data: Dict[str, Any], *, plugin_name: str) -> None:
+    """Remove plugin-specific entries from part properties.
+
+    :param data: A dictionary containing all part properties.
+    :plugin_name: The name of the plugin.
+    """
+    prefix = f"{plugin_name}-"
+    for key in list(data):
+        if key.startswith(prefix):
+            del data[key]

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -99,7 +99,7 @@ def strip_plugin_properties(data: Dict[str, Any], *, plugin_name: str) -> None:
     """Remove plugin-specific entries from part properties.
 
     :param data: A dictionary containing all part properties.
-    :plugin_name: The name of the plugin.
+    :param plugin_name: The name of the plugin.
     """
     prefix = f"{plugin_name}-"
     for key in list(data):

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -1,0 +1,154 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Dict, List, Set
+
+import pytest
+
+from craft_parts import plugins
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins import nil_plugin
+from craft_parts.plugins.plugins import (
+    AutotoolsPlugin,
+    DumpPlugin,
+    MakePlugin,
+    NilPlugin,
+)
+
+
+class TestGetPlugin:
+    """Check plugin instantiation given the part and API version.
+
+    The plugin is ordinarily selected using the `plugin` property defined
+    in the part. If it's not defined, use the part name as a fallback.
+    """
+
+    @pytest.mark.parametrize(
+        "name,plugin_class",
+        [
+            ("autotools", AutotoolsPlugin),
+            ("dump", DumpPlugin),
+            ("make", MakePlugin),
+            ("nil", NilPlugin),
+        ],
+    )
+    def test_get_plugin(self, name, plugin_class):
+        part = Part("foo", {"plugin": name})
+        project_info = ProjectInfo()
+        part_info = PartInfo(project_info=project_info, part=part)
+
+        pclass = plugins.get_plugin_class(name)
+        assert pclass == plugin_class
+
+        plugin = plugins.get_plugin(
+            part=part, part_info=part_info, properties=pclass.properties_class()
+        )
+
+        assert isinstance(plugin, plugin_class)
+
+    def test_get_plugin_fallback(self):
+        part = Part("nil", {})
+        project_info = ProjectInfo()
+        part_info = PartInfo(project_info=project_info, part=part)
+
+        plugin = plugins.get_plugin(
+            part=part,
+            part_info=part_info,
+            properties=nil_plugin.NilPluginProperties(),
+        )
+
+        assert isinstance(plugin, nil_plugin.NilPlugin)
+
+    def test_get_plugin_unregistered(self):
+        part = Part("foo", {"plugin": "invalid"})
+        project_info = ProjectInfo()
+        part_info = PartInfo(project_info=project_info, part=part)
+
+        with pytest.raises(ValueError) as raised:
+            plugins.get_plugin(
+                part=part,
+                part_info=part_info,
+                properties=None,  # type: ignore
+            )
+        assert str(raised.value) == "plugin not registered: 'invalid'"
+
+    def test_get_plugin_unspecified(self):
+        part = Part("foo", {})
+        project_info = ProjectInfo()
+        part_info = PartInfo(project_info=project_info, part=part)
+
+        with pytest.raises(ValueError) as raised:
+            plugins.get_plugin(
+                part=part,
+                part_info=part_info,
+                properties=None,  # type: ignore
+            )
+        assert str(raised.value) == "plugin not registered: 'foo'"
+
+
+class FooPlugin(plugins.Plugin):
+    """A test plugin."""
+
+    properties_class = plugins.PluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+class TestPluginRegistry:
+    """Verify plugin register/unregister functions."""
+
+    def test_register_unregister(self):
+        with pytest.raises(ValueError):
+            plugins.get_plugin_class("foo")
+
+        plugins.register({"foo": FooPlugin})
+        foo_plugin = plugins.get_plugin_class("foo")
+        assert foo_plugin == FooPlugin
+
+        plugins.unregister_all()
+        with pytest.raises(ValueError):
+            plugins.get_plugin_class("foo")
+
+
+class TestHelpers:
+    """Verify plugin helper functions."""
+
+    def test_strip_plugin_properties(self):
+        data = {
+            "foo": True,
+            "test": "yes",
+            "test-one": 1,
+            "test-two": 2,
+            "not-test-three": 3,
+        }
+
+        plugins.strip_plugin_properties(data, plugin_name="test")
+        assert data == {
+            "foo": True,
+            "test": "yes",
+            "not-test-three": 3,
+        }


### PR DESCRIPTION
Application-defined plugins must be registered to be recognized by
Craft Parts. This change implements the plugin registry and helpers
to register, unregister, and retrieve plugin classes and instances.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
