### PR TITLE
plugins: check presence of required part properties (CRAFT-74)

### DIFF
--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -27,6 +27,9 @@ class AutotoolsPluginProperties(PluginProperties, PluginModel):
 
     autotools_configure_parameters: List[str] = []
 
+    # part properties required by the plugin
+    source: str
+
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
         """Populate autotools properties from the part specification.
@@ -37,7 +40,9 @@ class AutotoolsPluginProperties(PluginProperties, PluginModel):
 
         :raise pydantic.ValidationError: If validation fails.
         """
-        plugin_data = extract_plugin_properties(data, plugin_name="autotools")
+        plugin_data = extract_plugin_properties(
+            data, plugin_name="autotools", required=["source"]
+        )
         return cls(**plugin_data)
 
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -17,7 +17,7 @@
 """Plugin base class and definitions."""
 
 import abc
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type
 
 from pydantic import BaseModel
 
@@ -86,7 +86,7 @@ class PluginModel(BaseModel):
 
 
 def extract_plugin_properties(
-    data: Dict[str, Any], *, plugin_name: str
+    data: Dict[str, Any], *, plugin_name: str, required: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     """Obtain plugin-specifc entries from part properties.
 
@@ -95,11 +95,14 @@ def extract_plugin_properties(
 
     :return: A dictionary with plugin properties.
     """
+    if required is None:
+        required = []
+
     plugin_data: Dict[str, Any] = {}
     prefix = f"{plugin_name}-"
 
     for key, value in data.items():
-        if key.startswith(prefix):
+        if key.startswith(prefix) or key in required:
             plugin_data[key] = value
 
     return plugin_data

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -27,6 +27,9 @@ class MakePluginProperties(PluginProperties, PluginModel):
 
     make_parameters: List[str] = []
 
+    # part properties required by the plugin
+    source: str
+
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
         """Populate make properties from the part specification.
@@ -37,7 +40,9 @@ class MakePluginProperties(PluginProperties, PluginModel):
 
         :raise pydantic.ValidationError: If validation fails.
         """
-        plugin_data = extract_plugin_properties(data, plugin_name="make")
+        plugin_data = extract_plugin_properties(
+            data, plugin_name="make", required=["source"]
+        )
         return cls(**plugin_data)
 
 

--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -31,6 +31,9 @@ class PythonPluginProperties(PluginProperties, PluginModel):
     python_constraints: List[str] = []
     python_packages: List[str] = ["pip", "setuptools", "wheel"]
 
+    # part properties required by the plugin
+    source: str
+
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]):
         """Populate make properties from the part specification.
@@ -41,7 +44,9 @@ class PythonPluginProperties(PluginProperties, PluginModel):
 
         :raise pydantic.ValidationError: If validation fails.
         """
-        plugin_data = extract_plugin_properties(data, plugin_name="python")
+        plugin_data = extract_plugin_properties(
+            data, plugin_name="python", required=["source"]
+        )
         return cls(**plugin_data)
 
 

--- a/tests/unit/plugins/test_autotools_plugin.py
+++ b/tests/unit/plugins/test_autotools_plugin.py
@@ -31,7 +31,7 @@ class TestPluginAutotools:
     """Autotools plugin tests."""
 
     def setup_method(self):
-        properties = AutotoolsPlugin.properties_class.unmarshal({})
+        properties = AutotoolsPlugin.properties_class.unmarshal({"source": "."})
         part = Part("foo", {})
 
         project_info = ProjectInfo()
@@ -67,7 +67,10 @@ class TestPluginAutotools:
 
     def test_get_build_commands_with_configure_parameters(self):
         properties = AutotoolsPlugin.properties_class.unmarshal(
-            {"autotools-configure-parameters": ["--with-foo=true", "--prefix=/foo"]},
+            {
+                "source": ".",
+                "autotools-configure-parameters": ["--with-foo=true", "--prefix=/foo"],
+            },
         )
 
         project_info = ProjectInfo()
@@ -88,10 +91,20 @@ class TestPluginAutotools:
             'make install DESTDIR="/tmp"',
         ]
 
-    def test_invalid_parameters(self):
+    def test_invalid_properties(self):
         with pytest.raises(ValidationError) as raised:
-            AutotoolsPlugin.properties_class.unmarshal({"autotools-invalid": True})
+            AutotoolsPlugin.properties_class.unmarshal(
+                {"source": ".", "autotools-invalid": True}
+            )
         err = raised.value.errors()
         assert len(err) == 1
         assert err[0]["loc"] == ("autotools-invalid",)
         assert err[0]["type"] == "value_error.extra"
+
+    def test_missing_properties(self):
+        with pytest.raises(ValidationError) as raised:
+            AutotoolsPlugin.properties_class.unmarshal({})
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("source",)
+        assert err[0]["type"] == "value_error.missing"

--- a/tests/unit/plugins/test_make_plugin.py
+++ b/tests/unit/plugins/test_make_plugin.py
@@ -30,7 +30,7 @@ class TestPluginMake:
     """Make plugin tests."""
 
     def setup_method(self):
-        properties = MakePlugin.properties_class.unmarshal({})
+        properties = MakePlugin.properties_class.unmarshal({"source": "."})
         part = Part("foo", {})
 
         project_info = ProjectInfo()
@@ -59,7 +59,7 @@ class TestPluginMake:
 
     def test_get_build_commands_with_parameters(self):
         props = MakePlugin.properties_class.unmarshal(
-            {"make-parameters": ["FLAVOR=gtk3"]}
+            {"source": ".", "make-parameters": ["FLAVOR=gtk3"]}
         )
         part = Part("foo", {})
 
@@ -76,10 +76,18 @@ class TestPluginMake:
             'make -j"8" install FLAVOR=gtk3 DESTDIR="/tmp"',
         ]
 
-    def test_invalid_parameters(self):
+    def test_invalid_properties(self):
         with pytest.raises(ValidationError) as raised:
-            MakePlugin.properties_class.unmarshal({"make-invalid": True})
+            MakePlugin.properties_class.unmarshal({"source": ".", "make-invalid": True})
         err = raised.value.errors()
         assert len(err) == 1
         assert err[0]["loc"] == ("make-invalid",)
         assert err[0]["type"] == "value_error.extra"
+
+    def test_missing_properties(self):
+        with pytest.raises(ValidationError) as raised:
+            MakePlugin.properties_class.unmarshal({})
+        err = raised.value.errors()
+        assert len(err) == 1
+        assert err[0]["loc"] == ("source",)
+        assert err[0]["type"] == "value_error.missing"

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -39,16 +39,16 @@ class TestGetPlugin:
     """
 
     @pytest.mark.parametrize(
-        "name,plugin_class",
+        "name,plugin_class,data",
         [
-            ("autotools", AutotoolsPlugin),
-            ("dump", DumpPlugin),
-            ("make", MakePlugin),
-            ("nil", NilPlugin),
-            ("python", PythonPlugin),
+            ("autotools", AutotoolsPlugin, {"source": "."}),
+            ("dump", DumpPlugin, {"source": "."}),
+            ("make", MakePlugin, {"source": "."}),
+            ("nil", NilPlugin, {}),
+            ("python", PythonPlugin, {"source": "."}),
         ],
     )
-    def test_get_plugin(self, name, plugin_class):
+    def test_get_plugin(self, name, plugin_class, data):
         part = Part("foo", {"plugin": name})
         project_info = ProjectInfo()
         part_info = PartInfo(project_info=project_info, part=part)
@@ -57,7 +57,9 @@ class TestGetPlugin:
         assert pclass == plugin_class
 
         plugin = plugins.get_plugin(
-            part=part, part_info=part_info, properties=pclass.properties_class()
+            part=part,
+            part_info=part_info,
+            properties=pclass.properties_class.unmarshal(data),
         )
 
         assert isinstance(plugin, plugin_class)

--- a/tests/unit/plugins/test_python_plugin.py
+++ b/tests/unit/plugins/test_python_plugin.py
@@ -27,7 +27,7 @@ from craft_parts.plugins.python_plugin import PythonPlugin
 
 @pytest.fixture
 def plugin(new_dir):
-    properties = PythonPlugin.properties_class.unmarshal({})
+    properties = PythonPlugin.properties_class.unmarshal({"source": "."})
     part_info = PartInfo(project_info=ProjectInfo(), part=Part("p1", {}))
 
     return PythonPlugin(properties=properties, part_info=part_info)
@@ -103,6 +103,7 @@ def test_get_build_commands_with_all_properties(new_dir):
     part_info = PartInfo(project_info=ProjectInfo(), part=Part("p1", {}))
     properties = PythonPlugin.properties_class.unmarshal(
         {
+            "source": ".",
             "python-constraints": ["constraints.txt"],
             "python-requirements": ["requirements.txt"],
             "python-packages": ["pip", "some-pkg; sys_platform != 'win32'"],
@@ -124,10 +125,19 @@ def test_get_build_commands_with_all_properties(new_dir):
     )
 
 
-def test_invalid_parameters():
+def test_invalid_properties():
     with pytest.raises(ValidationError) as raised:
-        PythonPlugin.properties_class.unmarshal({"python-invalid": True})
+        PythonPlugin.properties_class.unmarshal({"source": ".", "python-invalid": True})
     err = raised.value.errors()
     assert len(err) == 1
     assert err[0]["loc"] == ("python-invalid",)
     assert err[0]["type"] == "value_error.extra"
+
+
+def test_missing_properties():
+    with pytest.raises(ValidationError) as raised:
+        PythonPlugin.properties_class.unmarshal({})
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("source",)
+    assert err[0]["type"] == "value_error.missing"

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -102,6 +102,7 @@ class TestPluginProperties:
             {
                 "parts": {
                     "bar": {
+                        "source": ".",
                         "plugin": "make",
                         "make-parameters": ["-DTEST_PARAMETER"],
                     }
@@ -121,6 +122,7 @@ class TestPluginProperties:
             {
                 "parts": {
                     "make": {
+                        "source": ".",
                         "make-parameters": ["-DTEST_PARAMETER"],
                     }
                 }


### PR DESCRIPTION
Plugins may require certain part properties to be present, such as
"source". Let pydantic check these requirements during plugin property
validation instead of manually verifying their presence.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
