### PR TITLE
packages: add base and dummy repository classes

### DIFF
--- a/craft_parts/packages/__init__.py
+++ b/craft_parts/packages/__init__.py
@@ -1,0 +1,17 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Operations with platform-specific package repositories."""

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -1,0 +1,236 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definition and helpers for the repository base class."""
+
+import abc
+import contextlib
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Set, Tuple, Type
+
+from craft_parts import xattrs
+
+logger = logging.getLogger(__name__)
+
+
+class BaseRepository(abc.ABC):
+    """Base implementation for a platform specific repository handler."""
+
+    @classmethod
+    @abc.abstractmethod
+    def get_package_libraries(cls, package_name: str) -> Set[str]:
+        """Return a list of libraries in package_name.
+
+        Given the contents of package_name, return the subset of what are
+        considered libraries from those contents, be it static or shared.
+
+        :param package_name: The package name to get library contents from.
+        :return: A list of libraries that package_name provides, with paths.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def get_packages_for_source_type(cls, source_type: str) -> Set[str]:
+        """Return a list of packages required to to work with source_type.
+
+        :param source_type: A source type to handle.
+
+        :return: A set of packages that need to be installed on the host.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def refresh_build_packages_list(cls) -> None:
+        """Refresh the list of packages available in the repository.
+
+        If refreshing is not possible :class:`CacheUpdateFailed` should be
+        raised.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def install_build_packages(cls, package_names: List[str]) -> List[str]:
+        """Install packages on the host system.
+
+        This method needs to be implemented by using the appropriate mechanism
+        to install packages on the system. If possible they should be marked
+        as automatically installed to allow for easy removal. The method
+        should return a list of the actually installed packages in the form
+        "package=version".
+
+        If one of the packages cannot be found :class:`BuildPackageNotFound`
+        should be raised. If dependencies for a package cannot be resolved
+        :class:`PackageBroken` should be raised. If installing a package on the
+        host failed :class:`BuildPackagesNotInstalled` should be raised.
+
+        :param package_names: A list of package names to install.
+
+        :return: A list with the packages installed and their versions.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def is_package_installed(cls, package_name: str) -> bool:
+        """Inform if a package is installed on the host system.
+
+        :param package_name: The package name to query.
+
+        :return: Whether the package is installed.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def get_installed_packages(cls) -> List[str]:
+        """Obtain a list of the installed packages and their versions.
+
+        :return: A list of installed packages in the form package=version.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def refresh_stage_packages_list(
+        cls, *, application_name: str, target_arch: str
+    ) -> None:
+        """Update the list of packages available in the repository.
+
+        :param application_name: A unique identifier for the application
+            using Craft Parts.
+        :param target_arch: The architecture of the packages to fetch.
+
+        :raise CacheUpdateFailed: If the update process is not successful.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def fetch_stage_packages(
+        cls,
+        *,
+        application_name: str,
+        package_names: List[str],
+        stage_packages_path: Path,
+        base: str,
+        target_arch: str,
+        list_only: bool = False,
+    ) -> List[str]:
+        """Fetch stage packages to stage_packages_path.
+
+        :param application_name: A unique identifier for the application
+            using Craft Parts.
+        :param package_names: A list with the names of the packages to fetch.
+        :stage_packages_path: The path stage packages will be fetched to.
+        :param base: The base this project will run on.
+        :param target_arch: The architecture of the packages to fetch.
+        :param list_only: Whether to obtain a list of packages to be fetched
+            instead of actually fetching the packages.
+
+        :return: The list of all packages to be fetched, including dependencies.
+        """
+
+    @classmethod
+    @abc.abstractmethod
+    def unpack_stage_packages(
+        cls, *, stage_packages_path: Path, install_path: Path
+    ) -> None:
+        """Unpack stage packages.
+
+        :param stage_packages_path: The path to the directory containing the
+            stage packages to unpack.
+        :param install_path: The path stage packages will be unpacked to.
+        """
+
+
+RepositoryType = Type[BaseRepository]
+
+
+class DummyRepository(BaseRepository):
+    """A dummy repository."""
+
+    @classmethod
+    def get_package_libraries(cls, package_name: str) -> Set[str]:
+        """Return a list of libraries in package_name."""
+        return set()
+
+    @classmethod
+    def get_packages_for_source_type(cls, source_type: str) -> Set[str]:
+        """Return a list of packages required to to work with source_type."""
+        return set()
+
+    @classmethod
+    def refresh_build_packages_list(cls) -> None:
+        """Refresh the build packages cache."""
+
+    @classmethod
+    def install_build_packages(cls, package_names: List[str]) -> List[str]:
+        """Install packages on the host system."""
+        return []
+
+    @classmethod
+    def is_package_installed(cls, package_name: str) -> bool:
+        """Inform if a packahe is installed on the host system."""
+        return False
+
+    @classmethod
+    def get_installed_packages(cls) -> List[str]:
+        """Obtain a list of the installed packages and their versions."""
+        return []
+
+    @classmethod
+    def refresh_stage_packages_list(
+        cls, *, application_name: str, target_arch: str
+    ) -> None:
+        """Update the list of packages available in the repository."""
+
+    @classmethod
+    def fetch_stage_packages(
+        cls,
+        **kwargs,  # pylint: disable=unused-argument
+    ) -> List[str]:
+        """Fetch stage packages to stage_packages_path."""
+        return []
+
+    @classmethod
+    def unpack_stage_packages(
+        cls, *, stage_packages_path: Path, install_path: Path
+    ) -> None:
+        """Unpack stage packages to install_path."""
+
+
+def get_pkg_name_parts(pkg_name: str) -> Tuple[str, Optional[str]]:
+    """Break package name into base parts."""
+    name = pkg_name
+    version = None
+    with contextlib.suppress(ValueError):
+        name, version = pkg_name.split("=")
+
+    return name, version
+
+
+def mark_origin_stage_package(sources_dir: str, stage_package: str) -> Set[str]:
+    """Mark all files in sources_dir as coming from stage_package."""
+    file_list = set()
+    for (root, _, files) in os.walk(sources_dir):
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+
+            # Mark source.
+            xattrs.write_origin_stage_package(file_path, stage_package)
+
+            file_path = os.path.relpath(root, sources_dir)
+            file_list.add(file_path)
+
+    return file_list

--- a/tests/unit/packages/test_base.py
+++ b/tests/unit/packages/test_base.py
@@ -1,0 +1,72 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.packages import base
+from craft_parts.packages.base import BaseRepository, DummyRepository
+
+
+class TestBaseRepository:
+    """Verify the base repository class."""
+
+    def test_abstract_methods(self):
+        assert BaseRepository.__abstractmethods__ == {  # type: ignore
+            "get_installed_packages",
+            "get_package_libraries",
+            "is_package_installed",
+            "get_packages_for_source_type",
+            "install_build_packages",
+            "fetch_stage_packages",
+            "refresh_build_packages_list",
+            "refresh_stage_packages_list",
+            "unpack_stage_packages",
+        }
+
+
+class TestDummyRepository:
+    """Verify the dummy repository implementation."""
+
+    def test_methods_implemented(self):
+        DummyRepository()
+
+    def test_methods(self):
+        assert DummyRepository.get_package_libraries("foo") == set()
+        assert DummyRepository.get_packages_for_source_type("bar") == set()
+        assert DummyRepository.install_build_packages([]) == []
+        assert DummyRepository.is_package_installed("baz") is False
+        assert DummyRepository.get_installed_packages() == []
+        assert DummyRepository.fetch_stage_packages() == []
+
+
+class TestPkgNameParts:
+    """Check the extraction of package name parts."""
+
+    def test_get_pkg_name_parts_name_only(self):
+        name, version = base.get_pkg_name_parts("hello")
+        assert name == "hello"
+        assert version is None
+
+    def test_get_pkg_name_parts_all(self):
+        name, version = base.get_pkg_name_parts("hello:i386=2.10-1")
+        assert name == "hello:i386"
+        assert version == "2.10-1"
+
+    def test_get_pkg_name_parts_no_arch(self):
+        name, version = base.get_pkg_name_parts("hello=2.10-1")
+        assert name == "hello"
+        assert version == "2.10-1"
+
+
+# TODO: add tests for mark_origin_stage_package()


### PR DESCRIPTION
Execution of the parts lifecycle requires packages to be installed on
the build host and onto the stage tree. "Packages" is derived from
snapcraft's "repo", minus repository management, plus minor refactoring
including changes to split normalization from the base class to improve
code readability.

Packages/repo is planned to be moved into a separate project, where
it will be further refactored. Current code follows the snapcraft
implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
