### PR TITLE
docs: fix sphinx doc generation and update docstrings

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -20,7 +20,7 @@ __version__ = "0.0.1"  # noqa: F401
 
 from .actions import Action, ActionType  # noqa: F401
 from .dirs import ProjectDirs  # noqa: F401
-from .infos import ProjectInfo  # noqa: F401
+from .infos import PartInfo, ProjectInfo, StepInfo  # noqa: F401
 from .lifecycle_manager import LifecycleManager  # noqa: F401
 from .parts import Part  # noqa: F401
 from .steps import Step  # noqa: F401

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -150,6 +150,7 @@ class XAttributeError(PartsError):
     :param action: The action being performed.
     :param key: The extended attribute key.
     :param path: The file path.
+    :param is_write: Whether this is an attribute write operation.
     """
 
     def __init__(self, key: str, path: str, is_write: bool = False):
@@ -165,7 +166,12 @@ class XAttributeError(PartsError):
 
 
 class XAttributeTooLong(PartsError):
-    """Failed to write an extended attribute because key and/or value is too long."""
+    """Failed to write an extended attribute because key and/or value is too long.
+
+    :param key: The extended attribute key.
+    :param value: The extended attribute value.
+    :param path: The file path.
+    """
 
     def __init__(self, key: str, value: str, path: str):
         self.key = key
@@ -180,7 +186,7 @@ class XAttributeTooLong(PartsError):
 class UndefinedPlugin(PartsError):
     """The part didn't define a plugin and the part name is not a valid plugin name.
 
-    :param part_name: The name of the part with no plugin definition."
+    :param part_name: The name of the part with no plugin definition.
     """
 
     def __init__(self, *, part_name: str):
@@ -195,6 +201,7 @@ class InvalidPlugin(PartsError):
     """A request was made to use a plugin that's not registered.
 
     :param plugin_name: The invalid plugin name."
+    :param part_name: The name of the part defining the invalid plugin.
     """
 
     def __init__(self, plugin_name: str, *, part_name: str):
@@ -243,7 +250,11 @@ class OsReleaseCodenameError(PartsError):
 
 
 class FilesetError(PartsError):
-    """An invalid fileset operation was performed."""
+    """An invalid fileset operation was performed.
+
+    :param name: The name of the fileset.
+    :param message: The error message.
+    """
 
     def __init__(self, *, name: str, message: str):
         self.name = name
@@ -255,7 +266,10 @@ class FilesetError(PartsError):
 
 
 class FilesetConflict(PartsError):
-    """Inconsistent stage to prime filtering."""
+    """Inconsistent stage to prime filtering.
+
+    :param conflicting_files: A set containing the conflicting file names.
+    """
 
     def __init__(self, conflicting_files: Set[str]):
         self.conflicting_files = conflicting_files

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -199,7 +199,11 @@ class PartInfo:
 
 
 class StepInfo:
-    """Step-level information containing project, part, and step fields."""
+    """Step-level information containing project, part, and step fields.
+
+    :param part_info: The part information.
+    :param step: The step we want to obtain information from.
+    """
 
     def __init__(
         self,

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -24,7 +24,8 @@ from pydantic import BaseModel
 from .properties import PluginProperties
 
 if TYPE_CHECKING:
-    from craft_parts.infos import PartInfo
+    # import module to avoid circular imports in sphinx doc generation
+    from craft_parts import infos
 
 
 class Plugin(abc.ABC):
@@ -38,7 +39,9 @@ class Plugin(abc.ABC):
 
     properties_class: Type[PluginProperties]
 
-    def __init__(self, *, properties: PluginProperties, part_info: "PartInfo") -> None:
+    def __init__(
+        self, *, properties: PluginProperties, part_info: "infos.PartInfo"
+    ) -> None:
         self._name = part_info.part_name
         self._options = properties
         self._part_info = part_info

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -27,8 +27,8 @@ from .nil_plugin import NilPlugin
 from .properties import PluginProperties
 
 if TYPE_CHECKING:
-    from craft_parts.infos import PartInfo
-    from craft_parts.parts import Part
+    # import module to avoid circular imports in sphinx doc generation
+    from craft_parts import infos, parts
 
 
 PluginType = Type[Plugin]
@@ -47,8 +47,8 @@ _PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)
 
 def get_plugin(
     *,
-    part: "Part",
-    part_info: "PartInfo",
+    part: "parts.Part",
+    part_info: "infos.PartInfo",
     properties: PluginProperties,
 ) -> Plugin:
     """Obtain a plugin instance for the specified part.


### PR DESCRIPTION
Sphinx type hints are very sensitive to import cycles. In such case,
import only the module instead of classes/functions as explained in
the sphinx-autodoc-typehints documentation.

Also add missing parameter descriptions to docstrings.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
