### PR TITLE
packages: add support to apt cache operations

### DIFF
--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -1,0 +1,355 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Manages the state of packages obtained using apt."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+from contextlib import ContextDecorator
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+import apt
+import apt.cache
+import apt.package
+import apt.progress
+import apt.progress.text
+
+from craft_parts.utils import os_utils
+
+from . import errors
+from .base import get_pkg_name_parts
+
+logger = logging.getLogger(__name__)
+
+
+_HASHSUM_MISMATCH_PATTERN = re.compile(r"(E:Failed to fetch.+Hash Sum mismatch)+")
+
+
+class AptCache(ContextDecorator):
+    """Transient cache for stage packages, or read-only for build packages."""
+
+    def __init__(
+        self,
+        *,
+        stage_cache: Optional[Path] = None,
+        stage_cache_arch: Optional[str] = None,
+    ) -> None:
+        self.stage_cache = stage_cache
+        self.stage_cache_arch = stage_cache_arch
+        self.progress = None
+
+    # pylint: disable=attribute-defined-outside-init
+    def __enter__(self) -> AptCache:
+        if self.stage_cache is not None:
+            self._configure_apt()
+            self._populate_stage_cache_dir()
+            self.cache = apt.cache.Cache(rootdir=str(self.stage_cache), memonly=True)
+        else:
+            # Setting rootdir="/" is needed otherwise the previously set rootdir will
+            # be used and _deb.get_installed_packages() will return an empty list.
+            self.cache = apt.cache.Cache(rootdir="/")
+        return self
+
+    # pylint: enable=attribute-defined-outside-init
+
+    def __exit__(self, *exc) -> None:
+        self.cache.close()
+
+    def _configure_apt(self):
+        # Do not install recommends.
+        apt.apt_pkg.config.set("Apt::Install-Recommends", "False")
+
+        # Ensure repos are provided by trusted third-parties.
+        apt.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False")
+
+        # Methods and solvers dir for when in the SNAP.
+        snap_dir = os.getenv("SNAP")
+        if os_utils.is_snap() and snap_dir and os.path.exists(snap_dir):
+            apt_dir = os.path.join(snap_dir, "usr", "lib", "apt")
+            apt.apt_pkg.config.set("Dir", apt_dir)
+            # yes apt is broken like that we need to append os.path.sep
+            methods_dir = os.path.join(apt_dir, "methods")
+            apt.apt_pkg.config.set("Dir::Bin::methods", methods_dir + os.path.sep)
+            solvers_dir = os.path.join(apt_dir, "solvers")
+            apt.apt_pkg.config.set("Dir::Bin::solvers::", solvers_dir + os.path.sep)
+            apt_key_path = os.path.join(snap_dir, "usr", "bin", "apt-key")
+            apt.apt_pkg.config.set("Dir::Bin::apt-key", apt_key_path)
+            gpgv_path = os.path.join(snap_dir, "usr", "bin", "gpgv")
+            apt.apt_pkg.config.set("Apt::Key::gpgvcommand", gpgv_path)
+
+        apt.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg")
+        apt.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/")
+
+        # Clear up apt's Post-Invoke-Success as we are not running
+        # on the system.
+        apt.apt_pkg.config.clear("APT::Update::Post-Invoke-Success")
+
+        self.progress = apt.progress.text.AcquireProgress()
+        if os_utils.is_dumb_terminal():
+            # Make output more suitable for logging.
+            self.progress.pulse = lambda owner: True
+            self.progress._width = 0  # pylint: disable=protected-access
+
+    def _populate_stage_cache_dir(self) -> None:
+        """Create/refresh cache configuration.
+
+        (1) Delete old-style symlink cache, if symlink.
+        (2) Delete current-style (copied) tree.
+        (3) Copy current host apt configuration.
+        (4) Configure primary arch to target arch.
+        (5) Install dpkg into cache directory to support multi-arch.
+        """
+        if self.stage_cache is None:
+            return
+
+        # Copy apt configuration from host.
+        cache_etc_apt_path = Path(self.stage_cache, "etc", "apt")
+
+        # Delete potentially outdated cache configuration.
+        if cache_etc_apt_path.is_symlink():
+            cache_etc_apt_path.unlink()
+        elif cache_etc_apt_path.exists():
+            shutil.rmtree(cache_etc_apt_path)
+
+        # Copy current cache configuration.
+        cache_etc_apt_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree("/etc/apt", cache_etc_apt_path)
+
+        # Specify default arch (if specified).
+        if self.stage_cache_arch is not None:
+            arch_conf_path = cache_etc_apt_path / "apt.conf.d" / "00default-arch"
+            arch_conf_path.write_text(f'APT::Architecture "{self.stage_cache_arch}";\n')
+
+        # dpkg also needs to be in the rootdir in order to support multiarch
+        # (apt calls dpkg --print-foreign-architectures).
+        dpkg_path = shutil.which("dpkg")
+        if dpkg_path:
+            # Symlink it into place
+            destination = Path(self.stage_cache, dpkg_path[1:])
+            if not destination.exists():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(dpkg_path, destination)
+        else:
+            logger.warning("Cannot find 'dpkg' command needed to support multiarch")
+
+    def _autokeep_packages(self) -> None:
+        # If the package has been installed automatically as a dependency
+        # of another package, and if no packages depend on it anymore,
+        # the package is no longer required.
+        for package in self.cache.get_changes():
+            if package.is_auto_removable:
+                package.mark_keep()
+
+    def is_package_valid(self, package_name: str) -> bool:
+        """Verify whether there is a valid package with the given name.
+
+        :param package_name: The name of the package to verify.
+
+        :return: Whether a package with the given name is valid.
+        """
+        return package_name in self.cache or self.cache.is_virtual_package(package_name)
+
+    def get_installed_version(
+        self, package_name: str, *, resolve_virtual_packages: bool = False
+    ) -> Optional[str]:
+        """Obtain the version of the package currently installed on the system.
+
+        :param package_name: The package installed on the system.
+        :param resolve_virtual_packages: If the package is virtual, pick a non-virtual
+            package that satisfies this virtual package name.
+
+        :return: The installed package version.
+        """
+        if resolve_virtual_packages and self.cache.is_virtual_package(package_name):
+            logger.warning(
+                "%s is a virtual package, use non-virtual packages for "
+                "deterministic results.",
+                package_name,
+            )
+            # Recurse until a "real" package is found.
+            return self.get_installed_version(
+                self.cache.get_providing_packages(package_name)[0].name,
+                resolve_virtual_packages=resolve_virtual_packages,
+            )
+
+        if package_name in self.cache:
+            installed = self.cache[package_name].installed
+            if installed is not None:
+                return installed.version
+        return None
+
+    def fetch_archives(self, download_path: Path) -> List[Tuple[str, str, Path]]:
+        """Retrieve packages marked to be fetched.
+
+        :param download_path: The directory to download files to.
+
+        :return: A list of (<package-name>, <package-version>, <dl-path>) tuples.
+        """
+        downloaded = list()
+        for package in self.cache.get_changes():
+            if package.candidate is None:
+                continue
+
+            try:
+                dl_path = package.candidate.fetch_binary(str(download_path))
+            except apt.package.FetchError as err:
+                raise errors.PackageFetchError(str(err))
+
+            downloaded.append((package.name, package.candidate.version, Path(dl_path)))
+        return downloaded
+
+    def get_installed_packages(self) -> Dict[str, str]:
+        """Obtain a list of all packages and versions installed on the system.
+
+        :return: A dictionary of files and installed versions.
+        """
+        installed: Dict[str, str] = dict()
+        for package in self.cache:
+            if package.installed is not None:
+                installed[package.name] = str(package.installed.version)
+
+        return installed
+
+    def get_packages_marked_for_installation(self) -> List[Tuple[str, str]]:
+        """Obtain a list of packages and versions to be installed on the system.
+
+        :return: A list of (<package-name>, <package-version>) tuples.
+        """
+        return [
+            (package.name, package.candidate.version)
+            for package in self.cache.get_changes()
+            if package.marked_install and package.candidate is not None
+        ]
+
+    def mark_packages(self, package_names: Set[str]) -> None:
+        """Mark the given package names to be fetched from the repository.
+
+        :param package_names: The set of package names to be marked.
+        """
+        for name in package_names:
+            if name.endswith(":any"):
+                name = name[:-4]
+
+            if self.cache.is_virtual_package(name):
+                name = self.cache.get_providing_packages(name)[0].name
+
+            logger.debug("Marking %s (and its dependencies) to be fetched", name)
+
+            name_arch, version = get_pkg_name_parts(name)
+            if name_arch not in self.cache:
+                raise errors.PackageNotFound(name_arch)
+
+            package = self.cache[name_arch]
+            if version is not None:
+                _set_pkg_version(package, version)
+
+            logger.debug("package: %s", package)
+
+            # Disable automatic resolving of broken packages here
+            # because if that fails it raises a SystemError and the
+            # API doesn't expose enough information about the problem.
+            # Instead we let apt-get show a verbose error message later.
+            # Also, make sure this package is marked as auto-installed,
+            # which will propagate to its dependencies.
+            package.mark_install(auto_fix=False, from_user=False)
+
+            # Now mark this package as NOT automatically installed, which
+            # will leave its dependencies marked as auto-installed, which
+            # allows us to clean them up if necessary.
+            package.mark_auto(False)
+
+            _verify_marked_install(package)
+
+    def unmark_packages(self, *, unmark_names: Set[str]) -> None:
+        """Unmark packages and dependencies that are no longer required.
+
+        :param unmark_names: The names of the packages to unmark.
+        """
+        skipped_essential = set()
+        skipped_filtered = set()
+
+        for package in self.cache:
+            if (
+                package.candidate is not None
+                and package.candidate.priority == "essential"
+            ):
+                # Filter 'essential' packages.
+                skipped_essential.add(package.name)
+                package.mark_keep()
+                continue
+
+            if package.name in unmark_names:
+                # Filter packages from given list.
+                skipped_filtered.add(package.name)
+                package.mark_keep()
+                continue
+
+        if skipped_essential:
+            logger.debug(
+                "Skipping priority essential packages: %s",
+                sorted(skipped_essential),
+            )
+
+        if skipped_filtered:
+            logger.debug(
+                "Skipping filtered manifest packages: %s",
+                sorted(skipped_filtered),
+            )
+
+        # Unmark dependencies that are no longer required.
+        self._autokeep_packages()
+
+    # pylint: disable=attribute-defined-outside-init
+    def update(self) -> None:
+        """Update the package manager cache."""
+        try:
+            self.cache.update(fetch_progress=self.progress, sources_list=None)
+            self.cache.close()
+            self.cache = apt.cache.Cache(rootdir=str(self.stage_cache), memonly=True)
+        except apt.cache.FetchFailedException as err:
+            raise errors.PackageListRefreshError(str(err))
+
+    # pylint: enable=attribute-defined-outside-init
+
+
+def _verify_marked_install(package: apt.package.Package):
+    if package.installed or package.marked_install:
+        return
+
+    if not package.candidate:
+        return
+
+    broken_deps: List[str] = list()
+    for package_dependencies in package.candidate.dependencies:
+        for dep in package_dependencies:
+            if not dep.target_versions:
+                broken_deps.append(dep.name)
+    raise errors.PackageBroken(package.name, deps=broken_deps)
+
+
+def _set_pkg_version(package: apt.package.Package, version: str) -> None:
+    """Set candidate version to a specific version if available."""
+    if version in package.versions:
+        pkg_version = package.versions.get(version)
+        if pkg_version:
+            package.candidate = pkg_version
+    else:
+        raise errors.PackageNotFound("{}={}".format(package.name, version))

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -278,7 +278,7 @@ class AptCache(ContextDecorator):
 
             _verify_marked_install(package)
 
-    def unmark_packages(self, *, unmark_names: Set[str]) -> None:
+    def unmark_packages(self, unmark_names: Set[str]) -> None:
         """Unmark packages and dependencies that are no longer required.
 
         :param unmark_names: The names of the packages to unmark.

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -58,8 +58,8 @@ class BaseRepository(abc.ABC):
     def refresh_build_packages_list(cls) -> None:
         """Refresh the list of packages available in the repository.
 
-        If refreshing is not possible :class:`CacheUpdateFailed` should be
-        raised.
+        If refreshing is not possible :class:`PackageListRefreshError`
+        should be raised.
         """
 
     @classmethod
@@ -112,7 +112,7 @@ class BaseRepository(abc.ABC):
             using Craft Parts.
         :param target_arch: The architecture of the packages to fetch.
 
-        :raise CacheUpdateFailed: If the update process is not successful.
+        :raise PackageListRefreshError: If the update process is not successful.
         """
 
     @classmethod

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -1,0 +1,66 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Exceptions raised by the packages handling subsystem."""
+
+from typing import Sequence
+
+from craft_parts.errors import PartsError
+
+
+class PackagesError(PartsError):
+    """Base class for package handler errors."""
+
+
+class PackageListRefreshError(PackagesError):
+    """Failed to refresh the list of available packages."""
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = f"Failed to refresh package list: {message}."
+
+        super().__init__(brief=brief)
+
+
+class PackageFetchError(PackagesError):
+    """Failed to fetch package from remote repository."""
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = f"Failed to fetch package: {message}."
+
+        super().__init__(brief=brief)
+
+
+class PackageNotFound(PackagesError):
+    """Requested package doesn't exist in the remote repository."""
+
+    def __init__(self, package_name: str):
+        self.package_name = package_name
+        brief = f"Package not found: {package_name}."
+
+        super().__init__(brief=brief)
+
+
+class PackageBroken(PackagesError):
+    """Package has unmet dependencies."""
+
+    def __init__(self, package_name: str, *, deps: Sequence[str]):
+        self.package_name = package_name
+        self.deps = deps
+        brief = f"Package {package_name!r} has unmet dependencies: {', '.join(deps)}."
+
+        super().__init__(brief=brief)

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -16,10 +16,13 @@
 
 """Utilities related to the operating system."""
 
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 _WRITE_TIME_INTERVAL = 0.02
 
@@ -72,3 +75,24 @@ def is_dumb_terminal() -> bool:
     is_stdout_tty = os.isatty(1)
     is_term_dumb = os.environ.get("TERM", "") == "dumb"
     return not is_stdout_tty or is_term_dumb
+
+
+def is_snap(*, application_name: Optional[str] = None) -> bool:
+    """Verify whether we're running as a snap.
+
+    :application_name: The snap application name. If provided, check
+        if it matches the snap name.
+    """
+    snap_name = os.environ.get("SNAP_NAME", "")
+    if application_name:
+        res = snap_name == application_name
+    else:
+        res = snap_name is not None
+
+    logger.debug(
+        "craft_parts is is snap: %s, SNAP_NAME set to %s",
+        res,
+        snap_name,
+    )
+
+    return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==5.4.1
+http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_2.1.3ubuntu1.tar.xz; sys_platform == 'linux'
 progressbar==2.5
 pydantic==1.8.1
 pydantic-yaml==0.2.3

--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -1,0 +1,190 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+from unittest import mock
+from unittest.mock import call
+
+from craft_parts.packages.apt_cache import AptCache
+
+# pylint: disable=too-few-public-methods
+
+
+class TestAptStageCache:
+    """Make sure the stage cache is working correctly.
+
+    This are expensive tests, but is much more valuable than using mocks.
+    When adding tests, consider adding it to test_stage_packages(), or
+    create mocks.
+    """
+
+    def test_stage_packages(self, tmpdir):
+        fetch_dir_path = Path(tmpdir, "debs")
+        fetch_dir_path.mkdir(exist_ok=True, parents=True)
+        stage_cache = Path(tmpdir, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+
+        with AptCache(stage_cache=stage_cache) as apt_cache:
+            apt_cache.update()
+
+            package_names = {"pciutils"}
+            filtered_names = {
+                "base-files",
+                "libc6",
+                "libkmod2",
+                "libudev1",
+                "zlib1g",
+                # dependencies in focal
+                "dpkg",
+                "libacl1",
+                "libbz2-1.0",
+                "libcrypt1",
+                "liblzma5",
+                "libpcre2-8-0",
+                "libselinux1",
+                "libzstd1",
+                "pci.ids",
+                "perl-base",
+                "tar",
+            }
+
+            apt_cache.mark_packages(package_names)
+            apt_cache.unmark_packages(unmark_names=filtered_names)
+
+            marked_packages = apt_cache.get_packages_marked_for_installation()
+            assert sorted([name for name, _ in marked_packages]) == [
+                "libpci3",
+                "pciutils",
+            ]
+
+            names = []
+            for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
+                fetch_dir_path
+            ):
+                names.append(pkg_name)
+                assert dl_path.exists()
+                assert dl_path.parent == fetch_dir_path
+                assert isinstance(pkg_version, str)
+
+            assert sorted(names) == ["libpci3", "pciutils"]
+
+
+class TestMockedApt:
+    """Tests using mocked apt utility."""
+
+    def test_stage_cache(self, tmpdir, mocker):
+        stage_cache = Path(tmpdir, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+        fake_apt = mocker.patch("craft_parts.packages.apt_cache.apt")
+
+        with AptCache(stage_cache=stage_cache) as apt_cache:
+            apt_cache.update()
+
+        assert fake_apt.mock_calls == [
+            call.apt_pkg.config.set("Apt::Install-Recommends", "False"),
+            call.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False"),
+            call.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg"),
+            call.apt_pkg.config.set(
+                "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
+            ),
+            call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
+            call.progress.text.AcquireProgress(),
+            call.cache.Cache(rootdir=str(stage_cache), memonly=True),
+            call.cache.Cache().update(fetch_progress=mock.ANY, sources_list=None),
+            call.cache.Cache().close(),
+            call.cache.Cache(rootdir=str(stage_cache), memonly=True),
+            call.cache.Cache().close(),
+        ]
+
+    def test_stage_cache_in_snap(self, tmpdir, mocker):
+        fake_apt = mocker.patch("craft_parts.packages.apt_cache.apt")
+
+        stage_cache = Path(tmpdir, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+
+        snap = Path(tmpdir, "snap")
+        snap.mkdir(exist_ok=True, parents=True)
+
+        mocker.patch("craft_parts.utils.os_utils.is_snap", return_value=True)
+
+        with mock.patch.dict(os.environ, {"SNAP": str(snap)}), AptCache(
+            stage_cache=stage_cache
+        ) as apt_cache:
+            apt_cache.update()
+
+        assert fake_apt.mock_calls == [
+            call.apt_pkg.config.set("Apt::Install-Recommends", "False"),
+            call.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False"),
+            call.apt_pkg.config.set("Dir", str(Path(snap, "usr/lib/apt"))),
+            call.apt_pkg.config.set(
+                "Dir::Bin::methods",
+                str(Path(snap, "usr/lib/apt/methods")) + os.sep,
+            ),
+            call.apt_pkg.config.set(
+                "Dir::Bin::solvers::",
+                str(Path(snap, "usr/lib/apt/solvers")) + os.sep,
+            ),
+            call.apt_pkg.config.set(
+                "Dir::Bin::apt-key", str(Path(snap, "usr/bin/apt-key"))
+            ),
+            call.apt_pkg.config.set(
+                "Apt::Key::gpgvcommand", str(Path(snap, "usr/bin/gpgv"))
+            ),
+            call.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg"),
+            call.apt_pkg.config.set(
+                "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
+            ),
+            call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
+            call.progress.text.AcquireProgress(),
+            call.cache.Cache(rootdir=str(stage_cache), memonly=True),
+            call.cache.Cache().update(fetch_progress=mock.ANY, sources_list=None),
+            call.cache.Cache().close(),
+            call.cache.Cache(rootdir=str(stage_cache), memonly=True),
+            call.cache.Cache().close(),
+        ]
+
+    def test_host_cache_setup(self, mocker):
+        fake_apt = mocker.patch("craft_parts.packages.apt_cache.apt")
+
+        with AptCache() as _:
+            pass
+
+        assert fake_apt.mock_calls == [
+            call.cache.Cache(rootdir="/"),
+            call.cache.Cache().close(),
+        ]
+
+
+class TestAptReadonlyHostCache:
+    """Host cache tests."""
+
+    def test_host_is_package_valid(self):
+        with AptCache() as apt_cache:
+            assert apt_cache.is_package_valid("apt")
+            assert apt_cache.is_package_valid("fake-news-bears") is False
+
+    def test_host_get_installed_packages(self):
+        with AptCache() as apt_cache:
+            installed_packages = apt_cache.get_installed_packages()
+            assert isinstance(installed_packages, dict)
+            assert "apt" in installed_packages
+            assert "fake-news-bears" not in installed_packages
+
+    def test_host_get_installed_version(self):
+        with AptCache() as apt_cache:
+            assert isinstance(apt_cache.get_installed_version("apt"), str)
+            assert apt_cache.get_installed_version("fake-news-bears") is None

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.packages import errors
+
+
+def test_package_list_refresh_error():
+    err = errors.PackageListRefreshError("something bad happened")
+    assert err.message == "something bad happened"
+    assert err.brief == ("Failed to refresh package list: something bad happened.")
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_package_fetch_error():
+    err = errors.PackageFetchError("something bad happened")
+    assert err.message == "something bad happened"
+    assert err.brief == ("Failed to fetch package: something bad happened.")
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_package_not_found():
+    err = errors.PackageNotFound("foobar")
+    assert err.package_name == "foobar"
+    assert err.brief == ("Package not found: foobar.")
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_package_broken():
+    err = errors.PackageBroken("foobar", deps=["foo", "bar"])
+    assert err.package_name == "foobar"
+    assert err.deps == ["foo", "bar"]
+    assert err.brief == ("Package 'foobar' has unmet dependencies: foo, bar.")
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Add infrastructure to retrieve packages using apt.

Packages/repo is planned to be moved into a separate project, where
it will be further refactored. Current code follows the snapcraft
implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
