### PR TITLE
packages: add host platform selection

### DIFF
--- a/craft_parts/packages/platform.py
+++ b/craft_parts/packages/platform.py
@@ -14,24 +14,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Operations with platform-specific package repositories."""
+"""Helpers to determine the repository for the platform."""
 
-from . import errors  # noqa: F401
-from . import snaps  # noqa: F401
-from .platform import is_deb_based
+from craft_parts import errors
+from craft_parts.utils import os_utils
 
-# pylint: disable=import-outside-toplevel
-
-
-def _get_repository_for_platform():
-    if is_deb_based():
-        from .deb import Ubuntu
-
-        return Ubuntu
-
-    from .base import DummyRepository
-
-    return DummyRepository
+_DEB_BASED_PLATFORM = ["ubuntu", "debian", "elementary OS", "elementary", "neon"]
 
 
-Repository = _get_repository_for_platform()
+def is_deb_based(distro=None) -> bool:
+    """Verify the distribution packaging system.
+
+    :param distro: The distribution name.
+
+    :return: Whether the distribution uses .deb packages.
+    """
+    if not distro:
+        try:
+            distro = os_utils.OsRelease().id()
+        except errors.OsReleaseIdError:
+            distro = "unknown"
+    return distro in _DEB_BASED_PLATFORM

--- a/tests/unit/packages/test_platform.py
+++ b/tests/unit/packages/test_platform.py
@@ -1,0 +1,71 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import errors, packages
+from craft_parts.packages import platform
+from craft_parts.packages.base import DummyRepository
+from craft_parts.packages.deb import Ubuntu
+
+_deb_distros = {"ubuntu", "debian", "elementary OS", "elementary", "neon"}
+
+
+def test_deb_based_platforms():
+    assert set(platform._DEB_BASED_PLATFORM) == _deb_distros
+
+
+def test_is_deb_based():
+    for distro in [
+        "fedora",
+        "debian",
+        "ubuntu",
+        "elementary OS",
+        "elementary",
+        "neon",
+        "opensuse",
+        "other",
+    ]:
+        assert platform.is_deb_based(distro) == (distro in _deb_distros)
+
+
+def test_is_deb_based_default(mocker):
+    for distro in [
+        "fedora",
+        "debian",
+        "ubuntu",
+        "elementary OS",
+        "elementary",
+        "neon",
+        "opensuse",
+    ]:
+        mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+        assert platform.is_deb_based() == (distro in _deb_distros)
+
+
+def test_is_deb_based_error(mocker):
+    mocker.patch(
+        "craft_parts.utils.os_utils.OsRelease.id", side_effect=errors.OsReleaseIdError()
+    )
+    assert platform.is_deb_based() is False
+
+
+@pytest.mark.parametrize(
+    "distro,repo", [("ubuntu", Ubuntu), ("other", DummyRepository)]
+)
+def test_get_repository_for_platform(mocker, distro, repo):
+    mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+    assert packages._get_repository_for_platform() == repo


### PR DESCRIPTION
Determine the correct repository to use based on the host ID. This
implementation is a direct port from the corresponding function
in Snapcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
