### PR TITLE
utils: add call to retrieve system information

### DIFF
--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -20,7 +20,6 @@ import contextlib
 import logging
 import os
 import subprocess
-import sys
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -209,7 +208,7 @@ def get_system_info() -> str:
         return ""
 
     try:
-        uname = output.decode(sys.getfilesystemencoding()).strip()
+        uname = output.decode().strip()
     except UnicodeEncodeError:
         logger.warning("Could not decode output for 'uname' correctly")
         uname = output.decode("latin-1", "surrogateescape").strip()

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -24,6 +24,11 @@ from craft_parts import errors
 from craft_parts.utils import os_utils
 
 
+@pytest.fixture
+def fake_check_output(mocker):
+    return mocker.patch("subprocess.check_output")
+
+
 class TestTimedWriter:
     """Check if minimum interval ensured between writes."""
 
@@ -58,7 +63,32 @@ class TestTimedWriter:
         mock_sleep.assert_called_with(pytest.approx(0.015, 0.00001))
 
 
-#    paths = (os.path.join("usr", "sbin"), os.path.join("usr", "bin"), "sbin", "bin")
+class TestSystemInfo:
+    """Verify retrieval of system information."""
+
+    def test_get_system_info(self, fake_check_output):
+        fake_check_output.return_value = (
+            b"Linux 5.4.0-70-generic #78-Ubuntu SMP Fri Mar 19 13:29:52 "
+            b"UTC 2021 x86_64 x86_64 x86_64 GNU/Linux\n"
+        )
+
+        res = os_utils.get_system_info()
+        assert res == (
+            "Linux 5.4.0-70-generic #78-Ubuntu SMP Fri Mar 19 13:29:52 "
+            "UTC 2021 x86_64 x86_64 x86_64 GNU/Linux"
+        )
+        fake_check_output.assert_called_once_with(
+            [
+                "uname",
+                "--kernel-name",
+                "--kernel-release",
+                "--kernel-version",
+                "--machine",
+                "--processor",
+                "--hardware-platform",
+                "--operating-system",
+            ]
+        )
 
 
 class TestGetPaths:


### PR DESCRIPTION
Obtain information about the currently running system. This is a direct
port of the corresponding function in Snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
