### PR TITLE
packages: add snap package support

### DIFF
--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -1,0 +1,393 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to install snap packages."""
+
+import contextlib
+import logging
+import os
+import sys
+from subprocess import CalledProcessError, check_call, check_output
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from urllib import parse
+
+import requests_unixsocket  # type: ignore
+from requests import exceptions
+
+from . import errors
+
+# pylint: disable=line-too-long
+_STORE_ASSERTION = [
+    "account-key",
+    "public-key-sha3-384=BWDEoaqyr25nF5SNCvEv2v7QnM9QsfCc0PBMYD_i2NGSQ32EF2d4D0hqUel3m8ul",
+]
+# pylint: enable=line-too-long
+
+_CHANNEL_RISKS = ["stable", "candidate", "beta", "edge"]
+logger = logging.getLogger(__name__)
+
+
+# TODO https://bugs.launchpad.net/snapcraft/+bug/1786868
+
+
+class SnapPackage:
+    """SnapPackage acts as a mediator to install or refresh a snap.
+
+    It uses information provided by snapd implicitly referring to the local
+    and remote stores to obtain information about the snap, such as its
+    confinement value and channel availability.
+
+    This information can also be used to determine if a snap should be
+    installed or refreshed.
+
+    There are risks of the data falling out of date between the query and the
+    requested action given that it is not possible to hold a global lock on
+    snapd and the store data can change in between validation and execution.
+    """
+
+    @classmethod
+    def is_valid_snap(cls, snap: str) -> bool:
+        """Verify whether the given snap is valid."""
+        return cls(snap).is_valid()
+
+    @classmethod
+    def is_snap_installed(cls, snap: str) -> bool:
+        """Verify whether the given snap is installed."""
+        # Snaps are not currently supported on Windows
+        if sys.platform == "win32":
+            return False
+        return cls(snap).installed
+
+    def __init__(self, snap: str):
+        """Lifecycle handler for a snap of the format <snap-name>/<channel>."""
+        self.name, self.channel = _get_parsed_snap(snap)
+        self._original_channel = self.channel
+        if not self.channel or self.channel == "stable":
+            self.channel = "latest/stable"
+
+        # This store information from a local request
+        self._local_snap_info = None
+        # And this stores information from a remote request
+        self._store_snap_info = None
+
+        self._is_installed: Optional[bool] = None
+        self._is_in_store: Optional[bool] = None
+
+    @property
+    def installed(self) -> bool:
+        """Whether this snap is currently installed on the system."""
+        if self._is_installed is None:
+            self._is_installed = self.get_local_snap_info() is not None
+        return self._is_installed
+
+    @property
+    def in_store(self) -> bool:
+        """Whether this snap is available in the store."""
+        if self._is_in_store is None:
+            try:
+                self._is_in_store = self.get_store_snap_info() is not None
+            except errors.SnapUnavailable:
+                self._is_in_store = False
+        return self._is_in_store
+
+    def get_local_snap_info(self):
+        """Return a local payload for the snap.
+
+        Validity of the results are determined by checking self.installed.
+        """
+        if self._is_installed is None:
+            with contextlib.suppress(exceptions.HTTPError):
+                self._local_snap_info = _get_local_snap_info(self.name)
+        return self._local_snap_info
+
+    def get_store_snap_info(self):
+        """Return a store payload for the snap."""
+        if self._is_in_store is None:
+            # Some environments timeout often, like the armv7 testing
+            # infrastructure. Given that constraint, we add some retry
+            # logic.
+            retry_count = 5
+            while retry_count > 0:
+                try:
+                    self._store_snap_info = _get_store_snap_info(self.name)
+                    break
+                except exceptions.HTTPError as http_error:
+                    logger.debug(
+                        "The http error when checking the store for %s is %d "
+                        "(retries left %d)",
+                        self.name,
+                        http_error.response.status_code,
+                        retry_count,
+                    )
+                    if http_error.response.status_code == 404:
+                        raise errors.SnapUnavailable(
+                            snap_name=self.name, snap_channel=self.channel
+                        )
+                    retry_count -= 1
+
+        return self._store_snap_info
+
+    def _get_store_channels(self) -> Dict[str, Any]:
+        snap_store_info = self.get_store_snap_info()
+        if not self.in_store:
+            return dict()
+
+        return snap_store_info["channels"]
+
+    def get_current_channel(self) -> str:
+        """Obtain the current channel for this snap."""
+        current_channel = ""
+        if self.installed:
+            local_snap_info = self.get_local_snap_info()
+            current_channel = local_snap_info["channel"]
+            if any(current_channel.startswith(risk) for risk in _CHANNEL_RISKS):
+                current_channel = "latest/{}".format(current_channel)
+        return current_channel
+
+    def has_assertions(self) -> bool:
+        """Verify whether this snap has assertions."""
+        # A revision starting with x has been installed with
+        # --dangerous.
+        return not self.get_local_snap_info()["revision"].startswith("x")
+
+    def is_classic(self) -> bool:
+        """Verify whether this snap is a classic snap."""
+        store_channels = self._get_store_channels()
+        try:
+            return store_channels[self.channel]["confinement"] == "classic"
+        except KeyError:
+            # We have seen some KeyError issues when running tests that are
+            # hard to debug as they only occur there, logging in debug mode
+            # will help uncover the root cause if it happens again.
+            logger.debug(
+                "Current store channels are %s and the store payload is %s",
+                store_channels,
+                self._store_snap_info,
+            )
+            raise
+
+    def is_valid(self) -> bool:
+        """Check if the snap is valid."""
+        if self.installed and self.get_local_snap_info()["channel"] == self.channel:
+            return True
+        if not self.in_store:
+            return False
+        store_channels = self._get_store_channels()
+        return self.channel in store_channels.keys()
+
+    def download(self, *, directory: str = None):
+        """Download a given snap."""
+        # We use the `snap download` command here on recommendation
+        # of the snapd team.
+        snap_download_cmd = ["snap", "download", self.name]
+        if self._original_channel:
+            snap_download_cmd.extend(["--channel", self._original_channel])
+        try:
+            check_output(snap_download_cmd, cwd=directory)
+        except CalledProcessError as err:
+            raise errors.SnapDownloadError(
+                snap_name=self.name, snap_channel=self.channel
+            ) from err
+
+    def install(self):
+        """Installs the snap onto the system."""
+        snap_install_cmd = []
+        if _snap_command_requires_sudo():
+            snap_install_cmd = ["sudo"]
+        snap_install_cmd.extend(["snap", "install", self.name])
+        if self._original_channel:
+            snap_install_cmd.extend(["--channel", self._original_channel])
+        try:
+            if self.is_classic():
+                # TODO make this a user explicit choice
+                snap_install_cmd.append("--classic")
+        except (errors.SnapUnavailable, KeyError):
+            pass
+
+        try:
+            check_call(snap_install_cmd)
+        except CalledProcessError as err:
+            raise errors.SnapInstallError(
+                snap_name=self.name, snap_channel=self.channel
+            ) from err
+
+        # Now that the snap is installed, invalidate the data we had on it.
+        self._is_installed = None
+
+    def refresh(self):
+        """Refresh a snap onto a channel on the system."""
+        snap_refresh_cmd = []
+        if _snap_command_requires_sudo():
+            snap_refresh_cmd = ["sudo"]
+        snap_refresh_cmd.extend(
+            ["snap", "refresh", self.name, "--channel", self.channel]
+        )
+        try:
+            if self.is_classic():
+                # TODO make this a user explicit choice
+                snap_refresh_cmd.append("--classic")
+        except (errors.SnapUnavailable, KeyError):
+            pass
+
+        try:
+            check_call(snap_refresh_cmd)
+        except CalledProcessError as err:
+            raise errors.SnapRefreshError(
+                snap_name=self.name, snap_channel=self.channel
+            ) from err
+
+        # Now that the snap is refreshed, invalidate the data we had on it.
+        self._is_installed = None
+
+
+def download_snaps(*, snaps_list: Sequence[str], directory: str) -> None:
+    """Download snaps of the format <snap-name>/<channel> into directory.
+
+    The target directory is created if it does not exist.
+    """
+    # TODO manifest.yaml with snap revision from future machine output
+    # for `snap download`.
+    os.makedirs(directory, exist_ok=True)
+    for snap in snaps_list:
+        snap_pkg = SnapPackage(snap)
+
+        # TODO: use dependency injected echoer
+        logger.info("Downloading snap %s", snap_pkg.name)
+        snap_pkg.download(directory=directory)
+
+
+def install_snaps(snaps_list: Union[Sequence[str], Set[str]]) -> List[str]:
+    """Install snaps of the format <snap-name>/<channel>.
+
+    :return: a list of "name=revision" for the snaps installed.
+    """
+    snaps_installed = []
+    for snap in snaps_list:
+        snap_pkg = SnapPackage(snap)
+
+        # Allow bases to be installed from non stable channels.
+        snap_pkg_channel = snap_pkg.get_store_snap_info()["channel"]
+        snap_pkg_type = snap_pkg.get_store_snap_info()["type"]
+        if snap_pkg_channel != "stable" and snap_pkg_type == "base":
+            snap_pkg = SnapPackage(
+                "{snap_name}/latest/{channel}".format(
+                    snap_name=snap_pkg.name, channel=snap_pkg_channel
+                )
+            )
+
+        if not snap_pkg.installed:
+            snap_pkg.install()
+        elif snap_pkg.get_current_channel() != snap_pkg.channel:
+            snap_pkg.refresh()
+
+        snaps_installed.append(
+            "{}={}".format(snap_pkg.name, snap_pkg.get_local_snap_info()["revision"])
+        )
+    return snaps_installed
+
+
+def _snap_command_requires_sudo():
+    # snap whoami returns - if the user is not logged in.
+    output = check_output(["snap", "whoami"])
+    whoami = output.decode(sys.getfilesystemencoding())
+    requires_root = False
+    try:
+        requires_root = whoami.split(":")[1].strip() == "-"
+    # A safeguard if the output changes
+    except IndexError:
+        requires_root = True
+    if requires_root:
+        logger.warning("snapd is not logged in, snap install commands will use sudo")
+    return requires_root
+
+
+def get_assertion(assertion_params: Sequence[str]) -> bytes:
+    """Get assertion information.
+
+    :param assertion_params: a sequence of strings to pass to 'snap known'.
+    :returns: a stream of bytes from the assertion.
+    :rtype: bytes
+    """
+    try:
+        return check_output(["snap", "known", *assertion_params])
+    except CalledProcessError as call_error:
+        raise errors.SnapGetAssertionError(
+            assertion_params=assertion_params
+        ) from call_error
+
+
+def _get_parsed_snap(snap: str) -> Tuple[str, str]:
+    if "/" in snap:
+        sep_index = snap.find("/")
+        snap_name = snap[:sep_index]
+        snap_channel = snap[sep_index + 1 :]
+    else:
+        snap_name = snap
+        snap_channel = ""
+    return snap_name, snap_channel
+
+
+def get_snapd_socket_path_template():
+    """Return the template for the snapd socket URI."""
+    return "http+unix://%2Frun%2Fsnapd.socket/v2/{}"
+
+
+def _get_local_snap_file_iter(snap_name: str, *, chunk_size: int):
+    slug = "snaps/{}/file".format(parse.quote(snap_name, safe=""))
+    url = get_snapd_socket_path_template().format(slug)
+    try:
+        snap_file = requests_unixsocket.get(url)
+    except exceptions.ConnectionError as err:
+        raise errors.SnapdConnectionError(snap_name=snap_name, url=url) from err
+    snap_file.raise_for_status()
+    return snap_file.iter_content(chunk_size)
+
+
+def _get_local_snap_info(snap_name: str):
+    slug = "snaps/{}".format(parse.quote(snap_name, safe=""))
+    url = get_snapd_socket_path_template().format(slug)
+    try:
+        snap_info = requests_unixsocket.get(url)
+    except exceptions.ConnectionError as err:
+        raise errors.SnapdConnectionError(snap_name=snap_name, url=url) from err
+    snap_info.raise_for_status()
+    return snap_info.json()["result"]
+
+
+def _get_store_snap_info(snap_name: str) -> Dict[str, Any]:
+    # This logic uses /v2/find returns an array of results, given that
+    # we do a strict search either 1 result or a 404 will be returned.
+    slug = "find?{}".format(parse.urlencode(dict(name=snap_name)))
+    url = get_snapd_socket_path_template().format(slug)
+    snap_info = requests_unixsocket.get(url)
+    snap_info.raise_for_status()
+    return snap_info.json()["result"][0]
+
+
+def get_installed_snaps() -> List[str]:
+    """Return all the snaps installed in the system.
+
+    :return: a list of "name=revision" for the snaps installed.
+    """
+    slug = "snaps"
+    url = get_snapd_socket_path_template().format(slug)
+    try:
+        snap_info = requests_unixsocket.get(url)
+        snap_info.raise_for_status()
+        local_snaps = snap_info.json()["result"]
+    except exceptions.ConnectionError:
+        local_snaps = []
+    return ["{}={}".format(snap["name"], snap["revision"]) for snap in local_snaps]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==1.8.1
 pydantic-yaml==0.2.3
 pyxdg==0.27
 requests==2.25.1
+requests-unixsocket==0.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ import pytest
 import xdg  # type: ignore
 
 from . import fake_servers
+from .fake_snap_command import FakeSnapCommand
 from .fake_snapd import FakeSnapd
 
 
@@ -110,3 +111,9 @@ def fake_snapd():
 
     server.stop_fake_server(thread)
     socket_path_patcher.stop()
+
+
+@pytest.fixture
+def fake_snap_command(mocker):
+    """Mock the snap command."""
+    return FakeSnapCommand(mocker)

--- a/tests/fake_snap_command.py
+++ b/tests/fake_snap_command.py
@@ -1,0 +1,107 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2018-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import subprocess
+from typing import List, Tuple
+
+import craft_parts.packages.snaps
+
+# pylint: disable=too-few-public-methods
+# pylint: disable=unused-argument
+
+
+class FakeSnapCommand:
+    """Mock the snap command."""
+
+    def __init__(self, mocker):
+        self.calls = []
+        self.install_success = True
+        self.refresh_success = True
+        self.download_side_effect = None
+        self.fake_download = None
+        self._email = "-"
+
+        original_check_call = craft_parts.packages.snaps.check_call
+        original_check_output = craft_parts.packages.snaps.check_output
+
+        def side_effect_check_call(cmd, *args, **kwargs):
+            return side_effect(original_check_call, cmd, *args, **kwargs)
+
+        def side_effect_check_output(cmd, *args, **kwargs):
+            if self._is_snap_command(cmd):
+                self.calls.append(cmd)
+                return self._fake_snap_command(cmd, *args, **kwargs)
+
+            return side_effect(original_check_output, cmd, *args, **kwargs)
+
+        def side_effect(original, cmd, *args, **kwargs):
+            if self._is_snap_command(cmd):
+                self.calls.append(cmd)
+                return self._fake_snap_command(cmd, *args, **kwargs)
+
+            return original(cmd, *args, **kwargs)
+
+        mocker.patch("craft_parts.packages.snaps.check_call", side_effect_check_call)
+        mocker.patch(
+            "craft_parts.packages.snaps.check_output", side_effect_check_output
+        )
+
+    def login(self, email):
+        self._email = email
+
+    def _get_snap_cmd(self, cmd) -> Tuple[str, List[str]]:
+        try:
+            snap_cmd_index = cmd.index("snap")
+        except ValueError:
+            return "", []
+
+        try:
+            return cmd[snap_cmd_index + 1], cmd[snap_cmd_index + 2 :]
+        except IndexError:
+            return "", []
+
+    def _is_snap_command(self, cmd):
+        snap_cmd, _ = self._get_snap_cmd(cmd)
+        return snap_cmd in ["install", "refresh", "whoami", "download"]
+
+    def _fake_snap_command(self, cmd, *args, **kwargs):
+        cmd, params = self._get_snap_cmd(cmd)
+
+        if cmd == "install" and not self.install_success:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+        if cmd == "refresh" and not self.refresh_success:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+        if cmd == "whoami":
+            return "email: {}".format(self._email).encode()
+
+        if (
+            cmd == "download"
+            and self.download_side_effect is not None
+            and not self.download_side_effect.pop(0)
+        ):
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+        if cmd == "download":
+            if self.fake_download:
+                dest = os.path.join(kwargs["cwd"], params[0] + ".snap")
+                shutil.copyfile(self.fake_download, dest)
+            return "Downloaded  ".encode()
+
+        return None

--- a/tests/unit/packages/test_snaps.py
+++ b/tests/unit/packages/test_snaps.py
@@ -1,0 +1,564 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.packages import errors, snaps
+
+# pylint: disable=missing-class-docstring
+
+
+class TestSnapPackageCurrentChannel:
+    def assert_channels(self, *, snap, installed_snaps, expected, fake_snapd):
+        fake_snapd.snaps_result = installed_snaps
+        snap_pkg = snaps.SnapPackage(snap)
+        assert snap_pkg.get_current_channel() == expected
+
+    def test_risk(self, fake_snapd):
+        self.assert_channels(
+            snap="fake-snap-stable/stable",
+            installed_snaps=[{"name": "fake-snap-stable", "channel": "stable"}],
+            expected="latest/stable",
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk(self, fake_snapd):
+        self.assert_channels(
+            snap="fake-snap-stable/latest/stable",
+            installed_snaps=[{"name": "fake-snap-stable", "channel": "stable"}],
+            expected="latest/stable",
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk_branch(self, fake_snapd):
+        self.assert_channels(
+            snap="fake-snap-branch/candidate/branch",
+            installed_snaps=[
+                {"name": "fake-snap-branch", "channel": "candidate/branch"}
+            ],
+            expected="latest/candidate/branch",
+            fake_snapd=fake_snapd,
+        )
+
+
+class TestPackageIsInstalled:
+    def assert_installed(self, snap, installed_snaps, expected, fake_snapd):
+        fake_snapd.snaps_result = installed_snaps
+        snap_pkg = snaps.SnapPackage(snap)
+        assert snap_pkg.installed is expected
+        assert snaps.SnapPackage.is_snap_installed(snap) is expected
+
+    def test_default(self, fake_snapd):
+        self.assert_installed(
+            snap="fake-snap-stable",
+            installed_snaps=[{"name": "fake-snap-stable", "channel": "stable"}],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk(self, fake_snapd):
+        self.assert_installed(
+            snap="fake-snap-stable/latest/stable",
+            installed_snaps=[{"name": "fake-snap-stable", "channel": "stable"}],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_default_not_installed(self, fake_snapd):
+        self.assert_installed(
+            snap="missing-snap",
+            installed_snaps=[],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk_not_installed(self, fake_snapd):
+        self.assert_installed(
+            snap="missing-snap/latest/stable",
+            installed_snaps=[],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+
+class TestPackageIsInStore:
+    def assert_in_store(self, snap, find_result, expected, fake_snapd):
+        fake_snapd.find_result = find_result
+        snap_pkg = snaps.SnapPackage(snap)
+        assert snap_pkg.in_store is expected
+
+    def test_default(self, fake_snapd):
+        self.assert_in_store(
+            snap="fake-snap",
+            find_result=[{"fake-snap": "dummy"}],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk(self, fake_snapd):
+        self.assert_in_store(
+            snap="fake-snap/latest/stable",
+            find_result=[{"fake-snap": "dummy"}],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_default_not_in_store(self, fake_snapd):
+        self.assert_in_store(
+            snap="missing-snap", find_result=[], expected=False, fake_snapd=fake_snapd
+        )
+
+    def test_track_risk_not_in_store(self, fake_snapd):
+        self.assert_in_store(
+            snap="missing-snap/latest/stable",
+            find_result=[],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+
+class TestSnapPackageIsClassic:
+    def assert_classic(self, snap, find_result, expected, fake_snapd):
+        fake_snapd.find_result = find_result
+        snap_pkg = snaps.SnapPackage(snap)
+        assert snap_pkg.is_classic() is expected
+
+    def test_classic(self, fake_snapd):
+        self.assert_classic(
+            snap="fake-snap/classic/stable",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"classic/stable": {"confinement": "classic"}}
+                    }
+                }
+            ],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_strict(self, fake_snapd):
+        self.assert_classic(
+            snap="fake-snap/strict/stable",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"strict/stable": {"confinement": "strict"}}
+                    }
+                }
+            ],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_devmode(self, fake_snapd):
+        self.assert_classic(
+            snap="fake-snap/devmode/stable",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"devmode/stable": {"confinement": "devmode"}}
+                    }
+                }
+            ],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+
+class TestSnapPackageIsValid:
+    def assert_valid(self, snap, find_result, expected, fake_snapd):
+        fake_snapd.find_result = find_result
+        snap_pkg = snaps.SnapPackage(snap)
+        assert snap_pkg.is_valid() is expected
+        assert snaps.SnapPackage.is_valid_snap(snap) is expected
+
+    def test_default(self, fake_snapd):
+        self.assert_valid(
+            snap="fake-snap",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"latest/stable": {"confinement": "strict"}}
+                    }
+                }
+            ],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_track_risk(self, fake_snapd):
+        self.assert_valid(
+            snap="fake-snap/strict/stable",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"strict/stable": {"confinement": "strict"}}
+                    }
+                }
+            ],
+            expected=True,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_invalid_track(self, fake_snapd):
+        self.assert_valid(
+            snap="fake-snap/non-existent/edge",
+            find_result=[
+                {
+                    "fake-snap": {
+                        "channels": {"strict/stable": {"confinement": "strict"}}
+                    }
+                }
+            ],
+            expected=False,
+            fake_snapd=fake_snapd,
+        )
+
+    def test_missing_snap(self, fake_snapd):
+        self.assert_valid(
+            snap="missing-snap", find_result=[], expected=False, fake_snapd=fake_snapd
+        )
+
+    def test_installed(self):
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
+        snap_pkg.get_local_snap_info = lambda: {"channel": "strict/stable/branch"}
+        assert snap_pkg.is_valid()
+
+    def test_404(self, fake_snapd):
+        fake_snapd.find_code = 404
+        self.assert_valid(
+            snap="missing-snap", find_result=[], expected=False, fake_snapd=fake_snapd
+        )
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestSnapPackageLifecycle:
+    def test_install_classic(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"classic/stable": {"confinement": "classic"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
+        snap_pkg.install()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "install",
+                "fake-snap",
+                "--channel",
+                "classic/stable",
+                "--classic",
+            ],
+        ]
+
+    def test_install_non_classic(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/stable": {"confinement": "strict"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        snap_pkg.install()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "install",
+                "fake-snap",
+                "--channel",
+                "strict/stable",
+            ],
+        ]
+
+    def test_install_classic_not_on_channel(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [{"fake-snap": {"channels": {}}}]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
+        snap_pkg.install()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "install",
+                "fake-snap",
+                "--channel",
+                "classic/stable",
+            ],
+        ]
+
+    def test_install_branch(self, fake_snap_command):
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
+        snap_pkg.install()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "install",
+                "fake-snap",
+                "--channel",
+                "strict/stable/branch",
+            ],
+        ]
+
+    def test_install_logged_in(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/stable": {"confinement": "strict"}}}}
+        ]
+
+        fake_snap_command.login("user@email.com")
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        snap_pkg.install()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            ["snap", "install", "fake-snap", "--channel", "strict/stable"],
+        ]
+
+    def test_install_fails(self, fake_snapd, fake_snap_command):
+        fake_snap_command.install_success = False
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        with pytest.raises(errors.SnapInstallError):
+            snap_pkg.install()
+
+    def test_refresh(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/stable": {"confinement": "strict"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        snap_pkg.refresh()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "refresh",
+                "fake-snap",
+                "--channel",
+                "strict/stable",
+            ],
+        ]
+
+    def test_refresh_branch(self, fake_snap_command):
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
+        snap_pkg.refresh()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "refresh",
+                "fake-snap",
+                "--channel",
+                "strict/stable/branch",
+            ],
+        ]
+
+    def test_download(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/stable": {"confinement": "strict"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap")
+        snap_pkg.download()
+        assert fake_snap_command.calls == [["snap", "download", "fake-snap"]]
+
+    def test_download_channel(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/edge": {"confinement": "strict"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        snap_pkg.download()
+        assert fake_snap_command.calls == [
+            ["snap", "download", "fake-snap", "--channel", "strict/stable"]
+        ]
+
+    def test_download_classic(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"classic/stable": {"confinement": "classic"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap")
+        snap_pkg.download()
+        assert fake_snap_command.calls == [["snap", "download", "fake-snap"]]
+
+    def test_download_snaps(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"latest/stable": {"confinement": "strict"}}}},
+            {
+                "other-fake-snap": {
+                    "channels": {"latest/stable": {"confinement": "strict"}}
+                }
+            },
+        ]
+
+        snaps.download_snaps(
+            snaps_list=["fake-snap", "other-fake-snap/latest/stable"],
+            directory="fakedir",
+        )
+        assert fake_snap_command.calls == [
+            ["snap", "download", "fake-snap"],
+            [
+                "snap",
+                "download",
+                "other-fake-snap",
+                "--channel",
+                "latest/stable",
+            ],
+        ]
+
+    def test_download_snaps_with_invalid(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"latest/stable": {"confinement": "strict"}}}},
+        ]
+        fake_snap_command.download_side_effect = [True, False]
+
+        with pytest.raises(errors.SnapDownloadError):
+            snaps.download_snaps(
+                snaps_list=["fake-snap", "other-invalid"], directory="fakedir"
+            )
+
+        assert fake_snap_command.calls == [
+            ["snap", "download", "fake-snap"],
+            ["snap", "download", "other-invalid"],
+        ]
+
+    def test_refresh_to_classic(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"classic/stable": {"confinement": "classic"}}}}
+        ]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
+        snap_pkg.refresh()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "refresh",
+                "fake-snap",
+                "--channel",
+                "classic/stable",
+                "--classic",
+            ],
+        ]
+
+    def test_refresh_not_on_channel(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [{"fake-snap": {"channels": {}}}]
+
+        snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
+        snap_pkg.refresh()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            [
+                "sudo",
+                "snap",
+                "refresh",
+                "fake-snap",
+                "--channel",
+                "classic/stable",
+            ],
+        ]
+
+    def test_refresh_logged_in(self, fake_snapd, fake_snap_command):
+        fake_snapd.find_result = [
+            {"fake-snap": {"channels": {"strict/stable": {"confinement": "strict"}}}}
+        ]
+
+        fake_snap_command.login("user@email.com")
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        snap_pkg.refresh()
+        assert fake_snap_command.calls == [
+            ["snap", "whoami"],
+            ["snap", "refresh", "fake-snap", "--channel", "strict/stable"],
+        ]
+
+    def test_refresh_fails(self, fake_snapd, fake_snap_command):
+        snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
+        fake_snap_command.refresh_success = False
+        with pytest.raises(errors.SnapRefreshError):
+            snap_pkg.refresh()
+
+    def test_install_snaps_returns_revision(self, fake_snapd):
+        fake_snapd.find_result = [
+            {
+                "fake-snap": {
+                    "channel": "stable",
+                    "type": "app",
+                    "channels": {"latest/stable": {"confinement": "strict"}},
+                }
+            }
+        ]
+        fake_snapd.snaps_result = [
+            {
+                "name": "fake-snap",
+                "channel": "stable",
+                "revision": "test-fake-snap-revision",
+            }
+        ]
+
+        installed_snaps = snaps.install_snaps(["fake-snap"])
+        assert installed_snaps == ["fake-snap=test-fake-snap-revision"]
+
+    def test_install_snaps_non_stable_base(self, fake_snapd):
+        fake_snapd.find_result = [
+            {
+                "fake-base-snap": {
+                    "channel": "beta",
+                    "type": "base",
+                    "channels": {"latest/beta": {"confinement": "strict"}},
+                }
+            }
+        ]
+        fake_snapd.snaps_result = [
+            {
+                "name": "fake-base-snap",
+                "channel": "beta",
+                "revision": "test-fake-base-snap-revision",
+            }
+        ]
+
+        installed_snaps = snaps.install_snaps(["fake-base-snap"])
+        assert installed_snaps == ["fake-base-snap=test-fake-base-snap-revision"]
+
+
+class TestInstalledSnaps:
+    def test_get_installed_snaps(self, fake_snapd):
+        fake_snapd.snaps_result = [
+            {"name": "test-snap-1", "revision": "test-snap-1-revision"},
+            {"name": "test-snap-2", "revision": "test-snap-2-revision"},
+        ]
+        installed_snaps = snaps.get_installed_snaps()
+        assert installed_snaps == [
+            "test-snap-1=test-snap-1-revision",
+            "test-snap-2=test-snap-2-revision",
+        ]
+
+
+class TestSnapdNotInstalled:
+    def test_get_installed_snaps(self, mocker):
+        mocker.patch(
+            "craft_parts.packages.snaps.get_snapd_socket_path_template",
+            return_value="http+unix://nonexisting",
+        )
+
+        installed_snaps = snaps.get_installed_snaps()
+        assert installed_snaps == []


### PR DESCRIPTION
Snap packages can be listed in the parts specification as stage snaps
or build snaps. This change implements the mechanism to handle snap
download and installation.

Packages/repo is planned to be moved into a separate project, where
it will be further refactored. Current code follows the snapcraft
implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
