### PR TITLE
filesets: add fileset and file migration helpers

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -17,7 +17,7 @@
 """Craft parts errors."""
 
 import dataclasses
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 
 @dataclasses.dataclass(repr=True)
@@ -240,3 +240,32 @@ class OsReleaseCodenameError(PartsError):
         brief = "Unable to determine the host operating system codename."
 
         super().__init__(brief=brief)
+
+
+class FilesetError(PartsError):
+    """An invalid fileset operation was performed."""
+
+    def __init__(self, *, name: str, message: str):
+        self.name = name
+        self.message = message
+        brief = f"{name!r} fileset error: {message}."
+        resolution = "Review the parts definition and make sure it's correct."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class FilesetConflict(PartsError):
+    """Inconsistent stage to prime filtering."""
+
+    def __init__(self, conflicting_files: Set[str]):
+        self.conflicting_files = conflicting_files
+        brief = "Failed to filter files: inconsistent 'stage' and 'prime' filesets."
+        details = (
+            f"The following files have been excluded in the 'stage' fileset, "
+            f"but included by the 'prime' fileset: {conflicting_files!r}."
+        )
+        resolution = (
+            "Make sure that the files included in 'prime' are also included in 'stage'."
+        )
+
+        super().__init__(brief=brief, details=details, resolution=resolution)

--- a/craft_parts/executor/__init__.py
+++ b/craft_parts/executor/__init__.py
@@ -1,0 +1,17 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The action executor."""

--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -1,0 +1,250 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definitions and helpers to handle filesets."""
+
+import os
+from dataclasses import dataclass
+from glob import iglob
+from typing import List, Set, Tuple
+
+from craft_parts import errors
+
+
+@dataclass
+class Fileset:
+    """Helper class to process string lists."""
+
+    def __init__(self, entries: List[str], *, name: str = ""):
+        self._name = name
+        self._list = entries
+
+    def __repr__(self):
+        return f"Fileset({self._list!r}, name={self._name!r})"
+
+    @property
+    def name(self) -> str:
+        """Return the fileset name."""
+        return self._name
+
+    @property
+    def entries(self) -> List[str]:
+        """Return the list of entries in this fileset."""
+        return self._list.copy()
+
+    @property
+    def includes(self) -> List[str]:
+        """Return the list of files to be included."""
+        return [x for x in self._list if x[0] != "-"]
+
+    @property
+    def excludes(self) -> List[str]:
+        """Return the list of files to be excluded."""
+        return [x[1:] for x in self._list if x[0] == "-"]
+
+    def remove(self, item: str) -> None:
+        """Remove this entry from the list of files.
+
+        :param item: The item to remove.
+        """
+        self._list.remove(item)
+
+    def combine(self, other: "Fileset") -> None:
+        """Combine the entries in this fileset with entries from another fileset.
+
+        :param other: The fileset to combine with.
+        """
+        my_excludes = set(self.excludes)
+        other_includes = set(other.includes)
+
+        contradicting_set = set.intersection(my_excludes, other_includes)
+        if contradicting_set:
+            raise errors.FilesetConflict(contradicting_set)
+
+        to_combine = False
+        # combine if the other fileset has a wildcard
+        # XXX: should this only be a single wildcard and possibly excludes?
+        if "*" in other.entries:
+            to_combine = True
+            other.remove("*")
+
+        # combine if the other fileset is only excludes
+        if {x[0] for x in other.entries} == set("-"):
+            to_combine = True
+
+        if to_combine:
+            self._list = list(set(self._list + other.entries))
+        else:
+            self._list = other.entries
+
+
+def migratable_filesets(fileset: Fileset, srcdir: str) -> Tuple[Set[str], Set[str]]:
+    """Return the files and directories that can be migrated.
+
+    :param fileset: The fileset to migrate.
+
+    :return: A tuple containing the set of files and the set of directories
+        that can be migrated.
+    """
+    includes, excludes = _get_file_list(fileset)
+
+    include_files = _generate_include_set(srcdir, includes)
+    exclude_files, exclude_dirs = _generate_exclude_set(srcdir, excludes)
+
+    files = include_files - exclude_files
+    for exclude_dir in exclude_dirs:
+        files = {x for x in files if not x.startswith(exclude_dir + "/")}
+
+    # Separate dirs from files.
+    dirs = {
+        x
+        for x in files
+        if os.path.isdir(os.path.join(srcdir, x))
+        and not os.path.islink(os.path.join(srcdir, x))
+    }
+
+    # Remove dirs from files.
+    files = files - dirs
+
+    # Include (resolved) parent directories for each selected file.
+    for filename in files:
+        filename = _get_resolved_relative_path(filename, srcdir)
+        dirname = os.path.dirname(filename)
+        while dirname:
+            dirs.add(dirname)
+            dirname = os.path.dirname(dirname)
+
+    # Resolve parent paths for dirs and files.
+    resolved_dirs = set()
+    for dirname in dirs:
+        resolved_dirs.add(_get_resolved_relative_path(dirname, srcdir))
+
+    resolved_files = set()
+    for filename in files:
+        resolved_files.add(_get_resolved_relative_path(filename, srcdir))
+
+    return resolved_files, resolved_dirs
+
+
+def _get_file_list(fileset: Fileset) -> Tuple[List[str], List[str]]:
+    """Split a fileset to obtain include and exclude file filters.
+
+    :param fileset: The fileset to split.
+
+    :return: A tuple containing the include and exclude lists.
+    """
+    includes: List[str] = []
+    excludes: List[str] = []
+
+    for item in fileset.entries:
+        if item.startswith("-"):
+            excludes.append(item[1:])
+        elif item.startswith("\\"):
+            includes.append(item[1:])
+        else:
+            includes.append(item)
+
+    # paths must be relative
+    for entry in includes + excludes:
+        if os.path.isabs(entry):
+            raise errors.FilesetError(
+                name=fileset.name, message=f"path {entry!r} must be relative."
+            )
+
+    includes = includes or ["*"]
+
+    return includes, excludes
+
+
+def _generate_include_set(directory: str, includes: List[str]) -> Set[str]:
+    """Obtain the list of files to include based on include file filter.
+
+    :param directory: The path to the tree containing the files to filter.
+
+    :return: The set of files to include.
+    """
+    include_files = set()
+
+    for include in includes:
+        if "*" in include:
+            pattern = os.path.join(directory, include)
+            matches = iglob(pattern, recursive=True)
+            include_files |= set(matches)
+        else:
+            include_files |= set([os.path.join(directory, include)])
+
+    include_dirs = [
+        x for x in include_files if os.path.isdir(x) and not os.path.islink(x)
+    ]
+    include_files = {os.path.relpath(x, directory) for x in include_files}
+
+    # Expand includeFiles, so that an exclude like '*/*.so' will still match
+    # files from an include like 'lib'
+    for include_dir in include_dirs:
+        for root, dirs, files in os.walk(include_dir):
+            include_files |= {
+                os.path.relpath(os.path.join(root, d), directory) for d in dirs
+            }
+            include_files |= {
+                os.path.relpath(os.path.join(root, f), directory) for f in files
+            }
+
+    return include_files
+
+
+def _generate_exclude_set(
+    directory: str, excludes: List[str]
+) -> Tuple[Set[str], Set[str]]:
+    """Obtain the list of files to exclude based on exclude file filter.
+
+    :param directory: The path to the tree containing the files to filter.
+
+    :return: The set of files to exclude.
+    """
+    exclude_files = set()
+
+    for exclude in excludes:
+        pattern = os.path.join(directory, exclude)
+        matches = iglob(pattern, recursive=True)
+        exclude_files |= set(matches)
+
+    exclude_dirs = {
+        os.path.relpath(x, directory) for x in exclude_files if os.path.isdir(x)
+    }
+    exclude_files = {os.path.relpath(x, directory) for x in exclude_files}
+
+    return exclude_files, exclude_dirs
+
+
+def _get_resolved_relative_path(relative_path: str, base_directory: str) -> str:
+    """Resolve path components against target base_directory.
+
+    If the resulting target path is a symlink, it will not be followed.
+    Only the path's parents are fully resolved against base_directory,
+    and the relative path is returned.
+
+    :param relative_path: Path of target, relative to base_directory.
+    :param base_directory: Base path of target.
+
+    :return: Resolved path, relative to base_directory.
+    """
+    parent_relpath, filename = os.path.split(relative_path)
+    parent_abspath = os.path.realpath(os.path.join(base_directory, parent_relpath))
+
+    filename_abspath = os.path.join(parent_abspath, filename)
+    filename_relpath = os.path.relpath(filename_abspath, base_directory)
+
+    return filename_relpath

--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -17,14 +17,12 @@
 """Definitions and helpers to handle filesets."""
 
 import os
-from dataclasses import dataclass
 from glob import iglob
 from typing import List, Set, Tuple
 
 from craft_parts import errors
 
 
-@dataclass
 class Fileset:
     """Helper class to process string lists."""
 

--- a/tests/unit/executor/test_filesets.py
+++ b/tests/unit/executor/test_filesets.py
@@ -1,0 +1,111 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.executor import filesets
+from craft_parts.executor.filesets import Fileset
+
+
+@pytest.mark.parametrize(
+    "tc_data,tc_entries,tc_includes,tc_excludes",
+    [
+        ([], [], [], []),
+        (["a", "b"], ["a", "b"], ["a", "b"], []),
+        (["a", "-b"], ["a", "-b"], ["a"], ["b"]),
+    ],
+)
+def test_fileset(tc_data, tc_entries, tc_includes, tc_excludes):
+    fs = Fileset(tc_data)
+    assert fs.entries == tc_entries
+    assert fs.includes == tc_includes
+    assert fs.excludes == tc_excludes
+
+
+def test_representation():
+    fs = Fileset(["foo", "bar"], name="foobar")
+    assert f"{fs!r}" == "Fileset(['foo', 'bar'], name='foobar')"
+
+
+def test_entries():
+    fs = Fileset(["foo", "bar"])
+    fs.entries.append("baz")
+    assert fs.entries == ["foo", "bar"]
+
+
+def test_remove():
+    fs = Fileset(["foo", "bar", "baz"])
+    fs.remove("bar")
+    assert fs.entries == ["foo", "baz"]
+
+
+@pytest.mark.parametrize(
+    "tc_fs1,tc_fs2,tc_result",
+    [
+        ([], [], []),
+        (["foo"], ["bar"], ["bar"]),
+        # combine if fs2 has a wildcard
+        (["foo"], ["bar", "*"], ["foo", "bar"]),
+        # combine if fs2 is only excludes
+        (["foo"], ["-bar"], ["foo", "-bar"]),
+        (["foo", "*"], ["bar"], ["bar"]),
+        (["-foo"], ["-bar"], ["-foo", "-bar"]),
+        (["-foo"], ["bar"], ["bar"]),
+        (["foo"], ["-bar", "baz"], ["-bar", "baz"]),
+        (["-foo", "bar"], ["bar"], ["bar"]),
+    ],
+)
+def test_combine(tc_fs1, tc_fs2, tc_result):
+    fs1 = Fileset(tc_fs1)
+    fs2 = Fileset(tc_fs2)
+    fs1.combine(fs2)
+    assert sorted(fs1.entries) == sorted(tc_result)
+
+
+def test_fileset_only_includes():
+    stage_set = Fileset(["opt/something", "usr/bin"])
+
+    include, exclude = filesets._get_file_list(stage_set)
+
+    assert include == ["opt/something", "usr/bin"]
+    assert exclude == []
+
+
+def test_fileset_only_excludes():
+    stage_set = Fileset(["-etc", "-usr/lib/*.a"])
+
+    include, exclude = filesets._get_file_list(stage_set)
+
+    assert include == ["*"]
+    assert exclude == ["etc", "usr/lib/*.a"]
+
+
+def test_filesets_includes_without_relative_paths():
+    with pytest.raises(errors.FilesetError) as raised:
+        filesets._get_file_list(Fileset(["rel", "/abs/include"], name="test"))
+    assert raised.value.name == "test"
+    assert raised.value.message == "path '/abs/include' must be relative."
+
+
+def test_filesets_excludes_without_relative_paths():
+    with pytest.raises(errors.FilesetError) as raised:
+        filesets._get_file_list(Fileset(["rel", "-/abs/exclude"], name="test"))
+    assert raised.value.name == "test"
+    assert raised.value.message == "path '/abs/exclude' must be relative."
+
+
+# migratable_filesets tested in tests/unit/executor/test_step_handler.py

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -181,3 +181,27 @@ def test_os_release_codename_error():
     assert err.brief == "Unable to determine the host operating system codename."
     assert err.details is None
     assert err.resolution is None
+
+
+def test_fileset_error():
+    err = errors.FilesetError(name="stage", message="something is wrong")
+    assert err.name == "stage"
+    assert err.message == "something is wrong"
+    assert err.brief == "'stage' fileset error: something is wrong."
+    assert err.details is None
+    assert err.resolution == "Review the parts definition and make sure it's correct."
+
+
+def test_fileset_conflict():
+    err = errors.FilesetConflict({"foobar"})
+    assert err.conflicting_files == {"foobar"}
+    assert err.brief == (
+        "Failed to filter files: inconsistent 'stage' and 'prime' filesets."
+    )
+    assert err.details == (
+        "The following files have been excluded in the 'stage' fileset, "
+        "but included by the 'prime' fileset: {'foobar'}."
+    )
+    assert err.resolution == (
+        "Make sure that the files included in 'prime' are also included in 'stage'."
+    )


### PR DESCRIPTION
Filesets are filters used to include or exclude files that enter the
stage and prime filesystem areas. These filesets are defined under
the `stage` and `prime` properties in the parts specification.

Implementation of the filtering logic is ported from snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
