### PR TITLE
executor: add callbacks

### DIFF
--- a/craft_parts/callbacks.py
+++ b/craft_parts/callbacks.py
@@ -1,0 +1,140 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Register and execute callback functions."""
+
+import logging
+from collections import namedtuple
+from typing import Callable, List, Union
+
+from craft_parts import errors
+from craft_parts.infos import ProjectInfo, StepInfo
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+CallbackHook = namedtuple("CallbackHook", ["function", "step_list"])
+
+ExecutionCallback = Callable[[ProjectInfo, List[Part]], None]
+StepCallback = Callable[[StepInfo], bool]
+Callback = Union[ExecutionCallback, StepCallback]
+
+_PROLOGUE_HOOKS: List[CallbackHook] = []
+_EPILOGUE_HOOKS: List[CallbackHook] = []
+_PRE_STEP_HOOKS: List[CallbackHook] = []
+_POST_STEP_HOOKS: List[CallbackHook] = []
+
+logger = logging.getLogger(__name__)
+
+
+def register_prologue(func: ExecutionCallback) -> None:
+    """Register an execution prologue callback function.
+
+    :param func: The callback function to run.
+    """
+    _ensure_not_defined(func, _PROLOGUE_HOOKS)
+    _PROLOGUE_HOOKS.append(CallbackHook(func, None))
+
+
+def register_epilogue(func: ExecutionCallback) -> None:
+    """Register an execution epilogue callback function.
+
+    :param func: The callback function to run.
+    """
+    _ensure_not_defined(func, _EPILOGUE_HOOKS)
+    _EPILOGUE_HOOKS.append(CallbackHook(func, None))
+
+
+def register_pre_step(func: StepCallback, *, step_list: List[Step] = None) -> None:
+    """Register a pre-step callback function.
+
+    :param func: The callback function to run.
+    :param step_list: The steps before which the callback function should run.
+        If not specified, the callback function will be executed before all steps.
+    """
+    _ensure_not_defined(func, _PRE_STEP_HOOKS)
+    _PRE_STEP_HOOKS.append(CallbackHook(func, step_list))
+
+
+def register_post_step(func: StepCallback, *, step_list: List[Step] = None) -> None:
+    """Register a post-step callback function.
+
+    :param func: The callback function to run.
+    :param step_list: The steps after which the callback function should run.
+        If not specified, the callback function will be executed after all steps.
+    """
+    _ensure_not_defined(func, _POST_STEP_HOOKS)
+    _POST_STEP_HOOKS.append(CallbackHook(func, step_list))
+
+
+def clear() -> None:
+    """Clear all existing registered callback functions."""
+    global _PROLOGUE_HOOKS, _EPILOGUE_HOOKS  # pylint: disable=global-statement
+    global _PRE_STEP_HOOKS, _POST_STEP_HOOKS  # pylint: disable=global-statement
+    _PROLOGUE_HOOKS = []
+    _EPILOGUE_HOOKS = []
+    _PRE_STEP_HOOKS = []
+    _POST_STEP_HOOKS = []
+
+
+def run_prologue(project_info: ProjectInfo, *, part_list=List[Part]) -> None:
+    """Run all registered execution prologue callbacks.
+
+    :param project_info: The project information.
+    :param part_list: A list with all parts in the project.
+    """
+    for hook in _PROLOGUE_HOOKS:
+        hook.function(project_info, part_list)
+
+
+def run_epilogue(project_info: ProjectInfo, *, part_list=List[Part]) -> None:
+    """Run all registered execution epilogue callbacks.
+
+    :param project_info: The project information.
+    :param part_list: A list with all parts in the project.
+    """
+    for hook in _EPILOGUE_HOOKS:
+        hook.function(project_info, part_list)
+
+
+def run_pre_step(step_info: StepInfo) -> None:
+    """Run all registered pre-step callback functions.
+
+    :param step_info: the step information to be sent to the callback functions.
+    """
+    return _run_step(hook_list=_PRE_STEP_HOOKS, step_info=step_info)
+
+
+def run_post_step(step_info: StepInfo) -> None:
+    """Run all registered post-step callback functions.
+
+    :param step_info: the step information to be sent to the callback functions.
+    """
+    return _run_step(hook_list=_POST_STEP_HOOKS, step_info=step_info)
+
+
+def _run_step(*, hook_list: List[CallbackHook], step_info: StepInfo):
+    for hook in hook_list:
+        if not hook.step_list or step_info.step in hook.step_list:
+            hook.function(step_info)
+
+
+def _ensure_not_defined(func: Callback, hook_list: List[CallbackHook]):
+    for hook in hook_list:
+        if func == hook.function:
+            raise errors.CallbackRegistrationError(
+                f"callback function {hook.function.__name__!r} "
+                f"is already registered."
+            )

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -379,4 +379,18 @@ class ScriptletRunError(PartsError):
             f"{scriptlet_name!r} in part {part_name!r} failed with code {exit_code}."
         )
         resolution = "Review the scriptlet and make sure it's correct."
+
         super().__init__(brief=brief, resolution=resolution)
+
+
+class CallbackRegistrationError(PartsError):
+    """Error in callback function registration.
+
+    :param message: the error message.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = f"Callback registration error: {message}."
+
+        super().__init__(brief=brief)

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -1,0 +1,1 @@
+# TODO: add callbacks integration test after executor lands

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -1,0 +1,190 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+
+import pytest
+
+from craft_parts import callbacks, errors
+from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+
+def _callback_1(info: StepInfo) -> bool:
+    greet = getattr(info, "greet")
+    print(f"{greet} callback 1")
+    return True
+
+
+def _callback_2(info: StepInfo) -> bool:
+    greet = getattr(info, "greet")
+    print(f"{greet} callback 2")
+    return False
+
+
+def _callback_3(info: ProjectInfo, part_list: List[Part]) -> None:
+    greet = getattr(info, "greet")
+    names = " ".join([x.name for x in part_list])
+    print(f"{greet} callback 3 ({names})")
+
+
+def _callback_4(info: ProjectInfo, part_list: List[Part]) -> None:
+    greet = getattr(info, "greet")
+    names = " ".join([x.name for x in part_list])
+    print(f"{greet} callback 4 ({names})")
+
+
+class TestCallbackRegistration:
+    """Test different scenarios of callback function registration."""
+
+    def setup_method(self):
+        callbacks.clear()
+
+    def test_register_pre_step(self):
+        callbacks.register_pre_step(_callback_1)
+
+        # A callback function shouldn't be registered again
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_pre_step(_callback_1)
+        assert raised.value.message == (
+            "callback function '_callback_1' is already registered."
+        )
+
+        # But we can register a different one
+        callbacks.register_pre_step(_callback_2)
+
+    def test_register_post_step(self):
+        callbacks.register_post_step(_callback_1)
+
+        # A callback function shouldn't be registered again
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_post_step(_callback_1)
+        assert raised.value.message == (
+            "callback function '_callback_1' is already registered."
+        )
+
+        # But we can register a different one
+        callbacks.register_post_step(_callback_2)
+
+    def test_register_prologue(self):
+        callbacks.register_prologue(_callback_3)
+
+        # A callback function shouldn't be registered again
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_prologue(_callback_3)
+        assert raised.value.message == (
+            "callback function '_callback_3' is already registered."
+        )
+
+        # But we can register a different one
+        callbacks.register_prologue(_callback_4)
+
+    def test_register_epilogue(self):
+        callbacks.register_epilogue(_callback_3)
+
+        # A callback function shouldn't be registered again
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_epilogue(_callback_3)
+        assert raised.value.message == (
+            "callback function '_callback_3' is already registered."
+        )
+
+        # But we can register a different one
+        callbacks.register_epilogue(_callback_4)
+
+    def test_register_both_pre_and_post(self):
+        callbacks.register_pre_step(_callback_1)
+        callbacks.register_post_step(_callback_1)
+
+    def test_register_both_prologue_and_epilogue(self):
+        callbacks.register_prologue(_callback_3)
+        callbacks.register_epilogue(_callback_3)
+
+    def test_clear(self):
+        callbacks.register_pre_step(_callback_1)
+        callbacks.register_post_step(_callback_1)
+        callbacks.register_prologue(_callback_3)
+        callbacks.register_epilogue(_callback_3)
+        callbacks.clear()
+        callbacks.register_pre_step(_callback_1)
+        callbacks.register_post_step(_callback_1)
+        callbacks.register_prologue(_callback_3)
+        callbacks.register_epilogue(_callback_3)
+
+    def test_register_steps(self):
+        callbacks.register_pre_step(_callback_1, step_list=[Step.PULL, Step.BUILD])
+
+        # A callback function shouldn't be registered again, even for a different step
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_pre_step(_callback_1, step_list=[Step.PRIME])
+        assert raised.value.message == (
+            "callback function '_callback_1' is already registered."
+        )
+
+
+class TestCallbackExecution:
+    """Test different scenarios of callback function execution."""
+
+    # pylint: disable=attribute-defined-outside-init
+    def setup_method(self):
+        part = Part("foo", {})
+        self._project_info = ProjectInfo(
+            application_name="test",
+            target_arch="x86_64",
+            parallel_build_count=4,
+            local_plugins_dir=None,
+            greet="hello",
+        )
+        self._part_info = PartInfo(project_info=self._project_info, part=part)
+        self._step_info = StepInfo(part_info=self._part_info, step=Step.BUILD)
+        callbacks.clear()
+
+    def test_run_pre_step(self, capfd):
+        callbacks.register_pre_step(_callback_1)
+        callbacks.register_pre_step(_callback_2)
+        callbacks.run_pre_step(self._step_info)
+        out, err = capfd.readouterr()
+        assert not err
+        assert out == "hello callback 1\nhello callback 2\n"
+
+    def test_run_post_step(self, capfd):
+        callbacks.register_post_step(_callback_1)
+        callbacks.register_post_step(_callback_2)
+        callbacks.run_post_step(self._step_info)
+        out, err = capfd.readouterr()
+        assert not err
+        assert out == "hello callback 1\nhello callback 2\n"
+
+    def test_run_prologue(self, capfd):
+        part1 = Part("p1", {})
+        part2 = Part("p2", {})
+        callbacks.register_prologue(_callback_3)
+        callbacks.register_prologue(_callback_4)
+        callbacks.run_prologue(self._project_info, part_list=[part1, part2])
+        out, err = capfd.readouterr()
+        assert not err
+        assert out == "hello callback 3 (p1 p2)\nhello callback 4 (p1 p2)\n"
+
+    def test_run_epilogue(self, capfd):
+        part1 = Part("p1", {})
+        part2 = Part("p2", {})
+        callbacks.register_epilogue(_callback_3)
+        callbacks.register_epilogue(_callback_4)
+        callbacks.run_epilogue(self._project_info, part_list=[part1, part2])
+        out, err = capfd.readouterr()
+        assert not err
+        assert out == "hello callback 3 (p1 p2)\nhello callback 4 (p1 p2)\n"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -285,3 +285,11 @@ def test_scriptlet_run_error():
     assert err.brief == "'override-build' in part 'foo' failed with code 42."
     assert err.details is None
     assert err.resolution == "Review the scriptlet and make sure it's correct."
+
+
+def test_callback_registration_error():
+    err = errors.CallbackRegistrationError("General failure reading drive A")
+    assert err.message == "General failure reading drive A"
+    assert err.brief == "Callback registration error: General failure reading drive A."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Callbacks are a mechanism to run application-specified functions at
certain points of the lifecycle execution, such as before or after
each step is processed, before the execution phase starts, or after
the execution phase ends.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
