### PR TITLE
executor: create environment for step execution

### DIFF
--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -1,0 +1,153 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to handle part environment setting."""
+
+import io
+import logging
+from typing import Dict, Iterable
+
+from craft_parts.infos import StepInfo
+from craft_parts.parts import Part
+from craft_parts.plugins import Plugin
+from craft_parts.steps import Step
+from craft_parts.utils import os_utils
+
+logger = logging.getLogger(__name__)
+
+
+def generate_part_environment(
+    *, part: Part, plugin: Plugin, step_info: StepInfo
+) -> str:
+    """Generate an environment to use during step execution.
+
+    :param part: The part being processed.
+    :param plugin: The plugin used to build this part.
+    :param step_info: Information about the step to be executed.
+
+    :return: The environment to use when executing the step.
+    """
+    # Craft parts' say.
+    our_build_environment = _basic_environment_for_part(part=part, step_info=step_info)
+
+    step = step_info.step
+
+    # Plugin's say.
+    if step == Step.BUILD:
+        plugin_environment = plugin.get_build_environment()
+    else:
+        plugin_environment = dict()
+
+    # Part's (user) say.
+    user_build_environment = part.spec.build_environment
+    if not user_build_environment:
+        user_build_environment = []
+
+    # Create the script.
+    with io.StringIO() as run_environment:
+        print("#!/bin/sh", file=run_environment)
+        print("set -e", file=run_environment)
+
+        print("# Environment", file=run_environment)
+
+        print("## Part Environment", file=run_environment)
+        for key, val in our_build_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+
+        print("## Plugin Environment", file=run_environment)
+        for key, val in plugin_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+
+        print("## User Environment", file=run_environment)
+        for env in user_build_environment:
+            for key, val in env.items():
+                print(f'export {key}="{val}"', file=run_environment)
+
+        # Return something suitable for Runner.
+        return run_environment.getvalue()
+
+
+def _basic_environment_for_part(part: Part, *, step_info: StepInfo) -> Dict[str, str]:
+    """Return the built-in part environment.
+
+    :param part: The part to get environment information from.
+    :param step_info: Information for this step.
+
+    :return: A dictionary containing the built-in environment.
+    """
+    part_environment: Dict[str, str] = {}
+    paths = [part.part_install_dir, part.stage_dir]
+
+    bin_paths = list()
+    for path in paths:
+        bin_paths.extend(os_utils.get_bin_paths(root=path, existing_only=True))
+
+    if bin_paths:
+        bin_paths.append("$PATH")
+        part_environment["PATH"] = _combine_paths(
+            paths=bin_paths, prepend="", separator=":"
+        )
+
+    include_paths = list()
+    for path in paths:
+        include_paths.extend(
+            os_utils.get_include_paths(root=path, arch_triplet=step_info.arch_triplet)
+        )
+
+    if include_paths:
+        for envvar in ["CPPFLAGS", "CFLAGS", "CXXFLAGS"]:
+            part_environment[envvar] = _combine_paths(
+                paths=include_paths, prepend="-isystem ", separator=" "
+            )
+
+    library_paths = list()
+    for path in paths:
+        library_paths.extend(
+            os_utils.get_library_paths(root=path, arch_triplet=step_info.arch_triplet)
+        )
+
+    if library_paths:
+        part_environment["LDFLAGS"] = _combine_paths(
+            paths=library_paths, prepend="-L", separator=" "
+        )
+
+    pkg_config_paths = list()
+    for path in paths:
+        pkg_config_paths.extend(
+            os_utils.get_pkg_config_paths(
+                root=path, arch_triplet=step_info.arch_triplet
+            )
+        )
+
+    if pkg_config_paths:
+        part_environment["PKG_CONFIG_PATH"] = _combine_paths(
+            pkg_config_paths, prepend="", separator=":"
+        )
+
+    return part_environment
+
+
+def _combine_paths(paths: Iterable[str], prepend: str, separator: str) -> str:
+    """Combine list of paths into a string.
+
+    :param paths: The list of paths to stringify.
+    :param prepend: A prefix to prepend to each path in the string.
+    :param separator: A string to place between each path in the string.
+
+    :return: A string with the combined paths.
+    """
+    paths = ["{}{}".format(prepend, p) for p in paths]
+    return separator.join(paths)

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 from craft_parts import errors, utils
 from craft_parts.dirs import ProjectDirs
 from craft_parts.parts import Part
+from craft_parts.steps import Step
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,24 @@ class PartInfo:
     def part_state_dir(self) -> Path:
         """Return the subdirectory containing this part's lifecycle state."""
         return self._part_state_dir
+
+
+class StepInfo:
+    """Step-level information containing project, part, and step fields."""
+
+    def __init__(
+        self,
+        part_info: PartInfo,
+        step: Step,
+    ):
+        self._part_info = part_info
+        self.step = step
+
+    def __getattr__(self, name):
+        if hasattr(self._part_info, name):
+            return getattr(self._part_info, name)
+
+        raise AttributeError(f"{self.__class__.__name__!r} has no attribute {name!r}")
 
 
 def _get_host_architecture() -> str:

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -21,7 +21,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 from craft_parts import errors
 
@@ -68,6 +68,87 @@ class TimedWriter:
         filepath.write_text(text, encoding=encoding, errors=errors)
 
         cls._last_write_time = time.time()
+
+
+def get_bin_paths(*, root: Union[str, Path], existing_only=True) -> List[str]:
+    """List common system executable paths.
+
+    :param root: A path to prepend to each entry in the list.
+    :param existing_only: Only list paths that are present in the system.
+
+    :return: The list of executable paths.
+    """
+    paths = (os.path.join("usr", "sbin"), os.path.join("usr", "bin"), "sbin", "bin")
+    rooted_paths = (os.path.join(root, p) for p in paths)
+
+    if existing_only:
+        return [p for p in rooted_paths if os.path.exists(p)]
+
+    return list(rooted_paths)
+
+
+def get_include_paths(*, root: Union[str, Path], arch_triplet: str) -> List[str]:
+    """List common include paths.
+
+    :param root: A path to prepend to each entry in the list.
+    :arch_triplet: The machine-vendor-os platform triplet definition.
+
+    :return: The list of include paths.
+    """
+    paths = [
+        os.path.join(root, "include"),
+        os.path.join(root, "usr", "include"),
+        os.path.join(root, "include", arch_triplet),
+        os.path.join(root, "usr", "include", arch_triplet),
+    ]
+
+    return [p for p in paths if os.path.exists(p)]
+
+
+def get_library_paths(
+    *, root: Union[str, Path], arch_triplet: str, existing_only=True
+) -> List[str]:
+    """List common library paths.
+
+    :param root: A path to prepend to each entry in the list.
+    :arch_triplet: The machine-vendor-os platform triplet definition.
+    :param existing_only: Only list paths that are present in the system.
+
+    :return: The list of library paths.
+    """
+    paths = [
+        os.path.join(root, "lib"),
+        os.path.join(root, "usr", "lib"),
+        os.path.join(root, "lib", arch_triplet),
+        os.path.join(root, "usr", "lib", arch_triplet),
+    ]
+
+    if existing_only:
+        paths = [p for p in paths if os.path.exists(p)]
+
+    return paths
+
+
+def get_pkg_config_paths(*, root: Union[str, Path], arch_triplet: str) -> List[str]:
+    """List common pkg-config paths.
+
+    :param root: A path to prepend to each entry in the list.
+    :arch_triplet: The machine-vendor-os platform triplet definition.
+
+    :return: The list of pkg-config paths.
+    """
+    paths = [
+        os.path.join(root, "lib", "pkgconfig"),
+        os.path.join(root, "lib", arch_triplet, "pkgconfig"),
+        os.path.join(root, "usr", "lib", "pkgconfig"),
+        os.path.join(root, "usr", "lib", arch_triplet, "pkgconfig"),
+        os.path.join(root, "usr", "share", "pkgconfig"),
+        os.path.join(root, "usr", "local", "lib", "pkgconfig"),
+        os.path.join(root, "usr", "local", "lib", arch_triplet, "pkgconfig"),
+        os.path.join(root, "usr", "local", "share", "pkgconfig"),
+    ]
+
+    return [p for p in paths if os.path.exists(p)]
 
 
 def is_dumb_terminal() -> bool:

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -1,0 +1,172 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+from typing import Dict, List, Set
+
+import pytest
+
+from craft_parts import plugins
+from craft_parts.executor import environment
+from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+
+class FooPlugin(plugins.Plugin):
+    """A test plugin."""
+
+    properties_class = plugins.PluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {"PLUGIN_ENVVAR": "from_plugin"}
+
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+@pytest.fixture(autouse=True)
+def directories(new_dir):  # pylint: disable=unused-argument
+    part_info = PartInfo(project_info=ProjectInfo(), part=Part("p1", {}))
+
+    for directory in [
+        "bin",
+        "usr/bin",
+        "sbin",
+        "usr/sbin",
+        "usr/local/bin",
+        "usr/include",
+    ]:
+        Path(part_info.part_install_dir / directory).mkdir(parents=True)
+
+    for directory in [
+        "lib",
+        "lib/aarch64-linux-gnu",
+        "usr/lib",
+        "usr/local/lib",
+        "usr/share/pkgconfig",
+    ]:
+        Path(part_info.stage_dir / directory).mkdir(parents=True)
+
+
+# pylint: disable=line-too-long
+
+
+def test_generate_part_environment_build(new_dir):
+    p1 = Part("p1", {"build-environment": [{"PART_ENVVAR": "from_part"}]})
+    info = ProjectInfo(arch="aarch64")
+    part_info = PartInfo(project_info=info, part=p1)
+    step_info = StepInfo(part_info=part_info, step=Step.BUILD)
+    props = plugins.PluginProperties()
+    plugin = FooPlugin(properties=props, part_info=part_info)
+
+    env = environment.generate_part_environment(
+        part=p1, plugin=plugin, step_info=step_info
+    )
+
+    assert env == textwrap.dedent(
+        """\
+        #!/bin/sh
+        set -e
+        # Environment
+        ## Part Environment
+        export PATH="{0}/parts/p1/install/usr/sbin:{0}/parts/p1/install/usr/bin:{0}/parts/p1/install/sbin:{0}/parts/p1/install/bin:$PATH"
+        export CPPFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CXXFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export LDFLAGS="-L{0}/stage/lib -L{0}/stage/usr/lib -L{0}/stage/lib/aarch64-linux-gnu"
+        export PKG_CONFIG_PATH="{0}/stage/usr/share/pkgconfig"
+        ## Plugin Environment
+        export PLUGIN_ENVVAR="from_plugin"
+        ## User Environment
+        export PART_ENVVAR="from_part"
+        """.format(
+            new_dir
+        )
+    )
+
+
+def test_generate_part_environment_no_build(new_dir):
+    p1 = Part("p1", {"build-environment": [{"PART_ENVVAR": "from_part"}]})
+    info = ProjectInfo(arch="aarch64")
+    part_info = PartInfo(project_info=info, part=p1)
+    step_info = StepInfo(part_info=part_info, step=Step.STAGE)
+    props = plugins.PluginProperties()
+    plugin = FooPlugin(properties=props, part_info=part_info)
+
+    env = environment.generate_part_environment(
+        part=p1, plugin=plugin, step_info=step_info
+    )
+
+    assert env == textwrap.dedent(
+        """\
+        #!/bin/sh
+        set -e
+        # Environment
+        ## Part Environment
+        export PATH="{0}/parts/p1/install/usr/sbin:{0}/parts/p1/install/usr/bin:{0}/parts/p1/install/sbin:{0}/parts/p1/install/bin:$PATH"
+        export CPPFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CXXFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export LDFLAGS="-L{0}/stage/lib -L{0}/stage/usr/lib -L{0}/stage/lib/aarch64-linux-gnu"
+        export PKG_CONFIG_PATH="{0}/stage/usr/share/pkgconfig"
+        ## Plugin Environment
+        ## User Environment
+        export PART_ENVVAR="from_part"
+        """.format(
+            new_dir
+        )
+    )
+
+
+def test_generate_part_environment_no_user_env(new_dir):
+    p1 = Part("p1", {})
+    info = ProjectInfo(arch="aarch64")
+    part_info = PartInfo(project_info=info, part=p1)
+    step_info = StepInfo(part_info=part_info, step=Step.BUILD)
+    props = plugins.PluginProperties()
+    plugin = FooPlugin(properties=props, part_info=part_info)
+
+    env = environment.generate_part_environment(
+        part=p1, plugin=plugin, step_info=step_info
+    )
+
+    assert env == textwrap.dedent(
+        """\
+        #!/bin/sh
+        set -e
+        # Environment
+        ## Part Environment
+        export PATH="{0}/parts/p1/install/usr/sbin:{0}/parts/p1/install/usr/bin:{0}/parts/p1/install/sbin:{0}/parts/p1/install/bin:$PATH"
+        export CPPFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export CXXFLAGS="-isystem {0}/parts/p1/install/usr/include"
+        export LDFLAGS="-L{0}/stage/lib -L{0}/stage/usr/lib -L{0}/stage/lib/aarch64-linux-gnu"
+        export PKG_CONFIG_PATH="{0}/stage/usr/share/pkgconfig"
+        ## Plugin Environment
+        export PLUGIN_ENVVAR="from_plugin"
+        ## User Environment
+        """.format(
+            new_dir
+        )
+    )

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -18,8 +18,9 @@ import pytest
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
-from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
 from craft_parts.parts import Part
+from craft_parts.steps import Step
 
 _MOCK_NATIVE_ARCH = "aarch64"
 
@@ -132,3 +133,39 @@ def test_part_info_invalid_custom_args():
     with pytest.raises(AttributeError) as raised:
         print(x.custom1)
     assert str(raised.value) == "'PartInfo' has no attribute 'custom1'"
+
+
+def test_step_info(new_dir):
+    info = ProjectInfo(custom1="foobar", custom2=[1, 2])
+    part = Part("foo", {})
+    part_info = PartInfo(project_info=info, part=part)
+    x = StepInfo(part_info=part_info, step=Step.BUILD)
+
+    assert x.application_name == "craft_parts"
+    assert x.parallel_build_count == 1
+
+    assert x.part_name == "foo"
+    assert x.part_src_dir == new_dir / "parts/foo/src"
+    assert x.part_src_subdir == new_dir / "parts/foo/src"
+    assert x.part_build_dir == new_dir / "parts/foo/build"
+    assert x.part_build_subdir == new_dir / "parts/foo/build"
+    assert x.part_install_dir == new_dir / "parts/foo/install"
+    assert x.stage_dir == new_dir / "stage"
+    assert x.prime_dir == new_dir / "prime"
+
+    assert x.step == Step.BUILD
+
+    assert x.custom_args == ["custom1", "custom2"]
+    assert x.custom1 == "foobar"
+    assert x.custom2 == [1, 2]
+
+
+def test_step_info_invalid_custom_args():
+    info = ProjectInfo()
+    part = Part("foo", {})
+    part_info = PartInfo(project_info=info, part=part)
+    x = StepInfo(part_info=part_info, step=Step.PULL)
+
+    with pytest.raises(AttributeError) as raised:
+        print(x.custom1)
+    assert str(raised.value) == "'StepInfo' has no attribute 'custom1'"

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -58,6 +58,127 @@ class TestTimedWriter:
         mock_sleep.assert_called_with(pytest.approx(0.015, 0.00001))
 
 
+#    paths = (os.path.join("usr", "sbin"), os.path.join("usr", "bin"), "sbin", "bin")
+
+
+class TestGetPaths:
+    """Verify functions that get lists of system paths."""
+
+    def test_get_bin_paths_null(self, new_dir):
+        x = os_utils.get_bin_paths(root=new_dir)
+        assert x == []
+
+    def test_get_bin_paths_exist(self, new_dir):
+        for directory in ["usr/sbin", "usr/bin", "sbin", "bin", "other"]:
+            Path(directory).mkdir(parents=True)
+
+        x = os_utils.get_bin_paths(root=new_dir)
+
+        assert x == [
+            f"{new_dir}/usr/sbin",
+            f"{new_dir}/usr/bin",
+            f"{new_dir}/sbin",
+            f"{new_dir}/bin",
+        ]
+
+    def test_get_bin_paths_not_exist(self):
+        x = os_utils.get_bin_paths(root="/invalid", existing_only=False)
+        assert x == [
+            "/invalid/usr/sbin",
+            "/invalid/usr/bin",
+            "/invalid/sbin",
+            "/invalid/bin",
+        ]
+
+    def test_get_include_paths_null(self):
+        x = os_utils.get_include_paths(root="/invalid", arch_triplet="my-arch-triplet")
+        assert x == []
+
+    def test_get_include_paths(self, new_dir):
+        for directory in [
+            "include",
+            "usr/include",
+            "include/my-arch-triplet",
+            "usr/include/my-arch-triplet",
+            "something/else",
+        ]:
+            Path(directory).mkdir(parents=True)
+
+        x = os_utils.get_include_paths(root=new_dir, arch_triplet="my-arch-triplet")
+        assert x == [
+            f"{new_dir}/include",
+            f"{new_dir}/usr/include",
+            f"{new_dir}/include/my-arch-triplet",
+            f"{new_dir}/usr/include/my-arch-triplet",
+        ]
+
+    def test_get_library_paths_null(self):
+        x = os_utils.get_library_paths(root="/invalid", arch_triplet="my-arch-triplet")
+        assert x == []
+
+    def test_get_library_paths_exist(self, new_dir):
+        for directory in [
+            "lib",
+            "usr/lib",
+            "lib/my-arch-triplet",
+            "usr/lib/my-arch-triplet",
+            "other",
+        ]:
+            Path(directory).mkdir(parents=True)
+
+        x = os_utils.get_library_paths(root=new_dir, arch_triplet="my-arch-triplet")
+
+        assert x == [
+            f"{new_dir}/lib",
+            f"{new_dir}/usr/lib",
+            f"{new_dir}/lib/my-arch-triplet",
+            f"{new_dir}/usr/lib/my-arch-triplet",
+        ]
+
+    def test_get_library_paths_not_exist(self):
+        x = os_utils.get_library_paths(
+            root="/invalid", arch_triplet="my-arch-triplet", existing_only=False
+        )
+        assert x == [
+            "/invalid/lib",
+            "/invalid/usr/lib",
+            "/invalid/lib/my-arch-triplet",
+            "/invalid/usr/lib/my-arch-triplet",
+        ]
+
+    def test_get_pkg_config_paths_null(self):
+        x = os_utils.get_pkg_config_paths(
+            root="/invalid", arch_triplet="my-arch-triplet"
+        )
+        assert x == []
+
+    def test_get_pkg_config_paths(self, new_dir):
+        for directory in [
+            "lib/pkgconfig",
+            "lib/my-arch-triplet/pkgconfig",
+            "usr/lib/pkgconfig",
+            "usr/lib/my-arch-triplet/pkgconfig",
+            "usr/share/pkgconfig",
+            "usr/local/lib/pkgconfig",
+            "usr/local/lib/my-arch-triplet/pkgconfig",
+            "usr/local/share/pkgconfig",
+            "something/else",
+        ]:
+            Path(directory).mkdir(parents=True)
+
+        x = os_utils.get_pkg_config_paths(root=new_dir, arch_triplet="my-arch-triplet")
+        assert x == [
+            f"{new_dir}/lib/pkgconfig",
+            f"{new_dir}/lib/my-arch-triplet/pkgconfig",
+            f"{new_dir}/usr/lib/pkgconfig",
+            f"{new_dir}/usr/lib/my-arch-triplet/pkgconfig",
+            f"{new_dir}/usr/share/pkgconfig",
+            f"{new_dir}/usr/local/lib/pkgconfig",
+            f"{new_dir}/usr/local/lib/my-arch-triplet/pkgconfig",
+            f"{new_dir}/usr/local/share/pkgconfig",
+        ]
+
+
 class TestTerminal:
     """Tests for terminal-related utilities."""
 


### PR DESCRIPTION
Generate a list of environment variables to be set at step execution,
using built-in, plugin, and user-defined variables from the part
specification.

Environment generation logic ported from snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
