### PR TITLE
utils: add helpers to read os-release entries

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -204,3 +204,39 @@ class InvalidPlugin(PartsError):
         resolution = f"Review part {part_name!r} and make sure it's correct."
 
         super().__init__(brief=brief, resolution=resolution)
+
+
+class OsReleaseIdError(PartsError):
+    """Failed to determine the host operating system identification string."""
+
+    def __init__(self):
+        brief = "Unable to determine the host operating system ID."
+
+        super().__init__(brief=brief)
+
+
+class OsReleaseNameError(PartsError):
+    """Failed to determine the host operating system name."""
+
+    def __init__(self):
+        brief = "Unable to determine the host operating system name."
+
+        super().__init__(brief=brief)
+
+
+class OsReleaseVersionIdError(PartsError):
+    """Failed to determine the host operating system version."""
+
+    def __init__(self):
+        brief = "Unable to determine the host operating system version ID."
+
+        super().__init__(brief=brief)
+
+
+class OsReleaseCodenameError(PartsError):
+    """Failed to determine the host operating system version codename."""
+
+    def __init__(self):
+        brief = "Unable to determine the host operating system codename."
+
+        super().__init__(brief=brief)

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -16,10 +16,13 @@
 
 """Utilities related to the operating system."""
 
+import contextlib
 import os
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
+
+from craft_parts import errors
 
 _WRITE_TIME_INTERVAL = 0.02
 
@@ -43,7 +46,7 @@ class TimedWriter:
         filepath: Path,
         text: str,
         encoding: Optional[str] = None,
-        errors: Optional[str] = None,
+        errors: Optional[str] = None,  # pylint: disable=redefined-outer-name
     ) -> None:
         """Write text to the specified file.
 
@@ -72,3 +75,75 @@ def is_dumb_terminal() -> bool:
     is_stdout_tty = os.isatty(1)
     is_term_dumb = os.environ.get("TERM", "") == "dumb"
     return not is_stdout_tty or is_term_dumb
+
+
+_ID_TO_UBUNTU_CODENAME = {
+    "17.10": "artful",
+    "17.04": "zesty",
+    "16.04": "xenial",
+    "14.04": "trusty",
+}
+
+
+class OsRelease:
+    """A class to intelligently determine the OS on which we're running."""
+
+    def __init__(self, *, os_release_file: str = "/etc/os-release") -> None:
+        """Create a new OsRelease instance.
+
+        :param os_release_file: Path to os-release file to be parsed.
+        """
+        self._os_release: Dict[str, str] = {}
+        with contextlib.suppress(FileNotFoundError):
+            with open(os_release_file) as file:
+                for line in file:
+                    entry = line.rstrip().split("=")
+                    if len(entry) == 2:
+                        self._os_release[entry[0]] = entry[1].strip('"')
+
+    def id(self) -> str:
+        """Return the OS ID.
+
+        :raises OsReleaseIdError: If no ID can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["ID"]
+
+        raise errors.OsReleaseIdError()
+
+    def name(self) -> str:
+        """Return the OS name.
+
+        :raises OsReleaseNameError: If no name can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["NAME"]
+
+        raise errors.OsReleaseNameError()
+
+    def version_id(self) -> str:
+        """Return the OS version ID.
+
+        :raises OsReleaseVersionIdError: If no version ID can be determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["VERSION_ID"]
+
+        raise errors.OsReleaseVersionIdError()
+
+    def version_codename(self) -> str:
+        """Return the OS version codename.
+
+        This first tries to use the VERSION_CODENAME. If that's missing, it
+        tries to use the VERSION_ID to figure out the codename on its own.
+
+        :raises OsReleaseCodenameError: If no version codename can be
+            determined.
+        """
+        with contextlib.suppress(KeyError):
+            return self._os_release["VERSION_CODENAME"]
+
+        with contextlib.suppress(KeyError):
+            return _ID_TO_UBUNTU_CODENAME[self._os_release["VERSION_ID"]]
+
+        raise errors.OsReleaseCodenameError()

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -85,6 +85,9 @@ _ID_TO_UBUNTU_CODENAME = {
 }
 
 
+# TODO: consolidate os-release strategy with craft-providers/charmcraft
+
+
 class OsRelease:
     """A class to intelligently determine the OS on which we're running."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ extension-pkg-whitelist = [
     "pydantic"
 ]
 load-plugins = "pylint_fixme_info"
+good-names = "id"
 
 [tool.black]
 exclude = '/((\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|parts|stage|prime)/|setup.py)'

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -153,3 +153,31 @@ def test_invalid_plugin():
     assert err.brief == "Plugin 'name' in part 'foo' is not registered."
     assert err.details is None
     assert err.resolution == "Review part 'foo' and make sure it's correct."
+
+
+def test_os_release_id_error():
+    err = errors.OsReleaseIdError()
+    assert err.brief == "Unable to determine the host operating system ID."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_os_release_name_error():
+    err = errors.OsReleaseNameError()
+    assert err.brief == "Unable to determine the host operating system name."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_os_release_version_id_error():
+    err = errors.OsReleaseVersionIdError()
+    assert err.brief == "Unable to determine the host operating system version ID."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_os_release_codename_error():
+    err = errors.OsReleaseCodenameError()
+    assert err.brief == "Unable to determine the host operating system codename."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
The `os-release` file contains operating system identification data.
Add helpers to obtain information from this file, raising errors
if data could not be retrieved.

This implementation and accompanying tests are a direct port from
`snapcraft.internal.os_release`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
