### PR TITLE
packages: add snap-related exceptions

### DIFF
--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Exceptions raised by the packages handling subsystem."""
+
+from typing import Sequence
+
+from craft_parts.errors import PartsError
+
+
+class PackagesError(PartsError):
+    """Base class for package handler errors."""
+
+
+class SnapUnavailable(PackagesError):
+    """Failed to install or refresh a snap."""
+
+    def __init__(self, *, snap_name: str, snap_channel: str):
+        self.snap_name = snap_name
+        self.snap_channel = snap_channel
+        brief = f"Failed to install or refresh snap {snap_name!r}."
+        details = (
+            f"{snap_name!r} does not exist or is not available on channel "
+            f"{snap_channel!r}."
+        )
+        resolution = (
+            f"Use `snap info {snap_name}` to get a list of channels the snap "
+            "is available on."
+        )
+
+        super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class SnapInstallError(PackagesError):
+    """Failed to install a snap."""
+
+    def __init__(self, *, snap_name, snap_channel):
+        self.snap_name = snap_name
+        self.snap_channel = snap_channel
+        brief = f"Error installing snap {snap_name!r} from channel {snap_channel!r}."
+
+        super().__init__(brief=brief)
+
+
+class SnapDownloadError(PackagesError):
+    """Failed to download a snap."""
+
+    def __init__(self, *, snap_name, snap_channel):
+        self.snap_name = snap_name
+        self.snap_channel = snap_channel
+        brief = f"Error downloading snap {snap_name!r} from channel {snap_channel!r}."
+
+        super().__init__(brief=brief)
+
+
+class SnapRefreshError(PackagesError):
+    """Failed to refresh a snap."""
+
+    def __init__(self, *, snap_name, snap_channel):
+        self.snap_name = snap_name
+        self.snap_channel = snap_channel
+        brief = f"Error refreshing snap {snap_name!r} to channel {snap_channel!r}."
+
+        super().__init__(brief=brief)
+
+
+class SnapGetAssertionError(PackagesError):
+    """Failed to retrieve snap assertion."""
+
+    def __init__(self, *, assertion_params: Sequence[str]) -> None:
+        self.assertion_params = assertion_params
+        brief = f"Error retrieving assertion with parameters {assertion_params!r}"
+        resolution = "Verify the assertion exists and try again."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class SnapdConnectionError(PackagesError):
+    """Failed to connect to snapd."""
+
+    def __init__(self, *, snap_name: str, url: str) -> None:
+        self.snap_name = snap_name
+        self.url = url
+        brief = (
+            f"Failed to get information for snap {snap_name!r}: could not connect "
+            f"to {url!r}."
+        )
+
+        super().__init__(brief=brief)

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -1,0 +1,85 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.packages import errors
+
+
+def test_snap_unavailable():
+    err = errors.SnapUnavailable(snap_name="word-salad", snap_channel="stable")
+    assert err.snap_name == "word-salad"
+    assert err.snap_channel == "stable"
+    assert err.brief == "Failed to install or refresh snap 'word-salad'."
+    assert err.details == (
+        "'word-salad' does not exist or is not available on channel 'stable'."
+    )
+    assert err.resolution == (
+        "Use `snap info word-salad` to get a list of channels the snap "
+        "is available on."
+    )
+
+
+def test_snap_install_error():
+    err = errors.SnapInstallError(snap_name="word-salad", snap_channel="stable")
+    assert err.snap_name == "word-salad"
+    assert err.snap_channel == "stable"
+    assert err.brief == "Error installing snap 'word-salad' from channel 'stable'."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_snap_download_error():
+    err = errors.SnapDownloadError(snap_name="word-salad", snap_channel="stable")
+    assert err.snap_name == "word-salad"
+    assert err.snap_channel == "stable"
+    assert err.brief == "Error downloading snap 'word-salad' from channel 'stable'."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_snap_refresh_error():
+    err = errors.SnapRefreshError(snap_name="word-salad", snap_channel="stable")
+    assert err.snap_name == "word-salad"
+    assert err.snap_channel == "stable"
+    assert err.brief == "Error refreshing snap 'word-salad' to channel 'stable'."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_snap_get_assertion_error():
+    err = errors.SnapGetAssertionError(
+        assertion_params=["snap-revision=42", "snap-name=foo"]
+    )
+    assert err.assertion_params == ["snap-revision=42", "snap-name=foo"]
+    assert err.brief == (
+        "Error retrieving assertion with parameters ['snap-revision=42', "
+        "'snap-name=foo']"
+    )
+    assert err.details is None
+    assert err.resolution == "Verify the assertion exists and try again."
+
+
+def test_snapd_connection_error():
+    err = errors.SnapdConnectionError(
+        snap_name="word-salad", url="http+unix://%2Frun%2Fsnapd.socket/v2/whatever"
+    )
+    assert err.snap_name == "word-salad"
+    assert err.url == "http+unix://%2Frun%2Fsnapd.socket/v2/whatever"
+    assert err.brief == (
+        "Failed to get information for snap 'word-salad': could not connect "
+        "to 'http+unix://%2Frun%2Fsnapd.socket/v2/whatever'."
+    )
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Add exception classes for snap handling errors. These will be used
in `craft_parts.packages.snaps`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
