### PR TITLE
states: ensure minimum interval between state writes

### DIFF
--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Set
 
 from pydantic_yaml import YamlModel  # type: ignore
 
+from craft_parts.utils import os_utils
+
 
 class StepState(YamlModel, ABC):
     """Contextual information collected when a step is executed.
@@ -100,7 +102,7 @@ class StepState(YamlModel, ABC):
         """Write this state to disk."""
         filepath.parent.mkdir(parents=True, exist_ok=True)
         yaml_data = self.yaml(by_alias=True)
-        filepath.write_text(yaml_data)
+        os_utils.TimedWriter.write_text(filepath, yaml_data)
 
 
 def _get_differing_keys(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Set[str]:

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -17,8 +17,51 @@
 """Utilities related to the operating system."""
 
 import os
+import time
+from pathlib import Path
+from typing import Optional
+
+_WRITE_TIME_INTERVAL = 0.02
+
 
 # TODO:stdmsg: replace/remove terminal-related utilities
+
+
+class TimedWriter:
+    """Enforce minimum times between writes.
+
+    Ensure subsequent writes happen at least at the specified minimum
+    interval apart from each other, otherwise hosts with low tick
+    resolution may generate files with identical timestamps.
+    """
+
+    _last_write_time = 0.0
+
+    @classmethod
+    def write_text(
+        cls,
+        filepath: Path,
+        text: str,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+    ) -> None:
+        """Write text to the specified file.
+
+        :param filepath: The path to the file to write to.
+        :param text: The text to write.
+        :param encoding: The name of the encoding used to encode and
+            decode the file. See the corresponding parameter in ``os.open``
+            for details.
+        :param errors: How encoding/decoding errors are handled, in the
+            same format used in ``os.open``.
+        """
+        delta = time.time() - cls._last_write_time
+        if delta < _WRITE_TIME_INTERVAL:
+            time.sleep(_WRITE_TIME_INTERVAL - delta)
+
+        filepath.write_text(text, encoding=encoding, errors=errors)
+
+        cls._last_write_time = time.time()
 
 
 def is_dumb_terminal() -> bool:

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dataclasses
-import time
 from pathlib import Path
 
 import pytest
@@ -302,7 +301,6 @@ class TestStateManager:
         s1.write(Path("parts/p1/state/build"))
 
         # but p1 pull ran more recently
-        time.sleep(0.02)
         s1 = states.PullState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/pull"))
 
@@ -325,7 +323,6 @@ class TestStateManager:
         # p1 pull and build already ran
         s1 = states.PullState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/pull"))
-        time.sleep(0.02)
         s2 = states.BuildState(part_properties=part_properties)
         s2.write(Path("parts/p1/state/build"))
 
@@ -366,7 +363,6 @@ class TestStepOutdated:
         s1.write(Path("parts/p1/state/build"))
 
         # but p1 pull ran more recently
-        time.sleep(0.02)
         s1 = states.StageState()
         s1.write(Path("parts/p1/state/pull"))
 
@@ -408,7 +404,6 @@ class TestStepDirty:
         # p1 pull and build already ran
         s1 = states.PullState(part_properties=part_properties)
         s1.write(Path("parts/p1/state/pull"))
-        time.sleep(0.02)
         s2 = states.BuildState(part_properties=part_properties)
         s2.write(Path("parts/p1/state/build"))
 
@@ -441,18 +436,14 @@ class TestStepDirty:
         # p2 pull/build/stage already ran
         s2 = states.PullState(part_properties=p2_properties)
         s2.write(Path("parts/p2/state/pull"))
-        time.sleep(0.02)
         s2 = states.BuildState(part_properties=p2_properties)
         s2.write(Path("parts/p2/state/build"))
-        time.sleep(0.02)
         s2 = states.StageState(part_properties=p2_properties)
         s2.write(Path("parts/p2/state/stage"))
 
         # p1 pull/build already ran
-        time.sleep(0.02)
         s1 = states.PullState(part_properties=p1_properties)
         s1.write(Path("parts/p1/state/pull"))
-        time.sleep(0.02)
         s1 = states.BuildState(part_properties=p1_properties)
         s1.write(Path("parts/p1/state/build"))
 
@@ -492,10 +483,8 @@ class TestStepDirty:
         p2 = Part("p2", {})
 
         # p1 pull/build already ran
-        time.sleep(0.02)
         s1 = states.PullState(part_properties=p1_properties)
         s1.write(Path("parts/p1/state/pull"))
-        time.sleep(0.02)
         s1 = states.BuildState(part_properties=p1_properties)
         s1.write(Path("parts/p1/state/build"))
 
@@ -528,11 +517,8 @@ class TestHelpers:
         # use 20ms interval to avoid creating files with the same timestamp on
         # systems with low ticks resolution
         s4.write(Path("parts/bar/state/prime"))
-        time.sleep(0.02)
         s3.write(Path("parts/bar/state/pull"))
-        time.sleep(0.02)
         s1.write(Path("parts/foo/state/pull"))
-        time.sleep(0.02)
         s2.write(Path("parts/foo/state/build"))
 
         slist = state_manager._sort_steps_by_state_timestamp([p1, p2])

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -26,7 +26,7 @@ class TestTimedWriter:
     """Check if minimum interval ensured between writes."""
 
     @pytest.mark.usefixtures("new_dir")
-    def test_timed_write(self, mocker):
+    def test_timed_write_no_wait(self, mocker):
         mock_time = mocker.patch("time.time")
         mock_sleep = mocker.patch("time.sleep")
 
@@ -35,9 +35,20 @@ class TestTimedWriter:
         os_utils.TimedWriter.write_text(Path("foo"), "content")
         mock_sleep.assert_not_called()
 
+    @pytest.mark.usefixtures("new_dir")
+    def test_timed_write_full_wait(self, mocker):
+        mock_time = mocker.patch("time.time")
+        mock_sleep = mocker.patch("time.sleep")
+
         # no time passed since the last write
+        mock_time.return_value = os_utils.TimedWriter._last_write_time
         os_utils.TimedWriter.write_text(Path("bar"), "content")
         mock_sleep.assert_called_with(pytest.approx(0.02, 0.00001))
+
+    @pytest.mark.usefixtures("new_dir")
+    def test_timed_write_partial_wait(self, mocker):
+        mock_time = mocker.patch("time.time")
+        mock_sleep = mocker.patch("time.sleep")
 
         # some time passed since the last write
         mock_time.return_value = os_utils.TimedWriter._last_write_time + 0.005


### PR DESCRIPTION
Hosts with low timer resolution may create files with identical
timestamps if files are written at a rate higher than its tick
rate. Prevent that by enforcing a minimum time interval between
subsequent state writes.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
