### PR TITLE
parts: unmarshal plugin properties

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -175,3 +175,32 @@ class XAttributeTooLong(PartsError):
         details = f"key={key!r}, value={value!r}"
 
         super().__init__(brief=brief, details=details)
+
+
+class UndefinedPlugin(PartsError):
+    """The part didn't define a plugin and the part name is not a valid plugin name.
+
+    :param part_name: The name of the part with no plugin definition."
+    """
+
+    def __init__(self, *, part_name: str):
+        self.part_name = part_name
+        brief = f"Plugin not defined for part {part_name!r}."
+        resolution = f"Review part {part_name!r} and make sure it's correct."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class InvalidPlugin(PartsError):
+    """A request was made to use a plugin that's not registered.
+
+    :param plugin_name: The invalid plugin name."
+    """
+
+    def __init__(self, plugin_name: str, *, part_name: str):
+        self.plugin_name = plugin_name
+        self.part_name = part_name
+        brief = f"Plugin {plugin_name!r} in part {part_name!r} is not registered."
+        resolution = f"Review part {part_name!r} and make sure it's correct."
+
+        super().__init__(brief=brief, resolution=resolution)

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -109,6 +109,13 @@ class LifecycleManager:
 
 
 def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> Part:
+    """Create and populate a :class:`Part` object based on part specification data.
+
+    :param spec: A dictionary containing the part specification.
+    :param project_dirs: The project's work directories.
+
+    :return: A :class:`Part` object corresponding to the given part specification.
+    """
     if not isinstance(spec, dict):
         raise errors.PartSpecificationError(
             part_name=name, message="part definition is malformed"

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -116,14 +116,15 @@ def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> P
 
     plugin_name = spec.get("plugin", "")
 
-    fallback_plugin_name = not plugin_name
-    if fallback_plugin_name:
+    # If the plugin was not specified, use the part name as the plugin name.
+    part_name_as_plugin_name = not plugin_name
+    if part_name_as_plugin_name:
         plugin_name = name
 
     try:
         plugin_class = plugins.get_plugin_class(plugin_name)
     except ValueError as err:
-        if fallback_plugin_name:
+        if part_name_as_plugin_name:
             # If plugin was not specified, avoid raising an exception telling
             # that part name is an invalid plugin.
             raise errors.UndefinedPlugin(part_name=name) from err

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
+from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
 
 
@@ -126,6 +127,7 @@ class Part:
         data: Dict[str, Any],
         *,
         project_dirs: ProjectDirs = None,
+        plugin_properties: "Optional[PluginProperties]" = None,
     ):
         if not isinstance(data, dict):
             raise errors.PartSpecificationError(
@@ -135,12 +137,14 @@ class Part:
         if not project_dirs:
             project_dirs = ProjectDirs()
 
-        plugin_name: str = data.get("plugin", "")
+        if not plugin_properties:
+            plugin_properties = PluginProperties()
 
-        # TODO: handle fallback to part name if plugin not specified
+        plugin_name: str = data.get("plugin", "")
 
         self.name = name
         self.plugin = plugin_name
+        self.plugin_properties = plugin_properties
         self._dirs = project_dirs
         self._part_dir = project_dirs.parts_dir / name
         self._part_dir = project_dirs.parts_dir / name

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -17,13 +17,14 @@
 """Plugin base class and definitions."""
 
 import abc
-from typing import Any, Dict, List, Set, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Set, Type
 
 from pydantic import BaseModel
 
-from craft_parts.infos import PartInfo
-
 from .properties import PluginProperties
+
+if TYPE_CHECKING:
+    from craft_parts.infos import PartInfo
 
 
 class Plugin(abc.ABC):
@@ -37,7 +38,7 @@ class Plugin(abc.ABC):
 
     properties_class: Type[PluginProperties]
 
-    def __init__(self, *, properties: PluginProperties, part_info: PartInfo) -> None:
+    def __init__(self, *, properties: PluginProperties, part_info: "PartInfo") -> None:
         self._name = part_info.part_name
         self._options = properties
         self._part_info = part_info

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -136,3 +136,20 @@ def test_xattribute_write_error():
     assert err.brief == "Unable to write extended attribute."
     assert err.details == "Failed to write attribute 'name' on 'path'."
     assert err.resolution == "Make sure your filesystem supports extended attributes."
+
+
+def test_undefined_plugin():
+    err = errors.UndefinedPlugin(part_name="foo")
+    assert err.part_name == "foo"
+    assert err.brief == "Plugin not defined for part 'foo'."
+    assert err.details is None
+    assert err.resolution == "Review part 'foo' and make sure it's correct."
+
+
+def test_invalid_plugin():
+    err = errors.InvalidPlugin("name", part_name="foo")
+    assert err.plugin_name == "name"
+    assert err.part_name == "foo"
+    assert err.brief == "Plugin 'name' in part 'foo' is not registered."
+    assert err.details is None
+    assert err.resolution == "Review part 'foo' and make sure it's correct."


### PR DESCRIPTION
Plugin properties are specified along part properties and prefixed by
the plugin name. Validate and unmarshal properties and assign them
to the corresponding part.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
