### PR TITLE
executor: add part file collision verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_parts
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access,redefined-outer-name
 
 .PHONY: test-pyright
 test-pyright:

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_parts
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access,redefined-outer-name
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -269,3 +269,24 @@ class FilesetConflict(PartsError):
         )
 
         super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class PartFilesConflict(PartsError):
+    """Different parts list the same files with different contents."""
+
+    def __init__(
+        self, *, part_name: str, other_part_name: str, conflicting_files: List[str]
+    ):
+        self.part_name = part_name
+        self.other_part_name = other_part_name
+        self.conflicting_files = conflicting_files
+        indented_conflicting_files = ("    {}".format(i) for i in conflicting_files)
+        file_paths = "\n".join(sorted(indented_conflicting_files))
+        brief = "Failed to stage: parts list the same file with different contents."
+        details = (
+            f"Parts {part_name!r} and {other_part_name!r} list the following "
+            f"files, but with different contents:\n"
+            f"{file_paths}"
+        )
+
+        super().__init__(brief=brief, details=details)

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -111,17 +111,12 @@ def _file_collides(file_this: str, file_other: str) -> bool:
         return not filecmp.cmp(file_this, file_other, shallow=False)
 
     # pkgconfig files need special handling.
-    pc_file_1 = open(file_this)
-    pc_file_2 = open(file_other)
-
-    try:
+    with open(file_this) as pc_file_1, open(file_other) as pc_file_2:
         for lines in zip(pc_file_1, pc_file_2):
             for line in zip(lines[0].split("\n"), lines[1].split("\n")):
                 if line[0].startswith("prefix="):
                     continue
                 if line[0] != line[1]:
                     return True
-    finally:
-        pc_file_1.close()
-        pc_file_2.close()
+
     return False

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -38,7 +38,7 @@ def check_for_stage_collisions(part_list: List[Part]) -> None:
         if not stage_files:
             continue
 
-        # Gather our own files up
+        # Gather our own files up.
         stage_fileset = Fileset(stage_files, name="stage")
         srcdir = str(part.part_install_dir)
         part_files, part_directories = filesets.migratable_filesets(
@@ -46,9 +46,9 @@ def check_for_stage_collisions(part_list: List[Part]) -> None:
         )
         part_contents = part_files | part_directories
 
-        # Scan previous parts for collisions
+        # Scan previous parts for collisions.
         for other_part_name in all_parts_files:
-            # our files that are also in a different part
+            # Our files that are also in a different part.
             common = part_contents & all_parts_files[other_part_name]["files"]
 
             conflict_files = []
@@ -68,7 +68,7 @@ def check_for_stage_collisions(part_list: List[Part]) -> None:
                     conflicting_files=conflict_files,
                 )
 
-        # And add our files to the list
+        # And add our files to the list.
         all_parts_files[part.name] = {
             "files": part_contents,
             "installdir": part.part_install_dir,
@@ -85,24 +85,24 @@ def paths_collide(path1: str, path2: str) -> bool:
     path1_is_link = os.path.islink(path1)
     path2_is_link = os.path.islink(path2)
 
-    # Paths collide if they're both symlinks, but pointing to different places
+    # Paths collide if they're both symlinks, but pointing to different places.
     if path1_is_link and path2_is_link:
         return os.readlink(path1) != os.readlink(path2)
 
-    # Paths collide if one is a symlink, but not the other
+    # Paths collide if one is a symlink, but not the other.
     if path1_is_link or path2_is_link:
         return True
 
-    # Paths collide if one is a directory, but not the other
+    # Paths collide if one is a directory, but not the other.
     if path1_is_dir != path2_is_dir:
         return True
 
     # Paths collide if neither path is a directory, and the files have
-    # different contents
+    # different contents.
     if not (path1_is_dir and path2_is_dir) and _file_collides(path1, path2):
         return True
 
-    # Otherwise, paths do not conflict
+    # Otherwise, paths do not conflict.
     return False
 
 
@@ -110,7 +110,7 @@ def _file_collides(file_this: str, file_other: str) -> bool:
     if not file_this.endswith(".pc"):
         return not filecmp.cmp(file_this, file_other, shallow=False)
 
-    # pkgconfig files need special handling
+    # pkgconfig files need special handling.
     pc_file_1 = open(file_this)
     pc_file_2 = open(file_other)
 

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -1,0 +1,127 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to detect conflicting staging files from multiple parts."""
+
+import filecmp
+import os
+from typing import Any, Dict, List
+
+from craft_parts import errors
+from craft_parts.executor import filesets
+from craft_parts.executor.filesets import Fileset
+from craft_parts.parts import Part
+
+
+def check_for_stage_collisions(part_list: List[Part]) -> None:
+    """Verify whether parts have conflicting files to stage.
+
+    :param part_list: The list of parts to be tested.
+    :raises PartConflictError: If conflicts are found.
+    """
+    all_parts_files: Dict[str, Dict[str, Any]] = {}
+    for part in part_list:
+        stage_files = part.spec.stage_files
+        if not stage_files:
+            continue
+
+        # Gather our own files up
+        stage_fileset = Fileset(stage_files, name="stage")
+        srcdir = str(part.part_install_dir)
+        part_files, part_directories = filesets.migratable_filesets(
+            stage_fileset, srcdir
+        )
+        part_contents = part_files | part_directories
+
+        # Scan previous parts for collisions
+        for other_part_name in all_parts_files:
+            # our files that are also in a different part
+            common = part_contents & all_parts_files[other_part_name]["files"]
+
+            conflict_files = []
+            for file in common:
+                this = os.path.join(part.part_install_dir, file)
+                other = os.path.join(
+                    all_parts_files[other_part_name]["installdir"], file
+                )
+
+                if paths_collide(this, other):
+                    conflict_files.append(file)
+
+            if conflict_files:
+                raise errors.PartFilesConflict(
+                    part_name=part.name,
+                    other_part_name=other_part_name,
+                    conflicting_files=conflict_files,
+                )
+
+        # And add our files to the list
+        all_parts_files[part.name] = {
+            "files": part_contents,
+            "installdir": part.part_install_dir,
+        }
+
+
+def paths_collide(path1: str, path2: str) -> bool:
+    """Check whether the provided paths conflict to each other."""
+    if not (os.path.lexists(path1) and os.path.lexists(path2)):
+        return False
+
+    path1_is_dir = os.path.isdir(path1)
+    path2_is_dir = os.path.isdir(path2)
+    path1_is_link = os.path.islink(path1)
+    path2_is_link = os.path.islink(path2)
+
+    # Paths collide if they're both symlinks, but pointing to different places
+    if path1_is_link and path2_is_link:
+        return os.readlink(path1) != os.readlink(path2)
+
+    # Paths collide if one is a symlink, but not the other
+    if path1_is_link or path2_is_link:
+        return True
+
+    # Paths collide if one is a directory, but not the other
+    if path1_is_dir != path2_is_dir:
+        return True
+
+    # Paths collide if neither path is a directory, and the files have
+    # different contents
+    if not (path1_is_dir and path2_is_dir) and _file_collides(path1, path2):
+        return True
+
+    # Otherwise, paths do not conflict
+    return False
+
+
+def _file_collides(file_this: str, file_other: str) -> bool:
+    if not file_this.endswith(".pc"):
+        return not filecmp.cmp(file_this, file_other, shallow=False)
+
+    # pkgconfig files need special handling
+    pc_file_1 = open(file_this)
+    pc_file_2 = open(file_other)
+
+    try:
+        for lines in zip(pc_file_1, pc_file_2):
+            for line in zip(lines[0].split("\n"), lines[1].split("\n")):
+                if line[0].startswith("prefix="):
+                    continue
+                if line[0] != line[1]:
+                    return True
+    finally:
+        pc_file_1.close()
+        pc_file_2.close()
+    return False

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -110,13 +110,12 @@ def _file_collides(file_this: str, file_other: str) -> bool:
     if not file_this.endswith(".pc"):
         return not filecmp.cmp(file_this, file_other, shallow=False)
 
-    # pkgconfig files need special handling.
+    # pkgconfig files need special handling, only prefix line may be different.
     with open(file_this) as pc_file_1, open(file_other) as pc_file_2:
-        for lines in zip(pc_file_1, pc_file_2):
-            for line in zip(lines[0].split("\n"), lines[1].split("\n")):
-                if line[0].startswith("prefix="):
-                    continue
-                if line[0] != line[1]:
-                    return True
+        for line_pc_1, line_pc_2 in zip(pc_file_1, pc_file_2):
+            if line_pc_1.startswith("prefix=") and line_pc_2.startswith("prefix="):
+                continue
+            if line_pc_1 != line_pc_2:
+                return True
 
     return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ extension-pkg-whitelist = [
     "apt_pkg",
     "pydantic"
 ]
-load-plugins = "pylint_fixme_info"
+load-plugins = "pylint_fixme_info,pylint_pytest"
 good-names = "id"
 
 [tool.black]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ mypy
 pydocstyle
 pylint
 pylint-fixme-info
+pylint-pytest
 pytest
 pytest-mock
 requests-mock

--- a/tests/unit/executor/test_collisions.py
+++ b/tests/unit/executor/test_collisions.py
@@ -1,0 +1,154 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.dirs import ProjectDirs
+from craft_parts.executor.collisions import check_for_stage_collisions
+from craft_parts.parts import Part
+
+
+@pytest.fixture
+def part1(tmpdir) -> Part:
+    part = Part("part1", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    (p / "a").mkdir(parents=True)
+    (p / "a" / "1").write_text("")
+    (p / "file.pc").write_text("prefix={}\nName: File".format(part.part_install_dir))
+    return part
+
+
+@pytest.fixture
+def part2(tmpdir) -> Part:
+    part = Part("part2", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    (p / "a").mkdir(parents=True)
+    (p / "1").write_text("1")
+    (p / "2").write_text("")
+    (p / "a" / "2").write_text("a/2")
+    (p / "a" / "file.pc").write_text(
+        "prefix={}\nName: File".format(part.part_install_dir)
+    )
+    return part
+
+
+@pytest.fixture
+def part3(tmpdir) -> Part:
+    part = Part("part3", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    (p / "a").mkdir(parents=True)
+    (p / "b").mkdir()
+    (p / "1").write_text("2")
+    # (p / "2").write_text("1")
+    (p / "a" / "2").write_text("")
+    return part
+
+
+@pytest.fixture
+def part4(tmpdir) -> Part:
+    part = Part("part4", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    (p / "a").mkdir(parents=True)
+    (p / "a" / "2").write_text("")
+    (p / "file.pc").write_text(
+        "prefix={}\nName: ConflictFile".format(part.part_install_dir)
+    )
+    return part
+
+
+@pytest.fixture
+def part5(tmpdir) -> Part:
+    # Create a new part with a symlink that collides with part1's
+    # non-symlink.
+    part = Part("part5", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    p.mkdir(parents=True)
+    (p / "a").symlink_to("foo")
+
+    return part
+
+
+@pytest.fixture
+def part6(tmpdir) -> Part:
+    # Create a new part with a symlink that points to a different place
+    # than part5's symlink.
+    part = Part("part6", {}, project_dirs=ProjectDirs(work_dir=tmpdir))
+    p = part.part_install_dir
+    p.mkdir(parents=True)
+    (p / "a").symlink_to("bar")
+
+    return part
+
+
+class TestCollisions:
+    """Check collision scenarios."""
+
+    def test_no_collisions(self, part1, part2):
+        """No exception is expected as there are no collisions."""
+        check_for_stage_collisions([part1, part2])
+
+    def test_collisions_between_two_parts(self, part1, part2, part3):
+        with pytest.raises(errors.PartFilesConflict) as raised:
+            check_for_stage_collisions([part1, part2, part3])
+
+        assert raised.value.other_part_name == "part2"
+        assert raised.value.part_name == "part3"
+        assert sorted(raised.value.conflicting_files) == ["1", "a/2"]
+
+    def test_collisions_checks_symlinks(self, part5, part6):
+        with pytest.raises(errors.PartFilesConflict) as raised:
+            check_for_stage_collisions([part5, part6])
+
+        assert raised.value.other_part_name == "part5"
+        assert raised.value.part_name == "part6"
+        assert raised.value.conflicting_files == ["a"]
+
+    def test_collisions_not_both_symlinks(self, part1, part5):
+        with pytest.raises(errors.PartFilesConflict) as raised:
+            check_for_stage_collisions([part1, part5])
+
+        assert raised.value.other_part_name == "part1"
+        assert raised.value.part_name == "part5"
+        assert raised.value.conflicting_files == ["a"]
+
+    def test_collisions_between_two_parts_pc_files(self, part1, part4):
+        with pytest.raises(errors.PartFilesConflict) as raised:
+            check_for_stage_collisions([part1, part4])
+
+        assert raised.value.other_part_name == "part1"
+        assert raised.value.part_name == "part4"
+        assert raised.value.conflicting_files == ["file.pc"]
+
+    def test_collision_with_part_not_built(self, tmpdir):
+        part_built = Part(
+            "part_built",
+            {"stage": ["collision"]},
+            project_dirs=ProjectDirs(work_dir=tmpdir),
+        )
+
+        # a part built has the stage file in the installdir.
+        part_built.part_install_dir.mkdir(parents=True)
+        (part_built.part_install_dir / "collision").write_text("")
+
+        part_not_built = Part(
+            "part_not_built",
+            {"stage": ["collision"]},
+            project_dirs=ProjectDirs(work_dir=tmpdir),
+        )
+
+        # a part not built doesn't have the stage file in the installdir.
+        check_for_stage_collisions([part_built, part_not_built])

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -205,3 +205,21 @@ def test_fileset_conflict():
     assert err.resolution == (
         "Make sure that the files included in 'prime' are also included in 'stage'."
     )
+
+
+def test_part_files_conflict():
+    err = errors.PartFilesConflict(
+        part_name="foo", other_part_name="bar", conflicting_files=["file1", "file2"]
+    )
+    assert err.part_name == "foo"
+    assert err.other_part_name == "bar"
+    assert err.conflicting_files == ["file1", "file2"]
+    assert err.brief == (
+        "Failed to stage: parts list the same file with different contents."
+    )
+    assert err.details == (
+        "Parts 'foo' and 'bar' list the following files, but with different contents:\n"
+        "    file1\n"
+        "    file2"
+    )
+    assert err.resolution is None


### PR DESCRIPTION
Different parts must not stage files under the same name and with
different contents, it will result in staging error. This change adds
the functions that perform this verification.

Collision verification logic is ported from snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
