### PR TITLE
executor: add the step handler

### DIFF
--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -342,6 +342,7 @@ def _fix_pkg_config(
     :param pkg_config_file: The pkg-config file to process.
     :param prefix_trim: The initial path to remove from the configuration prefix.
     """
+    # FIXME: see https://bugs.launchpad.net/snapcraft/+bug/1916281
     pattern_trim = None
     if prefix_trim:
         pattern_trim = re.compile("^prefix={}(?P<prefix>.*)".format(prefix_trim))

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -1,0 +1,361 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2016-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Handle the execution of built-in or user specified step commands."""
+
+import fileinput
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from collections import namedtuple
+from pathlib import Path
+from typing import List, Optional, Set, Union
+
+from craft_parts import errors
+from craft_parts.executor import collisions
+from craft_parts.infos import StepInfo
+from craft_parts.parts import Part
+from craft_parts.plugins import Plugin
+from craft_parts.sources import SourceHandler
+from craft_parts.steps import Step
+from craft_parts.utils import file_utils
+
+from . import environment, filesets
+from .filesets import Fileset
+
+FilesAndDirs = namedtuple("FilesAndDirs", ["files", "dirs"])
+
+
+class StepHandler:
+    """Executes built-in or user-specified step commands.
+
+    The step handler takes care of the execution of a step, using either
+    a built-in set of actions to be taken, or executing a user-defined
+    script defined in the part specification User-defined scripts may also
+    call the built-in handler for a step by invoking a control utility.
+    This class implements the built-in handlers and a FIFO-based mechanism
+    and API to be used by the external control utility to communicate with
+    the running instance.
+    """
+
+    def __init__(
+        self,
+        part: Part,
+        *,
+        step_info: StepInfo,
+        plugin: Plugin,
+        source_handler: Optional[SourceHandler],
+    ):
+        self._part = part
+        self._step_info = step_info
+        self._plugin = plugin
+        self._source_handler = source_handler
+        self._env = environment.generate_part_environment(
+            part=part, plugin=plugin, step_info=step_info
+        )
+
+    def run_builtin(self) -> FilesAndDirs:
+        """Run the built-in commands for the current step."""
+        step = self._step_info.step
+        if step == Step.PULL:
+            handler = self._builtin_pull
+        elif step == Step.BUILD:
+            handler = self._builtin_build
+        elif step == Step.STAGE:
+            handler = self._builtin_stage
+        elif step == Step.PRIME:
+            handler = self._builtin_prime
+        else:
+            raise RuntimeError(
+                "Request to run the built-in handler for an invalid step."
+            )
+
+        return handler()
+
+    def _builtin_pull(self) -> FilesAndDirs:
+        if self._source_handler:
+            self._source_handler.pull()
+        return FilesAndDirs(set(), set())
+
+    def _builtin_build(self) -> FilesAndDirs:
+
+        # Plugin commands.
+        plugin_build_commands = self._plugin.get_build_commands()
+
+        # Save script to execute.
+        build_script_path = self._part.part_run_dir.absolute() / "build.sh"
+        with build_script_path.open("w") as run_file:
+            print(self._env, file=run_file)
+            print("set -x", file=run_file)
+
+            for build_command in plugin_build_commands:
+                print(build_command, file=run_file)
+
+        build_script_path.chmod(0o755)
+
+        try:
+            subprocess.run(
+                [build_script_path], check=True, cwd=self._part.part_build_subdir
+            )
+        except subprocess.CalledProcessError as process_error:
+            raise errors.PluginBuildError(part_name=self._part.name) from process_error
+
+        return FilesAndDirs(set(), set())
+
+    def _builtin_stage(self) -> FilesAndDirs:
+        stage_fileset = Fileset(self._part.spec.stage_files, name="stage")
+        srcdir = str(self._part.part_install_dir)
+        files, dirs = filesets.migratable_filesets(stage_fileset, srcdir)
+
+        def pkgconfig_fixup(file_path):
+            if os.path.islink(file_path):
+                return
+            if not file_path.endswith(".pc"):
+                return
+            _fix_pkg_config(
+                root=self._part.stage_dir,
+                pkg_config_file=file_path,
+                prefix_trim=self._part.part_install_dir,
+            )
+
+        _migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir=str(self._part.part_install_dir),
+            destdir=str(self._part.stage_dir),
+            fixup_func=pkgconfig_fixup,
+        )
+        return FilesAndDirs(files, dirs)
+
+    def _builtin_prime(self) -> FilesAndDirs:
+        prime_fileset = Fileset(self._part.spec.prime_files, name="prime")
+
+        # If we're priming and we don't have an explicit set of files to prime
+        # include the files from the stage step
+        if prime_fileset.entries == ["*"] or len(prime_fileset.includes) == 0:
+            stage_fileset = Fileset(self._part.spec.stage_files, name="stage")
+            prime_fileset.combine(stage_fileset)
+
+        srcdir = str(self._part.part_install_dir)
+        files, dirs = filesets.migratable_filesets(prime_fileset, srcdir)
+        _migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir=str(self._part.stage_dir),
+            destdir=str(self._part.prime_dir),
+        )
+        # TODO: handle elf dependencies
+
+        return FilesAndDirs(files, dirs)
+
+    def run_scriptlet(
+        self, scriptlet: str, *, scriptlet_name: str, work_dir: Path
+    ) -> None:
+        """Execute a scriptlet.
+
+        :param scriptlet: the scriptlet to run.
+        :param work_dir: the directory where the script will be executed.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            call_fifo = file_utils.NonBlockingRWFifo(
+                os.path.join(tempdir, "function_call")
+            )
+            feedback_fifo = file_utils.NonBlockingRWFifo(
+                os.path.join(tempdir, "call_feedback")
+            )
+
+            # the ctl client only works consistently if it's using the exact same
+            # interpreter as that used by the server, thus the definition of
+            # PARTS_INTERPRETER.
+            script = textwrap.dedent(
+                """\
+                set -e
+                export PARTS_CALL_FIFO={call_fifo}
+                export PARTS_FEEDBACK_FIFO={feedback_fifo}
+                export PARTS_INTERPRETER={interpreter}
+
+                {env}
+
+                {scriptlet}"""
+            ).format(
+                interpreter=sys.executable,
+                call_fifo=call_fifo.path,
+                feedback_fifo=feedback_fifo.path,
+                scriptlet=scriptlet,
+                env=self._env,
+            )
+
+            # FIXME: refactor ctl protocol server
+
+            with tempfile.TemporaryFile(mode="w+") as script_file:
+                print(script, file=script_file)
+                script_file.flush()
+                script_file.seek(0)
+                process = subprocess.Popen(  # pylint: disable=consider-using-with
+                    ["/bin/sh"], stdin=script_file, cwd=work_dir
+                )
+
+            status = None
+            try:
+                while status is None:
+                    function_call = call_fifo.read()
+                    if function_call:
+                        # Handle the function and let caller know that function
+                        # call has been handled (must contain at least a
+                        # newline, anything beyond is considered an error by
+                        # snapcraftctl)
+                        self._handle_control_api(scriptlet_name, function_call.strip())
+                        feedback_fifo.write("\n")
+
+                    status = process.poll()
+
+                    # Don't loop TOO busily
+                    time.sleep(0.1)
+            except Exception as error:
+                feedback_fifo.write(f"{error!s}\n")
+                raise error
+            finally:
+                call_fifo.close()
+                feedback_fifo.close()
+
+            if process.returncode != 0:
+                raise errors.ScriptletRunError(
+                    part_name=self._part.name,
+                    scriptlet_name=scriptlet_name,
+                    exit_code=status,
+                )
+
+    def _handle_control_api(self, scriptlet_name, function_call) -> None:
+        """Parse the message from the client and invoke the appropriate action."""
+        try:
+            function_json = json.loads(function_call)
+        except json.decoder.JSONDecodeError as err:
+            raise RuntimeError(
+                "{!r} scriptlet called a function with invalid json: "
+                "{}".format(scriptlet_name, function_call)
+            ) from err
+
+        for attr in ["function", "args"]:
+            if attr not in function_json:
+                raise RuntimeError(
+                    f"{scriptlet_name!r} control call missing attribute {attr!r}"
+                )
+
+        function_name = function_json["function"]
+
+        if function_name == "pull":
+            self._builtin_pull()
+        elif function_name == "build":
+            self._builtin_build()
+        elif function_name == "stage":
+            self._builtin_stage()
+        elif function_name == "prime":
+            self._builtin_prime()
+        else:
+            raise errors.InvalidControlAPICall(
+                part_name=self._part.name,
+                scriptlet_name=scriptlet_name,
+                message=f"invalid function {function_name!r}",
+            )
+
+
+def _migrate_files(
+    *,
+    files: Set[str],
+    dirs: Set[str],
+    srcdir: str,
+    destdir: str,
+    missing_ok: bool = False,
+    follow_symlinks: bool = False,
+    fixup_func=lambda *args: None,
+):
+    for dirname in sorted(dirs):
+        src = os.path.join(srcdir, dirname)
+        dst = os.path.join(destdir, dirname)
+
+        file_utils.create_similar_directory(src, dst)
+
+    for filename in sorted(files):
+        src = os.path.join(srcdir, filename)
+        dst = os.path.join(destdir, filename)
+
+        if missing_ok and not os.path.exists(src):
+            continue
+
+        # If the file is already here and it's a symlink, leave it alone.
+        if os.path.islink(dst):
+            continue
+
+        # Otherwise, remove and re-link it.
+        if os.path.exists(dst):
+            os.remove(dst)
+
+        file_utils.link_or_copy(src, dst, follow_symlinks=follow_symlinks)
+
+        fixup_func(dst)
+
+
+def _check_conflicts(
+    part_name: str, srcdir: str, destdir: str, files: List[str]
+) -> None:
+    conflict_files: List[str] = []
+
+    for filename in files:
+        src = os.path.join(srcdir, filename)
+        dst = os.path.join(destdir, filename)
+
+        if collisions.paths_collide(src, dst):
+            conflict_files.append(filename)
+
+    if conflict_files:
+        raise errors.StageFilesConflict(
+            part_name=part_name, conflicting_files=conflict_files
+        )
+
+
+def _fix_pkg_config(
+    root: Union[str, Path],
+    pkg_config_file: Union[str, Path],
+    prefix_trim: Optional[Union[str, Path]] = None,
+) -> None:
+    """Rewrite the prefix entry in a pkg-config file.
+
+    :param root: The root to add to the configuration prefix.
+    :param pkg_config_file: The pkg-config file to process.
+    :param prefix_trim: The initial path to remove from the configuration prefix.
+    """
+    pattern_trim = None
+    if prefix_trim:
+        pattern_trim = re.compile("^prefix={}(?P<prefix>.*)".format(prefix_trim))
+    pattern = re.compile("^prefix=(?P<prefix>.*)")
+
+    with fileinput.input(pkg_config_file, inplace=True) as input_file:
+        match_trim = None
+        for line in input_file:
+            match = pattern.search(str(line))
+            if prefix_trim is not None and pattern_trim is not None:
+                match_trim = pattern_trim.search(str(line))
+            if prefix_trim is not None and match_trim is not None:
+                print("prefix={}{}".format(root, match_trim.group("prefix")))
+            elif match:
+                print("prefix={}{}".format(root, match.group("prefix")))
+            else:
+                print(line, end="")

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -209,6 +209,11 @@ class Part:
         return self._part_dir / "stage_snaps"
 
     @property
+    def part_run_dir(self) -> Path:
+        """Return the subdirectory containing the part plugin scripts."""
+        return self._part_dir / "run"
+
+    @property
     def stage_dir(self) -> Path:
         """Return the staging area containing the installed files from all parts."""
         return self._dirs.stage_dir

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -1,0 +1,411 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import stat
+from pathlib import Path
+from typing import Dict, List, Set
+
+import pytest
+
+from craft_parts import plugins, sources
+from craft_parts.dirs import ProjectDirs
+from craft_parts.executor import filesets, step_handler
+from craft_parts.executor.filesets import Fileset
+from craft_parts.executor.step_handler import FilesAndDirs, StepHandler
+from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+
+class FooPlugin(plugins.Plugin):
+    """A test plugin."""
+
+    properties_class = plugins.PluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return ["hello"]
+
+
+def _step_handler_for_step(step: Step) -> StepHandler:
+    p1 = Part("p1", {"source": "."})
+    dirs = ProjectDirs()
+    info = ProjectInfo(project_dirs=dirs)
+    part_info = PartInfo(project_info=info, part=p1)
+    step_info = StepInfo(part_info=part_info, step=step)
+    props = plugins.PluginProperties()
+    plugin = FooPlugin(properties=props, part_info=part_info)
+    source_handler = sources.get_source_handler(
+        application_name="test",
+        part=p1,
+        project_dirs=dirs,
+    )
+
+    return StepHandler(
+        part=p1,
+        step_info=step_info,
+        plugin=plugin,
+        source_handler=source_handler,
+    )
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestStepHandlerBuiltins:
+    """Verify the built-in handlers."""
+
+    def test_run_builtin_pull(self, mocker):
+        mock_source_pull = mocker.patch(
+            "craft_parts.sources.local_source.LocalSource.pull"
+        )
+
+        sh = _step_handler_for_step(Step.PULL)
+        result = sh.run_builtin()
+
+        mock_source_pull.assert_called_once_with()
+        assert result == (set(), set())
+
+    def test_run_builtin_build(self, new_dir, mocker):
+        mock_run = mocker.patch("subprocess.run")
+
+        Path("parts/p1/run").mkdir(parents=True)
+        sh = _step_handler_for_step(Step.BUILD)
+        result = sh.run_builtin()
+
+        mock_run.assert_called_once_with(
+            [Path(new_dir / "parts/p1/run/build.sh")],
+            check=True,
+            cwd=Path(new_dir / "parts/p1/build"),
+        )
+        assert result == (set(), set())
+
+    def test_run_builtin_stage(self, mocker):
+        Path("parts/p1/install").mkdir(parents=True)
+        Path("parts/p1/install/subdir").mkdir(parents=True)
+        Path("parts/p1/install/foo").write_text("content")
+        Path("parts/p1/install/subdir/bar").write_text("content")
+        Path("stage").mkdir()
+        sh = _step_handler_for_step(Step.STAGE)
+        result = sh.run_builtin()
+
+        assert result == FilesAndDirs(files={"subdir/bar", "foo"}, dirs={"subdir"})
+
+    def test_run_builtin_prime(self, mocker):
+        Path("parts/p1/install").mkdir(parents=True)
+        Path("parts/p1/install/subdir").mkdir(parents=True)
+        Path("parts/p1/install/foo").write_text("content")
+        Path("parts/p1/install/subdir/bar").write_text("content")
+        Path("stage/subdir").mkdir(parents=True)
+        Path("stage/foo").write_text("content")
+        Path("stage/subdir/bar").write_text("content")
+        sh = _step_handler_for_step(Step.PRIME)
+        result = sh.run_builtin()
+
+        assert result == FilesAndDirs(files={"subdir/bar", "foo"}, dirs={"subdir"})
+
+    def test_run_builtin_invalid(self):
+        sh = _step_handler_for_step(999)  # type: ignore
+        with pytest.raises(RuntimeError) as raised:
+            sh.run_builtin()
+        assert str(raised.value) == (
+            "Request to run the built-in handler for an invalid step."
+        )
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestStepHandlerRunScriptlet:
+    """Verify the scriptlet runner."""
+
+    def test_run_scriptlet(self, new_dir, capfd):
+        sh = _step_handler_for_step(Step.PULL)
+        sh.run_scriptlet("echo hello world", scriptlet_name="name", work_dir=new_dir)
+        captured = capfd.readouterr()
+        assert captured.out == "hello world\n"
+
+    # TODO: test ctl api server
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestFileMigration:
+    """Verify different migration scenarios."""
+
+    def test_migrate_files_already_exists(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        # Place the already-staged file
+        with open("stage/foo", "w") as f:
+            f.write("staged")
+
+        # Place the to-be-staged file with the same name
+        with open("install/foo", "w") as f:
+            f.write("installed")
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the staged file is the one that was staged last
+        with open("stage/foo", "r") as f:
+            assert (
+                f.read() == "installed"
+            ), "Expected staging to allow overwriting of already-staged files"
+
+    def test_migrate_files_supports_no_follow_symlinks(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir="install",
+            destdir="stage",
+            follow_symlinks=False,
+        )
+
+        # Verify that the symlink was preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'bar' to still be a symlink."
+
+        assert (
+            os.readlink(os.path.join("stage", "bar")) == "foo"
+        ), "Expected migrated 'bar' to point to 'foo'"
+
+    def test_migrate_files_preserves_symlink_file(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'sym-a' to be a symlink."
+
+    def test_migrate_files_no_follow_symlinks(self):
+        os.makedirs("install/usr/bin")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "usr", "bin", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("usr/bin", os.path.join("install", "bin"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["-usr"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert files == {"bin"}
+        assert dirs == set()
+
+        assert os.path.islink(
+            os.path.join("stage", "bin")
+        ), "Expected migrated 'bin' to be a symlink."
+
+    def test_migrate_files_preserves_symlink_nested_file(self):
+        os.makedirs(os.path.join("install", "a"))
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "a", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink(os.path.join("a", "foo"), os.path.join("install", "bar"))
+        os.symlink(os.path.join("foo"), os.path.join("install", "a", "bar"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'sym-a' to be a symlink."
+
+        assert os.path.islink(
+            os.path.join("stage", "a", "bar")
+        ), "Expected migrated 'a/bar' to be a symlink."
+
+    def test_migrate_files_preserves_symlink_empty_dir(self):
+        os.makedirs(os.path.join("install", "foo"))
+        os.makedirs("stage")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'bar' to be a symlink."
+
+    def test_migrate_files_preserves_symlink_nonempty_dir(self):
+        os.makedirs(os.path.join("install", "foo"))
+        os.makedirs("stage")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        with open(os.path.join("install", "foo", "xfile"), "w") as f:
+            f.write("installed")
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'bar' to be a symlink."
+
+    def test_migrate_files_preserves_symlink_nested_dir(self):
+        os.makedirs(os.path.join("install", "a", "b"))
+        os.makedirs("stage")
+
+        os.symlink(os.path.join("a", "b"), os.path.join("install", "bar"))
+        os.symlink(os.path.join("b"), os.path.join("install", "a", "bar"))
+
+        with open(os.path.join("install", "a", "b", "xfile"), "w") as f:
+            f.write("installed")
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files, dirs=dirs, srcdir="install", destdir="stage"
+        )
+
+        # Verify that the symlinks were preserved
+        assert os.path.islink(
+            os.path.join("stage", "bar")
+        ), "Expected migrated 'bar' to be a symlink."
+
+        assert os.path.islink(
+            os.path.join("stage", "a", "bar")
+        ), "Expected migrated 'a/bar' to be a symlink."
+
+    def test_migrate_files_supports_follow_symlinks(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        with open(os.path.join("install", "foo"), "w") as f:
+            f.write("installed")
+
+        os.symlink("foo", os.path.join("install", "bar"))
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir="install",
+            destdir="stage",
+            follow_symlinks=True,
+        )
+
+        # Verify that the symlink was preserved
+        assert (
+            os.path.islink(os.path.join("stage", "bar")) is False
+        ), "Expected migrated 'bar' to no longer be a symlink."
+
+        with open(os.path.join("stage", "bar"), "r") as f:
+            assert (
+                f.read() == "installed"
+            ), "Expected migrated 'bar' to be a copy of 'foo'"
+
+    def test_migrate_files_preserves_file_mode(self):
+        os.makedirs("install")
+        os.makedirs("stage")
+
+        filepath = os.path.join("install", "foo")
+
+        with open(filepath, "w") as f:
+            f.write("installed")
+
+        mode = os.stat(filepath).st_mode
+
+        new_mode = 0o777
+        os.chmod(filepath, new_mode)
+        assert mode != new_mode
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir="install",
+            destdir="stage",
+            follow_symlinks=True,
+        )
+
+        assert new_mode == stat.S_IMODE(os.stat(os.path.join("stage", "foo")).st_mode)
+
+    # TODO: add test_migrate_files_preserves_file_mode_chown_permissions
+
+    def test_migrate_files_preserves_directory_mode(self):
+        os.makedirs("install/foo")
+        os.makedirs("stage")
+
+        filepath = os.path.join("install", "foo", "bar")
+
+        with open(filepath, "w") as f:
+            f.write("installed")
+
+        mode = os.stat(filepath).st_mode
+
+        new_mode = 0o777
+        assert mode != new_mode
+        os.chmod(os.path.dirname(filepath), new_mode)
+        os.chmod(filepath, new_mode)
+
+        files, dirs = filesets.migratable_filesets(Fileset(["*"]), "install")
+        step_handler._migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir="install",
+            destdir="stage",
+            follow_symlinks=True,
+        )
+
+        assert new_mode == stat.S_IMODE(os.stat(os.path.join("stage", "foo")).st_mode)
+        assert new_mode == stat.S_IMODE(
+            os.stat(os.path.join("stage", "foo", "bar")).st_mode
+        )

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -85,6 +85,7 @@ class TestPartData:
         assert p.part_state_dir == new_dir / "parts/foo/state"
         assert p.part_packages_dir == new_dir / "parts/foo/stage_packages"
         assert p.part_snaps_dir == new_dir / "parts/foo/stage_snaps"
+        assert p.part_run_dir == new_dir / "parts/foo/run"
         assert p.stage_dir == new_dir / "stage"
         assert p.prime_dir == new_dir / "prime"
 
@@ -99,6 +100,7 @@ class TestPartData:
         assert p.part_state_dir == new_dir / "foobar/parts/foo/state"
         assert p.part_packages_dir == new_dir / "foobar/parts/foo/stage_packages"
         assert p.part_snaps_dir == new_dir / "foobar/parts/foo/stage_snaps"
+        assert p.part_run_dir == new_dir / "foobar/parts/foo/run"
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -158,3 +158,6 @@ class TestCopy:
         with pytest.raises(errors.CopyFileNotFound) as raised:
             file_utils.copy("2", "3")
         assert raised.value.name == "2"
+
+
+# TODO: test NonBlockingRWFifo


### PR DESCRIPTION
The step handler takes care of the execution of a step, using either
a built-in set of actions to be taken, or executing a user-defined
script defined in the part specification. User-defined scripts may also
call the built-in handler for a step by invoking a control utility.

This class implements the built-in handlers and a FIFO-based mechanism
and API to be used by the external control utility to communicate with
the running instance.

The control API server is a direct port of the implementation used in
Snapcraft, and should be refactored later.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
