### PR TITLE
packages: add deb support

### DIFF
--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -62,6 +62,8 @@ class BaseRepository(abc.ABC):
         should be raised.
         """
 
+    # XXX: list-only functionality can be a separate method called by install_build_packages
+
     @classmethod
     @abc.abstractmethod
     def install_build_packages(

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -62,7 +62,7 @@ class BaseRepository(abc.ABC):
         should be raised.
         """
 
-    # XXX: list-only functionality can be a separate method called by install_build_packages
+    # XXX: list-only functionality can be a method called by install_build_packages
 
     @classmethod
     @abc.abstractmethod

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -64,7 +64,9 @@ class BaseRepository(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def install_build_packages(cls, package_names: List[str]) -> List[str]:
+    def install_build_packages(
+        cls, package_names: List[str], list_only: bool = False
+    ) -> List[str]:
         """Install packages on the host system.
 
         This method needs to be implemented by using the appropriate mechanism
@@ -175,7 +177,9 @@ class DummyRepository(BaseRepository):
         """Refresh the build packages cache."""
 
     @classmethod
-    def install_build_packages(cls, package_names: List[str]) -> List[str]:
+    def install_build_packages(
+        cls, package_names: List[str], list_only: bool = False
+    ) -> List[str]:
         """Install packages on the host system."""
         return []
 

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -1,0 +1,551 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for deb files."""
+
+import fileinput
+import functools
+import logging
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Dict, List, Set, Tuple
+
+from xdg import BaseDirectory  # type: ignore
+
+from craft_parts.utils import file_utils, os_utils
+
+from . import errors
+from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
+from .deb_package import DebPackage
+
+if sys.platform == "linux":
+    # Ensure importing works on non-Linux.
+    from .apt_cache import AptCache
+
+logger = logging.getLogger(__name__)
+
+
+_HASHSUM_MISMATCH_PATTERN = re.compile(r"(E:Failed to fetch.+Hash Sum mismatch)+")
+_DEFAULT_FILTERED_STAGE_PACKAGES: List[str] = [
+    "adduser",
+    "apt",
+    "apt-utils",
+    "base-files",
+    "base-passwd",
+    "bash",
+    "bsdutils",
+    "coreutils",
+    "dash",
+    "debconf",
+    "debconf-i18n",
+    "debianutils",
+    "diffutils",
+    "dmsetup",
+    "dpkg",
+    "e2fslibs",
+    "e2fsprogs",
+    "file",
+    "findutils",
+    "gcc-4.9-base",
+    "gcc-5-base",
+    "gnupg",
+    "gpgv",
+    "grep",
+    "gzip",
+    "hostname",
+    "init",
+    "initscripts",
+    "insserv",
+    "libacl1",
+    "libapparmor1",
+    "libapt",
+    "libapt-inst1.5",
+    "libapt-pkg4.12",
+    "libattr1",
+    "libaudit-common",
+    "libaudit1",
+    "libblkid1",
+    "libbz2-1.0",
+    "libc-bin",
+    "libc6",
+    "libcap2",
+    "libcap2-bin",
+    "libcomerr2",
+    "libcryptsetup4",
+    "libdb5.3",
+    "libdebconfclient0",
+    "libdevmapper1.02.1",
+    "libgcc1",
+    "libgcrypt20",
+    "libgpg-error0",
+    "libgpm2",
+    "libkmod2",
+    "liblocale-gettext-perl",
+    "liblzma5",
+    "libmagic1",
+    "libmount1",
+    "libncurses5",
+    "libncursesw5",
+    "libpam-modules",
+    "libpam-modules-bin",
+    "libpam-runtime",
+    "libpam0g",
+    "libpcre3",
+    "libprocps3",
+    "libreadline6",
+    "libselinux1",
+    "libsemanage-common",
+    "libsemanage1",
+    "libsepol1",
+    "libslang2",
+    "libsmartcols1",
+    "libss2",
+    "libstdc++6",
+    "libsystemd0",
+    "libtext-charwidth-perl",
+    "libtext-iconv-perl",
+    "libtext-wrapi18n-perl",
+    "libtinfo5",
+    "libudev1",
+    "libusb-0.1-4",
+    "libustr-1.0-1",
+    "libuuid1",
+    "locales",
+    "login",
+    "lsb-base",
+    "makedev",
+    "manpages",
+    "manpages-dev",
+    "mawk",
+    "mount",
+    "multiarch-support",
+    "ncurses-base",
+    "ncurses-bin",
+    "passwd",
+    "perl-base",
+    "procps",
+    "readline-common",
+    "sed",
+    "sensible-utils",
+    "systemd",
+    "systemd-sysv",
+    "sysv-rc",
+    "sysvinit-utils",
+    "tar",
+    "tzdata",
+    "ubuntu-keyring",
+    "udev",
+    "util-linux",
+    "zlib1g",
+]
+
+
+IGNORE_FILTERS: Dict[str, Set[str]] = {
+    "core20": {
+        "python3-attr",
+        "python3-blinker",
+        "python3-certifi",
+        "python3-cffi-backend",
+        "python3-chardet",
+        "python3-configobj",
+        "python3-cryptography",
+        # Rely on setuptools installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-distutils"
+        "python3-idna",
+        "python3-importlib-metadata",
+        "python3-jinja2",
+        "python3-json-pointer",
+        "python3-jsonpatch",
+        "python3-jsonschema",
+        "python3-jwt",
+        "python3-lib2to3",
+        "python3-markupsafe",
+        # Provides /usr/bin/python3, don't bring in unless explicitly requested.
+        # "python3-minimal"
+        "python3-more-itertools",
+        "python3-netifaces",
+        "python3-oauthlib",
+        # Rely on version brought in by setuptools, unless explicitly requested.
+        # "python3-pkg-resources"
+        "python3-pyrsistent",
+        "python3-pyudev",
+        "python3-requests",
+        "python3-requests-unixsocket",
+        "python3-serial",
+        # Rely on version installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-setuptools"
+        "python3-six",
+        "python3-urllib3",
+        "python3-urwid",
+        "python3-yaml",
+        "python3-zipp",
+    }
+}
+
+
+@functools.lru_cache(maxsize=256)
+def _run_dpkg_query_search(file_path: str) -> str:
+    try:
+        output = (
+            subprocess.check_output(
+                ["dpkg-query", "-S", os.path.join(os.path.sep, file_path)],
+                stderr=subprocess.STDOUT,
+                env=dict(LANG="C.UTF-8"),
+            )
+            .decode()
+            .strip()
+        )
+    except subprocess.CalledProcessError as call_error:
+        logger.debug("Error finding package for %s: %s", file_path, str(call_error))
+        raise errors.FileProviderNotFound(file_path=file_path) from call_error
+
+    # Remove diversions
+    provides_output = [p for p in output.splitlines() if not p.startswith("diversion")][
+        0
+    ]
+    return provides_output.split(":")[0]
+
+
+@functools.lru_cache(maxsize=256)
+def _run_dpkg_query_list_files(package_name: str) -> Set[str]:
+    output = (
+        subprocess.check_output(["dpkg", "-L", package_name])
+        .decode(sys.getfilesystemencoding())
+        .strip()
+        .split()
+    )
+
+    return {i for i in output if ("lib" in i and os.path.isfile(i))}
+
+
+def _get_dpkg_list_path(base: str) -> pathlib.Path:
+    return pathlib.Path(f"/snap/{base}/current/usr/share/snappy/dpkg.list")
+
+
+def _get_filtered_stage_package_names(
+    *, base: str, package_list: List[DebPackage]
+) -> Set[str]:
+    """Get filtered packages by name only - no version or architectures."""
+    manifest_packages = [p.name for p in get_packages_in_base(base=base)]
+    stage_packages = [p.name for p in package_list]
+
+    return (
+        set(manifest_packages) - set(stage_packages) - IGNORE_FILTERS.get(base, set())
+    )
+
+
+def get_packages_in_base(*, base: str) -> List[DebPackage]:
+    """Get the list of packages for the given base."""
+    # We do not want to break what we already have.
+    if base in ("core", "core16", "core18"):
+        return [DebPackage.from_unparsed(p) for p in _DEFAULT_FILTERED_STAGE_PACKAGES]
+
+    base_package_list_path = _get_dpkg_list_path(base)
+    if not base_package_list_path.exists():
+        return list()
+
+    # Lines we care about in dpkg.list had the following format:
+    # ii adduser 3.118ubuntu1 all add and rem
+    package_list = list()
+    with fileinput.input(str(base_package_list_path)) as file:
+        for line in file:
+            if not str(line).startswith("ii "):
+                continue
+            package = DebPackage.from_unparsed(str(line.split()[1]))
+            package_list.append(package)
+
+    return package_list
+
+
+class Ubuntu(BaseRepository):
+    """Repository management for Ubuntu packages."""
+
+    @classmethod
+    def get_package_libraries(cls, package_name: str) -> Set[str]:
+        """Return a list of libraries in package_name."""
+        return _run_dpkg_query_list_files(package_name)
+
+    @classmethod
+    def get_packages_for_source_type(cls, source_type):
+        """Return a list of packages required to to work with source_type."""
+        if source_type == "bzr":
+            packages = {"bzr"}
+        elif source_type == "git":
+            packages = {"git"}
+        elif source_type == "tar":
+            packages = {"tar"}
+        elif source_type in ["hg", "mercurial"]:
+            packages = {"mercurial"}
+        elif source_type == ["svn", "subversion"]:
+            packages = {"subversion"}
+        elif source_type == "rpm2cpio":
+            packages = {"rpm2cpio"}
+        elif source_type == "7zip":
+            packages = {"p7zip-full"}
+        else:
+            packages = set()
+
+        return packages
+
+    @classmethod
+    def refresh_build_packages_list(cls) -> None:
+        """Refresh the list of packages available in the repository."""
+        try:
+            cmd = ["sudo", "--preserve-env", "apt-get", "update"]
+            logger.debug("Executing: %s", cmd)
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError as call_error:
+            raise errors.PackageListRefreshError(
+                "failed to run apt update"
+            ) from call_error
+
+    @classmethod
+    def _check_if_all_packages_installed(cls, package_names: List[str]) -> bool:
+        """Check if all given packages are installed.
+
+        Will check versions if using <pkg_name>=<pkg_version> syntax parsed by
+        get_pkg_name_parts().  Used as an optimization to skip installation
+        and cache refresh if dependencies are already satisfied.
+
+        :return True if _all_ packages are installed (with correct versions).
+        """
+        with AptCache() as apt_cache:
+            for package in package_names:
+                pkg_name, pkg_version = get_pkg_name_parts(package)
+                installed_version = apt_cache.get_installed_version(
+                    pkg_name, resolve_virtual_packages=True
+                )
+
+                if installed_version is None or (
+                    pkg_version is not None and installed_version != pkg_version
+                ):
+                    return False
+
+        return True
+
+    @classmethod
+    def _get_packages_marked_for_installation(
+        cls, package_names: List[str]
+    ) -> List[Tuple[str, str]]:
+        with AptCache() as apt_cache:
+            try:
+                apt_cache.mark_packages(set(package_names))
+            except errors.PackageNotFound as error:
+                raise errors.BuildPackageNotFound(error.package_name)
+
+            return apt_cache.get_packages_marked_for_installation()
+
+    @classmethod
+    def install_build_packages(
+        cls, package_names: List[str], list_only: bool = False
+    ) -> List[str]:
+        """Install packages on the host system."""
+        if not package_names:
+            return []
+
+        install_required = False
+        package_names = sorted(package_names)
+
+        logger.debug("Requested build-packages: %s", package_names)
+
+        # Ensure we have an up-to-date cache first if we will have to
+        # install anything.
+        if not cls._check_if_all_packages_installed(package_names):
+            install_required = True
+            # refresh the build package list before planning for consistency
+            # cls.refresh_build_packages()
+
+        marked_packages = cls._get_packages_marked_for_installation(package_names)
+        packages = [f"{name}={version}" for name, version in sorted(marked_packages)]
+
+        if not list_only:
+            if install_required:
+                cls._install_packages(packages)
+            else:
+                logger.debug("Requested build-packages already installed: %s", packages)
+
+        return packages
+
+    @classmethod
+    def _install_packages(cls, package_names: List[str]) -> None:
+        logger.info("Installing build dependencies: %s", " ".join(package_names))
+        env = os.environ.copy()
+        env.update(
+            {
+                "DEBIAN_FRONTEND": "noninteractive",
+                "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                "DEBIAN_PRIORITY": "critical",
+            }
+        )
+
+        apt_command = [
+            "sudo",
+            "--preserve-env",
+            "apt-get",
+            "--no-install-recommends",
+            "-y",
+            "--allow-downgrades",
+        ]
+        if not os_utils.is_dumb_terminal():
+            apt_command.extend(["-o", "Dpkg::Progress-Fancy=1"])
+        apt_command.append("install")
+
+        try:
+            subprocess.check_call(apt_command + package_names, env=env)
+        except subprocess.CalledProcessError as err:
+            raise errors.BuildPackagesNotInstalled(packages=package_names) from err
+
+        versionless_names = [get_pkg_name_parts(p)[0] for p in package_names]
+        try:
+            subprocess.check_call(
+                ["sudo", "apt-mark", "auto"] + versionless_names, env=env
+            )
+        except subprocess.CalledProcessError as err:
+            logger.warning("Impossible to mark packages as auto-installed: %s", err)
+
+    @classmethod
+    def fetch_stage_packages(
+        cls,
+        *,
+        application_name: str,
+        package_names: List[str],
+        stage_packages_path: pathlib.Path,
+        base: str,
+        target_arch: str,
+        list_only: bool = False,
+    ) -> List[str]:
+        """Fetch stage packages to stage_packages_path."""
+        logger.debug("Requested stage-packages: %s", sorted(package_names))
+
+        if not package_names:
+            return []
+
+        filtered_names = _get_filtered_stage_package_names(
+            base=base,
+            package_list=[DebPackage.from_unparsed(name) for name in package_names],
+        )
+
+        if not list_only:
+            stage_packages_path.mkdir(exist_ok=True)
+
+        stage_cache_dir, deb_cache_dir = get_cache_dirs(application_name)
+
+        installed: Set[str] = set()
+
+        with AptCache(
+            stage_cache=stage_cache_dir, stage_cache_arch=target_arch
+        ) as apt_cache:
+            apt_cache.mark_packages(set(package_names))
+            apt_cache.unmark_packages(filtered_names)
+
+            if list_only:
+                marked_packages = apt_cache.get_packages_marked_for_installation()
+                installed = {
+                    f"{name}={version}" for name, version in sorted(marked_packages)
+                }
+            else:
+                for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
+                    deb_cache_dir
+                ):
+                    logger.debug("Extracting stage package: %s", pkg_name)
+                    installed.add(f"{pkg_name}={pkg_version}")
+                    file_utils.link_or_copy(
+                        str(dl_path), str(stage_packages_path / dl_path.name)
+                    )
+
+        return sorted(installed)
+
+    @classmethod
+    def refresh_stage_packages_list(cls, *, application_name: str, target_arch: str):
+        """Refresh the list of packages available in the repository."""
+        stage_cache_dir, _ = get_cache_dirs(application_name)
+
+        with AptCache(
+            stage_cache=stage_cache_dir, stage_cache_arch=target_arch
+        ) as apt_cache:
+            apt_cache.update()
+
+    @classmethod
+    def unpack_stage_packages(
+        cls, *, stage_packages_path: pathlib.Path, install_path: pathlib.Path
+    ) -> None:
+        """Unpack stage packages to install_path."""
+        for pkg_path in stage_packages_path.glob("*.deb"):
+            with tempfile.TemporaryDirectory(
+                suffix="deb-extract", dir=install_path.parent
+            ) as extract_dir:
+                # Extract deb package.
+                cls._extract_deb(pkg_path, extract_dir)
+                # Mark source of files.
+                marked_name = cls._extract_deb_name_version(pkg_path)
+                mark_origin_stage_package(extract_dir, marked_name)
+                # Stage files to install_dir.
+                file_utils.link_or_copy_tree(extract_dir, install_path.as_posix())
+        # XXX: normalization of stage packages done by the application
+        # cls.normalize(str(install_path))
+
+    @classmethod
+    def is_package_installed(cls, package_name) -> bool:
+        """Inform if a package is installed on the host system."""
+        with AptCache() as apt_cache:
+            return apt_cache.get_installed_version(package_name) is not None
+
+    @classmethod
+    def get_installed_packages(cls) -> List[str]:
+        """Obtain a list of the installed packages and their versions."""
+        with AptCache() as apt_cache:
+            return [
+                f"{pkg_name}={pkg_version}"
+                for pkg_name, pkg_version in apt_cache.get_installed_packages().items()
+            ]
+
+    @classmethod
+    def _extract_deb_name_version(cls, deb_path: pathlib.Path) -> str:
+        try:
+            output = subprocess.check_output(
+                ["dpkg-deb", "--show", "--showformat=${Package}=${Version}", deb_path]
+            )
+        except subprocess.CalledProcessError as err:
+            raise errors.UnpackError(str(deb_path)) from err
+
+        return output.decode().strip()
+
+    @classmethod
+    def _extract_deb(cls, deb_path: pathlib.Path, extract_dir: str) -> None:
+        """Extract deb and return `<package-name>=<version>`."""
+        try:
+            subprocess.check_call(["dpkg-deb", "--extract", deb_path, extract_dir])
+        except subprocess.CalledProcessError as err:
+            raise errors.UnpackError(str(deb_path)) from err
+
+
+def get_cache_dirs(name: str):
+    """Return the paths to the stage and deb cache directories."""
+    stage_cache_dir = pathlib.Path(
+        BaseDirectory.save_cache_path(name, "craft-parts", "stage-packages")
+    )
+
+    deb_cache_dir = pathlib.Path(
+        BaseDirectory.save_cache_path(name, "craft-parts", "download")
+    )
+
+    return (stage_cache_dir, deb_cache_dir)

--- a/craft_parts/packages/deb_package.py
+++ b/craft_parts/packages/deb_package.py
@@ -1,0 +1,53 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Debian package representation."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DebPackage:
+    """Debian package representation."""
+
+    name: str
+    arch: Optional[str] = None
+    version: Optional[str] = None
+
+    @classmethod
+    def from_unparsed(cls, package: str) -> "DebPackage":
+        """Parse package supported in yaml.
+
+        Package Format: <package-name>[:<arch>][=<version>]
+
+        Examples: "foo", "foo:i386", "foo=1.5", "foo:i386=1.5"
+
+        :param package: Package to parse.
+
+        :return: DebPackage with populated arch & version, if any.
+        """
+        parsed_name: str = package
+        parsed_arch: Optional[str] = None
+        parsed_version: Optional[str] = None
+
+        if "=" in parsed_name:
+            parsed_name, parsed_version = parsed_name.split("=")
+
+        if ":" in parsed_name:
+            parsed_name, parsed_arch = parsed_name.split(":")
+
+        return DebPackage(name=parsed_name, arch=parsed_arch, version=parsed_version)

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -64,3 +64,43 @@ class PackageBroken(PackagesError):
         brief = f"Package {package_name!r} has unmet dependencies: {', '.join(deps)}."
 
         super().__init__(brief=brief)
+
+
+class FileProviderNotFound(PackagesError):
+    """A file is not provided by any package."""
+
+    def __init__(self, *, file_path: str):
+        self.file_path = file_path
+        brief = f"{file_path} is not provided by any package."
+
+        super().__init__(brief=brief)
+
+
+class BuildPackageNotFound(PackagesError):
+    """A package listed in 'build-packages' was not found."""
+
+    def __init__(self, package):
+        self.package = package
+        brief = f"Cannot find package listed in 'build-packages': {package}"
+
+        super().__init__(brief=brief)
+
+
+class BuildPackagesNotInstalled(PackagesError):
+    """Could not install all requested build packages."""
+
+    def __init__(self, *, packages: Sequence[str]) -> None:
+        self.packages = packages
+        brief = f"Cannot install all requested build packages: {', '.join(packages)}"
+
+        super().__init__(brief=brief)
+
+
+class UnpackError(PackagesError):
+    """Error unpacking stage package."""
+
+    def __init__(self, package: str):
+        self.package = package
+        brief = f"Error unpacking {package!r}"
+
+        super().__init__(brief=brief)

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -1,0 +1,580 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import textwrap
+from pathlib import Path
+from subprocess import CalledProcessError
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+
+from craft_parts.packages import deb, errors
+from craft_parts.packages.deb_package import DebPackage
+
+# pylint: disable=line-too-long
+# pylint: disable=missing-class-docstring
+# pylint: disable=unused-argument
+
+
+@pytest.fixture(autouse=True)
+def mock_env_copy():
+    with mock.patch("os.environ.copy", return_value=dict()) as m:
+        yield m
+
+
+@pytest.fixture
+def fake_apt_cache(mocker):
+    def get_installed_version(package_name, resolve_virtual_packages=False):
+        return "1.0" if "installed" in package_name else None
+
+    fake = mocker.patch("craft_parts.packages.deb.AptCache")
+    fake.return_value.__enter__.return_value.get_installed_version.side_effect = (
+        get_installed_version
+    )
+    return fake
+
+
+@pytest.fixture
+def fake_run(mocker):
+    return mocker.patch("subprocess.check_call")
+
+
+@pytest.fixture
+def fake_dumb_terminal(mocker):
+    return mocker.patch(
+        "craft_parts.utils.os_utils.is_dumb_terminal", return_value=True
+    )
+
+
+@pytest.fixture(autouse=True)
+def cache_dirs(mocker, tmpdir):
+    stage_cache_path = Path(tmpdir, "stage-cache")
+    debs_path = Path(tmpdir, "debs")
+    debs_path.mkdir(parents=True, exist_ok=False)
+
+    mocker.patch(
+        "craft_parts.packages.deb.get_cache_dirs",
+        return_value=(stage_cache_path, debs_path),
+    )
+
+    @contextlib.contextmanager
+    def fake_tempdir(*, suffix: str, **kwargs):
+        temp_dir = Path(tmpdir, suffix)
+        temp_dir.mkdir(exist_ok=True, parents=True)
+        yield str(temp_dir)
+
+    mocker.patch(
+        "craft_parts.packages.deb.tempfile.TemporaryDirectory",
+        new=fake_tempdir,
+    )
+
+
+class TestPackages:
+    def test_fetch_stage_packages(self, mocker, tmpdir, fake_apt_cache):
+        mocker.patch(
+            "craft_parts.packages.deb._DEFAULT_FILTERED_STAGE_PACKAGES",
+            {"filtered-pkg-1", "filtered-pkg-2"},
+        )
+
+        stage_cache_path, debs_path = deb.get_cache_dirs("test")
+        fake_package = debs_path / "fake-package_1.0_all.deb"
+        fake_package.touch()
+        fake_apt_cache.return_value.__enter__.return_value.fetch_archives.return_value = [
+            ("fake-package", "1.0", fake_package)
+        ]
+
+        fetched_packages = deb.Ubuntu.fetch_stage_packages(
+            application_name="test",
+            package_names=["fake-package"],
+            stage_packages_path=Path(tmpdir),
+            base="core",
+            target_arch="amd64",
+        )
+
+        fake_apt_cache.assert_has_calls(
+            [
+                call(stage_cache=stage_cache_path, stage_cache_arch="amd64"),
+                call().__enter__(),
+                call().__enter__().mark_packages({"fake-package"}),
+                call()
+                .__enter__()
+                .unmark_packages({"filtered-pkg-1", "filtered-pkg-2"}),
+                call().__enter__().fetch_archives(debs_path),
+            ]
+        )
+
+        assert fetched_packages == ["fake-package=1.0"]
+
+    def test_fetch_virtual_stage_package(self, tmpdir, fake_apt_cache):
+        _, debs_path = deb.get_cache_dirs("test")
+        fake_package = debs_path / "fake-package_1.0_all.deb"
+        fake_package.touch()
+        fake_apt_cache.return_value.__enter__.return_value.fetch_archives.return_value = [
+            ("fake-package", "1.0", fake_package)
+        ]
+
+        fetched_packages = deb.Ubuntu.fetch_stage_packages(
+            application_name="test",
+            package_names=["virtual-fake-package"],
+            stage_packages_path=Path(tmpdir),
+            base="core",
+            target_arch="amd64",
+        )
+
+        assert fetched_packages == ["fake-package=1.0"]
+
+    def test_fetch_stage_package_with_deps(self, tmpdir, fake_apt_cache):
+        _, debs_path = deb.get_cache_dirs("test")
+        fake_package = debs_path / "fake-package_1.0_all.deb"
+        fake_package.touch()
+        fake_package_dep = debs_path / "fake-package-dep_1.0_all.deb"
+        fake_package_dep.touch()
+        fake_apt_cache.return_value.__enter__.return_value.fetch_archives.return_value = [
+            ("fake-package", "1.0", fake_package),
+            ("fake-package-dep", "2.0", fake_package_dep),
+        ]
+
+        fetched_packages = deb.Ubuntu.fetch_stage_packages(
+            application_name="test",
+            package_names=["fake-package"],
+            stage_packages_path=Path(tmpdir),
+            base="core",
+            target_arch="amd64",
+        )
+
+        assert sorted(fetched_packages) == sorted(
+            ["fake-package=1.0", "fake-package-dep=2.0"]
+        )
+
+    def test_fetch_stage_package_empty_list(self, tmpdir, fake_apt_cache):
+        fake_apt_cache.return_value.__enter__.return_value.fetch_archives.return_value = (
+            []
+        )
+
+        fetched_packages = deb.Ubuntu.fetch_stage_packages(
+            application_name="test",
+            package_names=[],
+            stage_packages_path=Path(tmpdir),
+            base="core",
+            target_arch="amd64",
+        )
+
+        assert fetched_packages == []
+
+    def test_get_package_fetch_error(self, tmpdir, fake_apt_cache):
+        fake_apt_cache.return_value.__enter__.return_value.fetch_archives.side_effect = errors.PackageFetchError(
+            "foo"
+        )
+
+        with pytest.raises(errors.PackageFetchError) as raised:
+            deb.Ubuntu.fetch_stage_packages(
+                application_name="test",
+                package_names=["fake-package"],
+                stage_packages_path=Path(tmpdir),
+                base="core",
+                target_arch="amd64",
+            )
+        assert raised.value.message == "foo"
+
+
+class TestBuildPackages:
+    def test_install_build_packages(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package", "1.0"),
+            ("package-installed", "1.0"),
+            ("versioned-package", "2.0"),
+            ("dependency-package", "1.0"),
+        ]
+
+        deb.Ubuntu.refresh_build_packages_list()
+
+        build_packages = deb.Ubuntu.install_build_packages(
+            ["package-installed", "package", "versioned-package=2.0"]
+        )
+
+        assert build_packages == [
+            "dependency-package=1.0",
+            "package=1.0",
+            "package-installed=1.0",
+            "versioned-package=2.0",
+        ]
+        fake_run.assert_has_calls(
+            [
+                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(
+                    [
+                        "sudo",
+                        "--preserve-env",
+                        "apt-get",
+                        "--no-install-recommends",
+                        "-y",
+                        "--allow-downgrades",
+                        "install",
+                        "dependency-package=1.0",
+                        "package=1.0",
+                        "package-installed=1.0",
+                        "versioned-package=2.0",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+                call(
+                    [
+                        "sudo",
+                        "apt-mark",
+                        "auto",
+                        "dependency-package",
+                        "package",
+                        "package-installed",
+                        "versioned-package",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+            ]
+        )
+
+    def test_install_build_packages_empty_list(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = (
+            []
+        )
+
+        build_packages = deb.Ubuntu.install_build_packages([])
+
+        assert build_packages == []
+        fake_run.assert_has_calls([])
+
+    def test_already_installed_no_specified_version(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package-installed", "1.0")
+        ]
+
+        build_packages = deb.Ubuntu.install_build_packages(["package-installed"])
+
+        assert build_packages == ["package-installed=1.0"]
+        fake_run.assert_has_calls([])
+
+    def test_already_installed_with_specified_version(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package-installed", "1.0")
+        ]
+
+        build_packages = deb.Ubuntu.install_build_packages(["package-installed=1.0"])
+
+        assert build_packages == ["package-installed=1.0"]
+        fake_run.assert_has_calls([])
+
+    def test_already_installed_with_different_version(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package-installed", "3.0")
+        ]
+
+        deb.Ubuntu.refresh_build_packages_list()
+
+        build_packages = deb.Ubuntu.install_build_packages(["package-installed=3.0"])
+
+        assert build_packages == ["package-installed=3.0"]
+        fake_run.assert_has_calls(
+            [
+                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(
+                    [
+                        "sudo",
+                        "--preserve-env",
+                        "apt-get",
+                        "--no-install-recommends",
+                        "-y",
+                        "--allow-downgrades",
+                        "install",
+                        "package-installed=3.0",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+                call(
+                    ["sudo", "apt-mark", "auto", "package-installed"],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+            ]
+        )
+
+    def test_install_virtual_build_package(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package", "1.0")
+        ]
+
+        deb.Ubuntu.refresh_build_packages_list()
+
+        build_packages = deb.Ubuntu.install_build_packages(["virtual-package"])
+
+        assert build_packages == ["package=1.0"]
+        fake_run.assert_has_calls(
+            [
+                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(
+                    [
+                        "sudo",
+                        "--preserve-env",
+                        "apt-get",
+                        "--no-install-recommends",
+                        "-y",
+                        "--allow-downgrades",
+                        "install",
+                        "package=1.0",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+                call(
+                    ["sudo", "apt-mark", "auto", "package"],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+            ]
+        )
+
+    def test_smart_terminal(self, fake_apt_cache, fake_run, fake_dumb_terminal):
+        fake_dumb_terminal.return_value = False
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package", "1.0")
+        ]
+
+        deb.Ubuntu.refresh_build_packages_list()
+
+        deb.Ubuntu.install_build_packages(["package"])
+
+        fake_run.assert_has_calls(
+            [
+                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(
+                    [
+                        "sudo",
+                        "--preserve-env",
+                        "apt-get",
+                        "--no-install-recommends",
+                        "-y",
+                        "--allow-downgrades",
+                        "-o",
+                        "Dpkg::Progress-Fancy=1",
+                        "install",
+                        "package=1.0",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+                call(
+                    ["sudo", "apt-mark", "auto", "package"],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+            ]
+        )
+
+    def test_invalid_package_requested(self, fake_apt_cache, fake_run):
+        fake_apt_cache.return_value.__enter__.return_value.mark_packages.side_effect = (
+            errors.PackageNotFound("package-invalid")
+        )
+
+        with pytest.raises(errors.BuildPackageNotFound):
+            deb.Ubuntu.install_build_packages(["package-invalid"])
+
+    def test_broken_package_apt_install(self, fake_apt_cache, fake_run, mocker):
+        fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
+            ("package", "1.0")
+        ]
+        mocker.patch("craft_parts.packages.deb.Ubuntu.refresh_build_packages_list")
+        fake_run.side_effect = CalledProcessError(100, "apt-get")
+
+        with pytest.raises(errors.BuildPackagesNotInstalled) as raised:
+            deb.Ubuntu.install_build_packages(["package=1.0"])
+        assert raised.value.packages == ["package=1.0"]
+
+    def test_refresh_build_packages_list(self, fake_run):
+        deb.Ubuntu.refresh_build_packages_list()
+
+        fake_run.assert_called_once_with(
+            ["sudo", "--preserve-env", "apt-get", "update"]
+        )
+
+    def test_refresh_build_packages_list_fails(self, fake_run):
+        fake_run.side_effect = CalledProcessError(
+            returncode=1, cmd=["sudo", "--preserve-env", "apt-get", "update"]
+        )
+
+        with pytest.raises(errors.PackageListRefreshError):
+            deb.Ubuntu.refresh_build_packages_list()
+
+        fake_run.assert_has_calls(
+            [call(["sudo", "--preserve-env", "apt-get", "update"])]
+        )
+
+
+@pytest.fixture
+def fake_dpkg_query(mocker):
+    def dpkg_query(*args, **kwargs):
+        # dpkg-query -S file_path
+        if args[0][2] == "/bin/bash":
+            return "bash: /bin/bash\n".encode()
+
+        if args[0][2] == "/bin/sh":
+            return (
+                "diversion by dash from: /bin/sh\n"
+                "diversion by dash to: /bin/sh.distrib\n"
+                "dash: /bin/sh\n"
+            ).encode()
+
+        raise CalledProcessError(
+            1,
+            "dpkg-query: no path found matching pattern {}".format(args[0][2]),
+        )
+
+    mocker.patch("subprocess.check_output", side_effect=dpkg_query)
+
+
+class TestGetPackagesInBase:
+    def test_hardcoded_bases(self):
+        for base in ("core", "core16", "core18"):
+            packages = [
+                DebPackage.from_unparsed(p)
+                for p in deb._DEFAULT_FILTERED_STAGE_PACKAGES
+            ]
+            assert deb.get_packages_in_base(base=base) == packages
+
+    def test_package_list_from_dpkg_list(self, tmpdir, mocker):
+        dpkg_list_path = Path(tmpdir, "dpkg.list")
+        mocker.patch(
+            "craft_parts.packages.deb._get_dpkg_list_path", return_value=dpkg_list_path
+        )
+        with dpkg_list_path.open("w") as dpkg_list_file:
+            print(
+                textwrap.dedent(
+                    """\
+            Desired=Unknown/Install/Remove/Purge/Hold
+            | Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+            |/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+            ||/ Name                          Version                    Architecture Description
+            +++-=============================-==========================-============-===========
+            ii  adduser                       3.118ubuntu1               all          add and rem
+            ii  apparmor                      2.13.3-7ubuntu2            amd64        user-space
+            ii  apt                           2.0.1                      amd64        commandline
+            ii  base-files                    11ubuntu4                  amd64        Debian base
+            ii  base-passwd                   3.5.47                     amd64        Debian base
+            ii  zlib1g:amd64                  1:1.2.11.dfsg-2ubuntu1     amd64        compression
+            """
+                ),
+                file=dpkg_list_file,
+            )
+
+        assert deb.get_packages_in_base(base="core20") == [
+            DebPackage("adduser"),
+            DebPackage("apparmor"),
+            DebPackage("apt"),
+            DebPackage("base-files"),
+            DebPackage("base-passwd"),
+            DebPackage("zlib1g", arch="amd64"),
+        ]
+
+    def test_package_empty_list_from_missing_dpkg_list(self, tmpdir, mocker):
+        dpkg_list_path = Path(tmpdir, "dpkg.list")
+        mocker.patch(
+            "craft_parts.packages.deb._get_dpkg_list_path", return_value=dpkg_list_path
+        )
+
+        assert deb.get_packages_in_base(base="core22") == list()
+
+
+def test_get_filtered_stage_package_restricts_core20_ignore_filter(mocker):
+    mock_get_packages_in_base = mocker.patch.object(deb, "get_packages_in_base")
+    mock_get_packages_in_base.return_value = [
+        DebPackage(name="foo"),
+        DebPackage(name="foo2"),
+        DebPackage(name="python3-attr"),
+        DebPackage(name="python3-blinker"),
+        DebPackage(name="python3-certifi"),
+        DebPackage(name="python3-cffi-backend"),
+        DebPackage(name="python3-chardet"),
+        DebPackage(name="python3-configobj"),
+        DebPackage(name="python3-cryptography"),
+        DebPackage(name="python3-idna"),
+        DebPackage(name="python3-importlib-metadata"),
+        DebPackage(name="python3-jinja2"),
+        DebPackage(name="python3-json-pointer"),
+        DebPackage(name="python3-jsonpatch"),
+        DebPackage(name="python3-jsonschema"),
+        DebPackage(name="python3-jwt"),
+        DebPackage(name="python3-lib2to3"),
+        DebPackage(name="python3-markupsafe"),
+        DebPackage(name="python3-more-itertools"),
+        DebPackage(name="python3-netifaces"),
+        DebPackage(name="python3-oauthlib"),
+        DebPackage(name="python3-pyrsistent"),
+        DebPackage(name="python3-pyudev"),
+        DebPackage(name="python3-requests"),
+        DebPackage(name="python3-requests-unixsocket"),
+        DebPackage(name="python3-serial"),
+        DebPackage(name="python3-six"),
+        DebPackage(name="python3-urllib3"),
+        DebPackage(name="python3-urwid"),
+        DebPackage(name="python3-yaml"),
+        DebPackage(name="python3-zipp"),
+    ]
+
+    filtered_names = deb._get_filtered_stage_package_names(
+        base="core20", package_list=[]
+    )
+
+    assert filtered_names == {"foo", "foo2"}
+
+
+def test_get_filtered_stage_package_empty_ignore_filter(mocker):
+    mock_get_packages_in_base = mocker.patch.object(deb, "get_packages_in_base")
+    mock_get_packages_in_base.return_value = [
+        DebPackage(name="some-base-pkg"),
+        DebPackage(name="some-other-base-pkg"),
+    ]
+
+    filtered_names = deb._get_filtered_stage_package_names(
+        base="core00", package_list=[]
+    )
+
+    assert filtered_names == {"some-base-pkg", "some-other-base-pkg"}

--- a/tests/unit/packages/test_deb_package.py
+++ b/tests/unit/packages/test_deb_package.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.packages.deb_package import DebPackage
+
+
+def test_basic():
+    package = DebPackage(name="foo", arch="arch", version="1.0")
+
+    assert package.name == "foo"
+    assert package.arch == "arch"
+    assert package.version == "1.0"
+
+
+def test_parse_simple():
+    assert DebPackage.from_unparsed("foo") == DebPackage(
+        name="foo", arch=None, version=None
+    )
+
+
+def test_parse_arch():
+    assert DebPackage.from_unparsed("foo:arch") == DebPackage(
+        name="foo", arch="arch", version=None
+    )
+
+
+def test_parse_arch_and_version():
+    assert DebPackage.from_unparsed("foo:arch=4.5") == DebPackage(
+        name="foo", arch="arch", version="4.5"
+    )
+
+
+def test_parse_version():
+    assert DebPackage.from_unparsed("foo=4.5") == DebPackage(
+        name="foo", arch=None, version="4.5"
+    )

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -48,3 +48,35 @@ def test_package_broken():
     assert err.brief == ("Package 'foobar' has unmet dependencies: foo, bar.")
     assert err.details is None
     assert err.resolution is None
+
+
+def test_file_provider_not_found():
+    err = errors.FileProviderNotFound(file_path="/some/path")
+    assert err.file_path == "/some/path"
+    assert err.brief == "/some/path is not provided by any package."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_build_package_not_found():
+    err = errors.BuildPackageNotFound("foobar")
+    assert err.package == "foobar"
+    assert err.brief == "Cannot find package listed in 'build-packages': foobar"
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_build_packages_not_installed():
+    err = errors.BuildPackagesNotInstalled(packages=["foo", "bar"])
+    assert err.packages == ["foo", "bar"]
+    assert err.brief == "Cannot install all requested build packages: foo, bar"
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_unpack_error():
+    err = errors.UnpackError("foobar")
+    assert err.package == "foobar"
+    assert err.brief == "Error unpacking 'foobar'"
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
The Ubuntu deb repository support adds the mechanism to refresh
package lists, fetch and unpack stage packages, and install build
packages.

Packages/repo is planned to be moved into a separate project, where
it will be further refactored. Current code follows the snapcraft
implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
