### PR TITLE
sources: add source handler integration

### DIFF
--- a/craft_parts/sources/__init__.py
+++ b/craft_parts/sources/__init__.py
@@ -15,3 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Source handler definitions and helpers."""
+
+from . import errors  # noqa: F401
+from .local_source import LocalSource  # noqa: F401
+from .sources import SourceHandler  # noqa: F401
+from .sources import get_source_handler  # noqa: F401
+from .sources import get_source_type_from_uri  # noqa: F401

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -55,13 +55,13 @@ class SourceHandler(abc.ABC):
         source_depth: Optional[int] = None,
         source_checksum: Optional[str] = None,
         command: Optional[str] = None,
-        dirs: Optional[ProjectDirs] = None,
+        project_dirs: Optional[ProjectDirs] = None,
     ):
         if not application_name:
             application_name = utils.package_name()
 
-        if not dirs:
-            dirs = ProjectDirs()
+        if not project_dirs:
+            project_dirs = ProjectDirs()
 
         self.source = str(source)
         self.part_src_dir = str(part_src_dir)
@@ -75,7 +75,7 @@ class SourceHandler(abc.ABC):
         self.command = command
 
         self._application_name = application_name
-        self._dirs = dirs
+        self._dirs = project_dirs
         self._checked = False
 
     # pylint: enable=too-many-arguments
@@ -123,7 +123,7 @@ class FileSourceHandler(SourceHandler):
         source_depth: Optional[int] = None,
         source_checksum: Optional[str] = None,
         command: Optional[str] = None,
-        dirs: Optional[ProjectDirs] = None,
+        project_dirs: Optional[ProjectDirs] = None,
     ):
         super().__init__(
             source,
@@ -135,7 +135,7 @@ class FileSourceHandler(SourceHandler):
             source_depth=source_depth,
             source_checksum=source_checksum,
             command=command,
-            dirs=dirs,
+            project_dirs=project_dirs,
         )
         self._file = ""
 

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -16,11 +16,55 @@
 
 """Source handler error definitions."""
 
+from typing import List
+
 from craft_parts import errors
+from craft_parts.utils import formatting_utils
 
 
 class SourceError(errors.PartsError):
     """Base class for source handler errors."""
+
+
+class InvalidSourceType(SourceError):
+    """Failed to determine a source type."""
+
+    def __init__(self, source: str):
+        self.source = source
+        brief = f"Failed to pull source: unable to determine source type of {source!r}."
+
+        super().__init__(brief=brief)
+
+
+class InvalidSourceOption(SourceError):
+    """A source option is not allowed for the given source type."""
+
+    def __init__(self, *, source_type: str, option: str):
+        self.source_type = source_type
+        self.option = option
+        brief = (
+            f"Failed to pull source: {option!r} cannot be used "
+            f"with a {source_type} source."
+        )
+        resolution = "Make sure sources are correctly specified."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class IncompatibleSourceOptions(SourceError):
+    """Source specified options that can't be used at the same time."""
+
+    def __init__(self, source_type: str, options: List[str]):
+        self.source_type = source_type
+        self.options = options
+        humanized_options = formatting_utils.humanize_list(options, "and")
+        brief = (
+            f"Failed to pull source: cannot specify both {humanized_options} "
+            f"for a {source_type} source."
+        )
+        resolution = "Make sure sources are correctly specified."
+
+        super().__init__(brief=brief, resolution=resolution)
 
 
 class ChecksumMismatch(SourceError):
@@ -62,20 +106,5 @@ class SourceNotFound(SourceError):
         self.source = source
         brief = f"Failed to pull source: {source!r} not found."
         resolution = "Make sure the source path is correct and accessible."
-
-        super().__init__(brief=brief, resolution=resolution)
-
-
-class InvalidSourceOption(SourceError):
-    """A source option is not allowed for the given source type."""
-
-    def __init__(self, *, source_type: str, option: str):
-        self.source_type = source_type
-        self.option = option
-        brief = (
-            f"Failed to pull source: {option!r} cannot be used "
-            f"with a {source_type} source."
-        )
-        resolution = "Make sure sources are correctly specified."
 
         super().__init__(brief=brief, resolution=resolution)

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -52,7 +52,7 @@ class InvalidSourceOption(SourceError):
 
 
 class IncompatibleSourceOptions(SourceError):
-    """Source specified options that can't be used at the same time."""
+    """Source specified options that cannot be used at the same time."""
 
     def __init__(self, source_type: str, options: List[str]):
         self.source_type = source_type

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -71,11 +71,19 @@ have their own built-in packaging systems (think CPAN, PyPI, NPM). In those
 cases you want to refer to the documentation for the specific plugin.
 """
 
-from typing import Dict, Type
+import os
+import re
+from typing import TYPE_CHECKING, Dict, Optional, Type
 
+from craft_parts.dirs import ProjectDirs
+
+from . import errors
 from .base import SourceHandler
 from .local_source import LocalSource
 from .tar_source import TarSource
+
+if TYPE_CHECKING:
+    from craft_parts.parts import Part
 
 SourceHandlerType = Type[SourceHandler]
 
@@ -84,3 +92,92 @@ _source_handler: Dict[str, SourceHandlerType] = {
     "local": LocalSource,
     "tar": TarSource,
 }
+
+
+def get_source_handler(
+    application_name: str,
+    part: "Part",
+    dirs: ProjectDirs,
+) -> Optional[SourceHandler]:
+    """Return the appropriate handler for the given source.
+
+    :param application_name: The name of the application using Craft Parts.
+    :param part: The part to get a source handler for.
+    :param dirs: The project's work directories.
+    """
+    if not dirs:
+        dirs = ProjectDirs()
+
+    source_handler = None
+    if part.spec.source:
+        handler_class = _get_source_handler_class(
+            part.spec.source,
+            source_type=part.spec.source_type,
+        )
+        source_handler = handler_class(
+            application_name=application_name,
+            source=part.spec.source,
+            part_src_dir=part.part_src_dir,
+            source_checksum=part.spec.source_checksum,
+            source_branch=part.spec.source_branch,
+            source_tag=part.spec.source_tag,
+            source_depth=part.spec.source_depth,
+            source_commit=part.spec.source_commit,
+            dirs=dirs,
+        )
+
+    return source_handler
+
+
+def _get_source_handler_class(source, *, source_type: str = "") -> SourceHandlerType:
+    """Return the appropriate handler class for the given source.
+
+    :param source: The source specification.
+    :param source_type: The source type to use. If not specified, the
+        type will be inferred from the source specification.
+    """
+    if not source_type:
+        source_type = get_source_type_from_uri(source)
+
+    if source_type not in _source_handler:
+        raise errors.InvalidSourceType(source)
+
+    return _source_handler.get(source_type, LocalSource)
+
+
+_tar_type_regex = re.compile(r".*\.((tar(\.(xz|gz|bz2))?)|tgz)$")
+
+
+def get_source_type_from_uri(
+    source: str, ignore_errors: bool = False
+) -> str:  # noqa: C901
+    """Return the source type based on the given source URI.
+
+    :param source: The source specification.
+    :param ignore_errors: Don't raise InvalidSourceType if the source
+        type could not be determined.
+
+    :raise InvalidSourceType: If the source type is unknown.
+    """
+    for extension in ["zip", "deb", "rpm", "7z", "snap"]:
+        if source.endswith(".{}".format(extension)):
+            return extension
+    source_type = ""
+    if source.startswith("bzr:") or source.startswith("lp:"):
+        source_type = "bzr"
+    elif (
+        source.startswith("git:")
+        or source.startswith("git@")
+        or source.endswith(".git")
+    ):
+        source_type = "git"
+    elif source.startswith("svn:"):
+        source_type = "subversion"
+    elif _tar_type_regex.match(source):
+        source_type = "tar"
+    elif os.path.isdir(source):
+        source_type = "local"
+    elif not ignore_errors:
+        raise errors.InvalidSourceType(source)
+
+    return source_type

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -97,17 +97,14 @@ _source_handler: Dict[str, SourceHandlerType] = {
 def get_source_handler(
     application_name: str,
     part: "Part",
-    dirs: ProjectDirs,
+    project_dirs: ProjectDirs,
 ) -> Optional[SourceHandler]:
     """Return the appropriate handler for the given source.
 
     :param application_name: The name of the application using Craft Parts.
     :param part: The part to get a source handler for.
-    :param dirs: The project's work directories.
+    :param project_dirs: The project's work directories.
     """
-    if not dirs:
-        dirs = ProjectDirs()
-
     source_handler = None
     if part.spec.source:
         handler_class = _get_source_handler_class(
@@ -123,7 +120,7 @@ def get_source_handler(
             source_tag=part.spec.source_tag,
             source_depth=part.spec.source_depth,
             source_commit=part.spec.source_commit,
-            dirs=dirs,
+            project_dirs=project_dirs,
         )
 
     return source_handler

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -44,7 +44,7 @@ class TarSource(FileSourceHandler):
         source_branch: Optional[str] = None,
         source_depth: Optional[int] = None,
         source_checksum: Optional[str] = None,
-        dirs: Optional[ProjectDirs] = None,
+        project_dirs: Optional[ProjectDirs] = None,
     ):
         super().__init__(
             source,
@@ -55,7 +55,7 @@ class TarSource(FileSourceHandler):
             source_branch=source_branch,
             source_depth=source_depth,
             source_checksum=source_checksum,
-            dirs=dirs,
+            project_dirs=project_dirs,
         )
         if source_tag:
             raise errors.InvalidSourceOption(source_type="tar", option="source-tag")

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -276,7 +276,7 @@ class StateManager:
                 source_handler = sources.get_source_handler(
                     application_name=self._project_info.application_name,
                     part=part,
-                    dirs=self._project_info.dirs,
+                    project_dirs=self._project_info.dirs,
                 )
                 self._source_handler_cache[part.name] = source_handler
 

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -16,14 +16,17 @@
 
 """Part crafter step state management."""
 
+import contextlib
 import itertools
 import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
-from craft_parts import parts, steps
+from craft_parts import parts, sources, steps
 from craft_parts.infos import ProjectInfo
 from craft_parts.parts import Part
+from craft_parts.sources import SourceHandler
+from craft_parts.state_manager import states
 from craft_parts.steps import Step
 
 from .reports import Dependency, DirtyReport, OutdatedReport
@@ -170,6 +173,7 @@ class StateManager:
         self._state_db = _StateDB()
         self._project_info = project_info
         self._part_list = part_list
+        self._source_handler_cache: Dict[str, Optional[SourceHandler]] = {}
 
         part_step_list = _sort_steps_by_state_timestamp(part_list)
 
@@ -265,7 +269,26 @@ class StateManager:
         if not stw:
             return None
 
-        # TODO: verify if the source is outdated according to the source handler
+        if step == Step.PULL:
+            if part.name in self._source_handler_cache:
+                source_handler = self._source_handler_cache[part.name]
+            else:
+                source_handler = sources.get_source_handler(
+                    application_name=self._project_info.application_name,
+                    part=part,
+                    dirs=self._project_info.dirs,
+                )
+                self._source_handler_cache[part.name] = source_handler
+
+            state_file = states.state_file_path(part, step)
+
+            if source_handler:
+                # Not all sources support checking for updates
+                with contextlib.suppress(sources.errors.SourceUpdateUnsupported):
+                    if source_handler.check_if_outdated(str(state_file)):
+                        return OutdatedReport(source_modified=True)
+
+            return None
 
         for previous_step in reversed(step.previous_steps()):
             # Has a previous step run since this one ran? Then this

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -17,6 +17,41 @@
 from craft_parts.sources import errors
 
 
+def test_invalid_source_type():
+    err = errors.InvalidSourceType("t-death.adf")
+    assert err.source == "t-death.adf"
+    assert err.brief == (
+        "Failed to pull source: unable to determine source type of 't-death.adf'."
+    )
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_invalid_source_option():
+    err = errors.InvalidSourceOption(source_type="lzx", option="source-depth")
+    assert err.source_type == "lzx"
+    assert err.option == "source-depth"
+    assert err.brief == (
+        "Failed to pull source: 'source-depth' cannot be used with a lzx source."
+    )
+    assert err.details is None
+    assert err.resolution == "Make sure sources are correctly specified."
+
+
+def test_incompatible_source_options():
+    err = errors.IncompatibleSourceOptions(
+        source_type="dms", options=["source-tag", "source-branch"]
+    )
+    assert err.source_type == "dms"
+    assert err.options == ["source-tag", "source-branch"]
+    assert err.brief == (
+        "Failed to pull source: cannot specify both 'source-branch' and 'source-tag' "
+        "for a dms source."
+    )
+    assert err.details is None
+    assert err.resolution == "Make sure sources are correctly specified."
+
+
 def test_checksum_mismatch():
     err = errors.ChecksumMismatch(expected="1234", obtained="5678")
     assert err.expected == "1234"
@@ -48,14 +83,3 @@ def test_source_not_found():
     assert err.brief == "Failed to pull source: 'some_source' not found."
     assert err.details is None
     assert err.resolution == "Make sure the source path is correct and accessible."
-
-
-def test_invalid_source_option():
-    err = errors.InvalidSourceOption(source_type="lzx", option="source-depth")
-    assert err.source_type == "lzx"
-    assert err.option == "source-depth"
-    assert err.brief == (
-        "Failed to pull source: 'source-depth' cannot be used with a lzx source."
-    )
-    assert err.details is None
-    assert err.resolution == "Make sure sources are correctly specified."

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -1,0 +1,96 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts.dirs import ProjectDirs
+from craft_parts.parts import Part
+from craft_parts.sources import LocalSource, errors, sources
+from craft_parts.sources.tar_source import TarSource
+
+
+@pytest.mark.parametrize(
+    "tc_url,tc_handler",
+    [
+        (".", LocalSource),
+        (".", LocalSource),
+        (".tar.gz", TarSource),
+        (".tar.bz2", TarSource),
+        (".tgz", TarSource),
+        (".tar", TarSource),
+    ],
+)
+def test_get_source_handler_class(tc_url, tc_handler):
+    h = sources._get_source_handler_class(tc_url)
+    assert h == tc_handler
+
+
+def test_get_source_handler_class_with_invalid_type():
+    with pytest.raises(errors.InvalidSourceType) as raised:
+        sources._get_source_handler_class(".", source_type="invalid")
+    assert raised.value.source == "."
+
+
+@pytest.mark.parametrize(
+    "source,result",
+    [
+        (".tar.gz", "tar"),
+        (".tar.bz2", "tar"),
+        (".tgz", "tar"),
+        (".tar", "tar"),
+        ("git:", "git"),
+        ("git@", "git"),
+        (".git", "git"),
+        ("lp:", "bzr"),
+        ("bzr:", "bzr"),
+        ("svn:", "subversion"),
+    ],
+)
+def test_type_from_uri(source, result):
+    assert sources.get_source_type_from_uri(source) == result
+
+
+@pytest.mark.parametrize(
+    "source_type,source_branch,source_tag,source_commit,error",
+    [
+        ("tar", "test_branch", None, None, "source-branch"),  # tar with source branch
+        ("tar", None, "test_tag", None, "source-tag"),  # tar with source tag
+        ("tar", None, None, "commit", "source-commit"),  # tar with source commit
+    ],
+)
+def test_sources_with_branch_errors(
+    source_type, source_branch, source_tag, source_commit, error
+):
+    part_data = {
+        "source": "https://source.com",
+        "source-type": source_type,
+    }
+
+    if source_branch:
+        part_data["source-branch"] = source_branch
+
+    if source_tag:
+        part_data["source-tag"] = source_tag
+
+    if source_commit:
+        part_data["source-commit"] = source_commit
+
+    p1 = Part("p1", part_data)
+
+    with pytest.raises(errors.InvalidSourceOption) as err:
+        sources.get_source_handler(application_name="test", part=p1, dirs=ProjectDirs())
+    assert err.value.source_type == source_type
+    assert err.value.option == error

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -91,6 +91,8 @@ def test_sources_with_branch_errors(
     p1 = Part("p1", part_data)
 
     with pytest.raises(errors.InvalidSourceOption) as err:
-        sources.get_source_handler(application_name="test", part=p1, dirs=ProjectDirs())
+        sources.get_source_handler(
+            application_name="test", part=p1, project_dirs=ProjectDirs()
+        )
     assert err.value.source_type == source_type
     assert err.value.option == error


### PR DESCRIPTION
Provide calls to integrate source handlers with state manager and the
executor, and use it to check if sources are outdated during the
planning phase.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
