### PR TITLE
executor: add file organization support

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -269,3 +269,18 @@ class FilesetConflict(PartsError):
         )
 
         super().__init__(brief=brief, details=details, resolution=resolution)
+
+
+class FileOrganizeError(PartsError):
+    """Failed to organize a file layout.
+
+    :param part_name: The name of the part being processed.
+    :param message: The error message.
+    """
+
+    def __init__(self, *, part_name, message):
+        self.part_name = part_name
+        self.message = message
+        brief = f"Failed to organize part {part_name!r}: {message}."
+
+        super().__init__(brief=brief)

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Handle part files organization.
+
+Installed part files can be reorganized according to a mapping specified
+under the `organize` entry in a part definition. In the key/value pair,
+the key represents the path of a file inside the part and the value
+represents how the file is going to be staged.
+"""
+
+import contextlib
+import os
+import shutil
+from glob import iglob
+from pathlib import Path
+from typing import Dict
+
+from craft_parts import errors
+from craft_parts.utils import file_utils
+
+
+def organize_files(
+    *, part_name: str, mapping: Dict[str, str], base_dir: Path, overwrite: bool
+) -> None:
+    """Rearrange files for part staging.
+
+    :param fileset: A fileset containing the `organize` file mapping.
+    :param base_dir: Where the installed files are located.
+    :param overwrite: Whether existing files should be overwritten.
+    """
+    for key in sorted(mapping, key=lambda x: ["*" in x, x]):
+        src = os.path.join(base_dir, key)
+        # Remove the leading slash so the path actually joins
+        # Also trailing slash is significant, be careful if using pathlib!
+        dst = os.path.join(base_dir, mapping[key].lstrip("/"))
+
+        sources = iglob(src, recursive=True)
+
+        # Keep track of the number of glob expansions so we can properly error if more
+        # than one tries to organize to the same file
+        src_count = 0
+        for src in sources:
+            src_count += 1
+
+            if os.path.isdir(src) and "*" not in key:
+                file_utils.link_or_copy_tree(src, dst)
+                # TODO create alternate organization location to avoid
+                # deletions.
+                shutil.rmtree(src)
+                continue
+
+            if os.path.isfile(dst):
+                if overwrite and src_count <= 1:
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(dst)
+                elif src_count > 1:
+                    raise errors.FileOrganizeError(
+                        part_name=part_name,
+                        message=(
+                            "multiple files to be organized into {!r}. If this is "
+                            "supposed to be a directory, end it with a slash.".format(
+                                os.path.relpath(dst, base_dir)
+                            )
+                        ),
+                    )
+                else:
+                    raise errors.FileOrganizeError(
+                        part_name=part_name,
+                        message=(
+                            "trying to organize file {key!r} to {dst!r}, but {dst!r} "
+                            "already exists".format(
+                                key=key, dst=os.path.relpath(dst, base_dir)
+                            )
+                        ),
+                    )
+
+            if os.path.isdir(dst) and overwrite:
+                real_dst = os.path.join(dst, os.path.basename(src))
+                if os.path.isdir(real_dst):
+                    shutil.rmtree(real_dst)
+                else:
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(real_dst)
+
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.move(src, dst)

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -40,7 +40,9 @@ def organize_files(
 
     :param fileset: A fileset containing the `organize` file mapping.
     :param base_dir: Where the installed files are located.
-    :param overwrite: Whether existing files should be overwritten.
+    :param overwrite: Whether existing files should be overwritten. This is
+        only used in build updates, when a part may organize over files
+        it previously organized.
     """
     for key in sorted(mapping, key=lambda x: ["*" in x, x]):
         src = os.path.join(base_dir, key)

--- a/tests/unit/executor/test_organize.py
+++ b/tests/unit/executor/test_organize.py
@@ -1,0 +1,227 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.executor.organize import organize_files
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # simple_file
+        dict(
+            setup_dirs=[],
+            setup_files=["foo"],
+            organize_map={"foo": "bar"},
+            expected=[(["bar"], "")],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # simple_dir_with_file
+        dict(
+            setup_dirs=["foodir"],
+            setup_files=[os.path.join("foodir", "foo")],
+            organize_map={"foodir": "bardir"},
+            expected=[(["bardir"], ""), (["foo"], "bardir")],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # organize_to_the_same_directory
+        dict(
+            setup_dirs=["bardir", "foodir"],
+            setup_files=[
+                os.path.join("foodir", "foo"),
+                os.path.join("bardir", "bar"),
+                "basefoo",
+            ],
+            organize_map={
+                "foodir": "bin",
+                "bardir": "bin",
+                "basefoo": "bin/basefoo",
+            },
+            expected=[(["bin"], ""), (["bar", "basefoo", "foo"], "bin")],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # leading_slash_in_value
+        dict(
+            setup_dirs=[],
+            setup_files=["foo"],
+            organize_map={"foo": "/bar"},
+            expected=[(["bar"], "")],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # overwrite_existing_file
+        dict(
+            setup_dirs=[],
+            setup_files=["foo", "bar"],
+            organize_map={"foo": "bar"},
+            expected=errors.FileOrganizeError,
+            expected_message=(
+                r".*trying to organize file 'foo' to 'bar', but 'bar' already exists.*"
+            ),
+            expected_overwrite=[(["bar"], "")],
+        ),
+        # *_for_files
+        dict(
+            setup_dirs=[],
+            setup_files=["foo.conf", "bar.conf"],
+            organize_map={"*.conf": "dir/"},
+            expected=[(["dir"], ""), (["bar.conf", "foo.conf"], "dir")],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # *_for_files_with_non_dir_dst
+        dict(
+            setup_dirs=[],
+            setup_files=["foo.conf", "bar.conf"],
+            organize_map={"*.conf": "dir"},
+            expected=errors.FileOrganizeError,
+            expected_message=r".*multiple files to be organized into 'dir'.*",
+            expected_overwrite=None,
+        ),
+        # *_for_directories
+        dict(
+            setup_dirs=["dir1", "dir2"],
+            setup_files=[
+                os.path.join("dir1", "foo"),
+                os.path.join("dir2", "bar"),
+            ],
+            organize_map={"dir*": "dir/"},
+            expected=[
+                (["dir"], ""),
+                (["dir1", "dir2"], "dir"),
+                (["foo"], os.path.join("dir", "dir1")),
+                (["bar"], os.path.join("dir", "dir2")),
+            ],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # combined_*_with_file
+        dict(
+            setup_dirs=["dir1", "dir2"],
+            setup_files=[
+                os.path.join("dir1", "foo"),
+                os.path.join("dir1", "bar"),
+                os.path.join("dir2", "bar"),
+            ],
+            organize_map={"dir*": "dir/", "dir1/bar": "."},
+            expected=[
+                (["bar", "dir"], ""),
+                (["dir1", "dir2"], "dir"),
+                (["foo"], os.path.join("dir", "dir1")),
+                (["bar"], os.path.join("dir", "dir2")),
+            ],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+        # *_into_dir
+        dict(
+            setup_dirs=["dir"],
+            setup_files=[
+                os.path.join("dir", "foo"),
+                os.path.join("dir", "bar"),
+            ],
+            organize_map={"dir/f*": "nested/dir/"},
+            expected=[
+                (["dir", "nested"], ""),
+                (["bar"], "dir"),
+                (["dir"], "nested"),
+                (["foo"], os.path.join("nested", "dir")),
+            ],
+            expected_message=None,
+            expected_overwrite=None,
+        ),
+    ],
+)
+def test_organize(new_dir, data):
+    _organize_and_assert(
+        tmp_path=new_dir,
+        setup_dirs=data["setup_dirs"],
+        setup_files=data["setup_files"],
+        organize_map=data["organize_map"],
+        expected=data["expected"],
+        expected_message=data["expected_message"],
+        expected_overwrite=data["expected_overwrite"],
+        overwrite=False,
+    )
+
+    # Verify that it can be organized again by overwriting
+    _organize_and_assert(
+        tmp_path=new_dir,
+        setup_dirs=data["setup_dirs"],
+        setup_files=data["setup_files"],
+        organize_map=data["organize_map"],
+        expected=data["expected"],
+        expected_message=data["expected_message"],
+        expected_overwrite=data["expected_overwrite"],
+        overwrite=True,
+    )
+
+
+def _organize_and_assert(
+    *,
+    tmp_path: Path,
+    setup_dirs,
+    setup_files,
+    organize_map,
+    expected: List[Any],
+    expected_message,
+    expected_overwrite,
+    overwrite,
+):
+    base_dir = Path(tmp_path / "install")
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    for directory in setup_dirs:
+        (base_dir / directory).mkdir(exist_ok=True)
+
+    for file_entry in setup_files:
+        (base_dir / file_entry).touch()
+
+    if overwrite and expected_overwrite is not None:
+        expected = expected_overwrite
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected) as error:  # type: ignore
+            organize_files(
+                part_name="part-name",
+                mapping=organize_map,
+                base_dir=base_dir,
+                overwrite=overwrite,
+            )
+        assert re.match(expected_message, str(error)) is not None
+
+    else:
+        organize_files(
+            part_name="part-name",
+            mapping=organize_map,
+            base_dir=base_dir,
+            overwrite=overwrite,
+        )
+        for expect in expected:
+            dir_path = (base_dir / expect[1]).as_posix()
+            dir_contents = os.listdir(dir_path)
+            dir_contents.sort()
+            assert dir_contents == expect[0]

--- a/tests/unit/executor/test_organize.py
+++ b/tests/unit/executor/test_organize.py
@@ -204,14 +204,14 @@ def _organize_and_assert(
         expected = expected_overwrite
 
     if isinstance(expected, type) and issubclass(expected, Exception):
-        with pytest.raises(expected) as error:  # type: ignore
+        with pytest.raises(expected) as raised:  # type: ignore
             organize_files(
                 part_name="part-name",
                 mapping=organize_map,
                 base_dir=base_dir,
                 overwrite=overwrite,
             )
-        assert re.match(expected_message, str(error)) is not None
+        assert re.match(expected_message, str(raised.value)) is not None
 
     else:
         organize_files(

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -205,3 +205,12 @@ def test_fileset_conflict():
     assert err.resolution == (
         "Make sure that the files included in 'prime' are also included in 'stage'."
     )
+
+
+def test_file_organize_error():
+    err = errors.FileOrganizeError(part_name="foo", message="not ready reading drive A")
+    assert err.part_name == "foo"
+    assert err.message == "not ready reading drive A"
+    assert err.brief == "Failed to organize part 'foo': not ready reading drive A."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Parts can rearrange file locations according to a dictionary
provided in the `organize` property. This change implements
the file organization feature.

Organize logic and accompanying tests ported from Snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
