### PR TITLE
executor: add errors raised in part handling

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -394,3 +394,31 @@ class CallbackRegistrationError(PartsError):
         brief = f"Callback registration error: {message}."
 
         super().__init__(brief=brief)
+
+
+class StagePackageNotFound(PartsError):
+    """Failed to install a stage package.
+
+    :param part_name: The name of the part being processed.
+    :param message: the error message.
+    """
+
+    def __init__(self, *, part_name: str, package_name: str):
+        self.part_name = part_name
+        self.package_name = package_name
+        brief = f"Stage package not found in part {part_name!r}: {package_name}."
+
+        super().__init__(brief=brief)
+
+
+class InvalidAction(PartsError):
+    """An attempt was made to execute an action with invalid parameters.
+
+    :param message: The error message.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = f"Action is invalid: {message}."
+
+        super().__init__(brief=brief)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -293,3 +293,20 @@ def test_callback_registration_error():
     assert err.brief == "Callback registration error: General failure reading drive A."
     assert err.details is None
     assert err.resolution is None
+
+
+def test_stage_package_not_found():
+    err = errors.StagePackageNotFound(part_name="foo", package_name="figlet")
+    assert err.part_name == "foo"
+    assert err.package_name == "figlet"
+    assert err.brief == "Stage package not found in part 'foo': figlet."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_invalid_action():
+    err = errors.InvalidAction("cannot update step 'stage'")
+    assert err.message == "cannot update step 'stage'"
+    assert err.brief == "Action is invalid: cannot update step 'stage'."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Define the errors that can be raised by the part handler during
action execution.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
