### PR TITLE
ctl: add ctl protocol client (CRAFT-35)

### DIFF
--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -68,7 +68,6 @@ def client(cmd: str, args: List[str]):
 
     with open(call_fifo, "w") as fifo:
         fifo.write(json.dumps(data))
-        fifo.flush()
 
     with open(feedback_fifo, "r") as fifo:
         feedback = fifo.readline().strip()

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to invoke step execution handlers from the command line."""
+
+import json
+import os
+import sys
+from typing import List
+
+
+def main():
+    """Run the ctl client cli."""
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} <command>")
+        sys.exit(1)
+
+    cmd, param = sys.argv[1], sys.argv[2:]
+    try:
+        client(cmd, param)
+    except RuntimeError as err:
+        print(f"Error: {err}.", file=sys.stderr)
+        sys.exit(1)
+
+
+def client(cmd: str, args: List[str]):
+    """Execute a command in the running step processor.
+
+    :param cmd: The function to execute in the step processor.
+    :param args: Optional arguments.
+
+    :raise RuntimeError: If the command is invalid.
+    """
+    if cmd not in ["pull", "build", "stage", "prime", "set"]:
+        raise RuntimeError(f"invalid command {cmd!r}")
+
+    try:
+        call_fifo = os.environ["PARTS_CALL_FIFO"]
+        feedback_fifo = os.environ["PARTS_FEEDBACK_FIFO"]
+    except KeyError as err:
+        raise RuntimeError(
+            "{!s} environment variable must be defined.\nNote that this "
+            "utility is designed for use only in part scriptlets.".format(err)
+        ) from err
+
+    data = {"function": cmd, "args": args}
+
+    with open(call_fifo, "w") as fifo:
+        fifo.write(json.dumps(data))
+        fifo.flush()
+
+    with open(feedback_fifo, "r") as fifo:
+        feedback = fifo.readline().strip()
+
+    # Any feedback is considered a fatal error.
+    if feedback:
+        raise RuntimeError(feedback)

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -35,7 +35,7 @@ def main():
     try:
         client(cmd, param)
     except RuntimeError as err:
-        logger.warning("ctl error: %s", err)
+        logger.error("ctl error: %s", err)
         sys.exit(1)
 
 

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -17,9 +17,12 @@
 """Helpers to invoke step execution handlers from the command line."""
 
 import json
+import logging
 import os
 import sys
 from typing import List
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -32,7 +35,7 @@ def main():
     try:
         client(cmd, param)
     except RuntimeError as err:
-        print(f"Error: {err}.", file=sys.stderr)
+        logger.warning("ctl error: %s", err)
         sys.exit(1)
 
 

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def main():
     """Run the ctl client cli."""
     if len(sys.argv) < 2:
-        print(f"usage: {sys.argv[0]} <command>")
+        print(f"usage: {sys.argv[0]} <command> [arguments]")
         sys.exit(1)
 
     cmd, param = sys.argv[1], sys.argv[2:]

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -39,6 +39,11 @@ def main():
 def client(cmd: str, args: List[str]):
     """Execute a command in the running step processor.
 
+    The control protocol client allows a user scriptlet to execute
+    the default handler for a step in the running application context,
+    or set the value of a custom variable previously passed as an
+    argument to :class:`craft_parts.LifecycleManager`.
+
     :param cmd: The function to execute in the step processor.
     :param args: Optional arguments.
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -223,9 +223,9 @@ class StepHandler:
                     function_call = call_fifo.read()
                     if function_call:
                         # Handle the function and let caller know that function
-                        # call has been handled (must contain at least a
-                        # newline, anything beyond is considered an error by
-                        # snapcraftctl)
+                        # call has been handled (the feedback message must contain
+                        # at least a newline, anything beyond is considered an error
+                        # by the client).
                         self._handle_control_api(scriptlet_name, function_call.strip())
                         feedback_fifo.write("\n")
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -285,8 +285,8 @@ class StepHandler:
                         f"invalid number of arguments to function {function_name!r}"
                     ),
                 )
-            name = function_args[0]
-            value = function_args[1]
+            name, value = function_args
+
             try:
                 self._step_info.set_custom_argument(name, value)
             except ValueError as err:

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -121,6 +121,19 @@ class ProjectInfo:
             "target_arch": self.target_arch,
         }
 
+    def set_custom_argument(self, name: str, value: str) -> None:
+        """Set the value of a custom argument.
+
+        :param name: The custom argument name.
+        :param value: The new custom argument value.
+
+        :raise ValueError: If there is no custom argument with the given name.
+        """
+        if name not in self._custom_args:
+            raise ValueError(f"{name!r} not in project custom arguments")
+
+        self._custom_args[name] = value
+
     def _set_machine(self, arch: Optional[str]):
         """Initialize machine information based on the architecture.
 
@@ -204,6 +217,16 @@ class PartInfo:
         """Return the subdirectory containing this part's lifecycle state."""
         return self._part_state_dir
 
+    def set_custom_argument(self, name: str, value: str) -> None:
+        """Set the value of a custom argument.
+
+        :param name: The custom argument name.
+        :param value: The new custom argument value.
+
+        :raise ValueError: If there is no custom argument with the given name.
+        """
+        self._project_info.set_custom_argument(name, value)
+
 
 class StepInfo:
     """Step-level information containing project, part, and step fields.
@@ -225,6 +248,16 @@ class StepInfo:
             return getattr(self._part_info, name)
 
         raise AttributeError(f"{self.__class__.__name__!r} has no attribute {name!r}")
+
+    def set_custom_argument(self, name: str, value: str) -> None:
+        """Set the value of a custom argument.
+
+        :param name: The custom argument name.
+        :param value: The new custom argument value.
+
+        :raise ValueError: If there is no custom argument with the given name.
+        """
+        self._part_info.set_custom_argument(name, value)
 
 
 def _get_host_architecture() -> str:

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     entry_points={
         "console_scripts": [
             "craft_parts=craft_parts.main:main",
+            "partsctl=craft_parts.ctl:main",
         ],
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     description="Craft parts tooling",
     entry_points={
         "console_scripts": [
-            "craft_parts=craft_parts.main:main",
             "partsctl=craft_parts.ctl:main",
         ],
     },

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent

--- a/tests/integration/lifecycle/test_partsctl.py
+++ b/tests/integration/lifecycle/test_partsctl.py
@@ -1,0 +1,191 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Action, Step, errors
+from tests import TESTS_DIR
+
+
+@pytest.fixture(autouse=True)
+def setup_fixture(new_dir, mocker):
+    partsctl = Path("partsctl")
+    partsctl.write_text(f"#!{sys.executable}\nfrom craft_parts import ctl\nctl.main()")
+    partsctl.chmod(0o755)
+
+    mocker.patch.dict(
+        os.environ,
+        {
+            "PATH": "/bin" + os.pathsep + str(new_dir),
+            "PYTHONPATH": str(TESTS_DIR.parent),
+        },
+    )
+
+
+def test_ctl_client_steps(new_dir, capfd, mocker):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: dump
+            source: foo
+            override-pull: |
+              echo "pull step"
+              partsctl pull
+            override-build: |
+              echo "build step"
+              partsctl build
+            override-stage: |
+              echo "stage step"
+              partsctl stage
+            override-prime: |
+              echo "prime step"
+              partsctl prime
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    Path("foo").mkdir()
+    Path("foo/foo.txt").touch()
+
+    lf = craft_parts.LifecycleManager(parts, application_name="test_ctl")
+    actions = lf.plan(Step.PRIME)
+    assert actions == [
+        Action("foo", Step.PULL),
+        Action("foo", Step.BUILD),
+        Action("foo", Step.STAGE),
+        Action("foo", Step.PRIME),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions[0])
+        captured = capfd.readouterr()
+        assert captured.out == "pull step\n"
+        assert Path("parts/foo/src/foo.txt").exists()
+        assert Path("parts/foo/install/foo.txt").exists() is False
+        assert Path("stage/foo.txt").exists() is False
+        assert Path("prime/foo.txt").exists() is False
+
+        ctx.execute(actions[1])
+        captured = capfd.readouterr()
+        assert captured.out == "build step\n"
+        assert Path("parts/foo/install/foo.txt").exists()
+        assert Path("stage/foo.txt").exists() is False
+        assert Path("prime/foo.txt").exists() is False
+
+        ctx.execute(actions[2])
+        captured = capfd.readouterr()
+        assert captured.out == "stage step\n"
+        assert Path("stage/foo.txt").exists()
+        assert Path("prime/foo.txt").exists() is False
+
+        ctx.execute(actions[3])
+        captured = capfd.readouterr()
+        assert captured.out == "prime step\n"
+        assert Path("prime/foo.txt").exists()
+
+
+@pytest.mark.parametrize("step", list(Step))
+def test_ctl_client_step_argments(new_dir, step):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            override-pull: partsctl pull argument
+            override-build: partsctl build argument
+            override-stage: partsctl stage argument
+            override-prime: partsctl prime argument
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(parts, application_name="test_ctl")
+    with pytest.raises(errors.InvalidControlAPICall) as raised:
+        with lf.action_executor() as ctx:
+            ctx.execute(Action("foo", step))
+
+    assert raised.value.message == (
+        "invalid arguments to function {!r}".format(step.name.lower())
+    )
+
+
+def test_ctl_client_set(new_dir):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            override-pull: |
+              partsctl set myvar myvalue
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(parts, application_name="test_set", myvar="")
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+    assert lf.project_info.myvar == "myvalue"
+
+
+def test_ctl_client_set_var_error(new_dir, capfd, mocker):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            override-pull: |
+              partsctl set myvar myvalue
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(parts, application_name="test_set")
+    with pytest.raises(errors.InvalidControlAPICall) as raised:
+        with lf.action_executor() as ctx:
+            ctx.execute(Action("foo", Step.PULL))
+
+    assert raised.value.part_name == "foo"
+    assert raised.value.scriptlet_name == "override-pull"
+    assert raised.value.message == "'myvar' not in project custom arguments"
+
+
+def test_ctl_client_set_argument_error(new_dir, capfd, mocker):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            override-pull: |
+              partsctl set myvar myvalue anothervalue
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(parts, application_name="test_set")
+    with pytest.raises(errors.InvalidControlAPICall) as raised:
+        with lf.action_executor() as ctx:
+            ctx.execute(Action("foo", Step.PULL))
+
+    assert raised.value.part_name == "foo"
+    assert raised.value.scriptlet_name == "override-pull"
+    assert raised.value.message == "invalid number of arguments to function 'set'"

--- a/tests/unit/test_ctl.py
+++ b/tests/unit/test_ctl.py
@@ -1,0 +1,96 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+
+import pytest
+
+from craft_parts import ctl
+
+
+class TestClient:
+    """Verify the ctl client."""
+
+    def test_call_function(self, new_dir, mocker):
+        call_fifo = Path("call_fifo")
+        feedback_fifo = Path("feedback_fifo")
+
+        call_fifo.touch()
+        feedback_fifo.touch()
+
+        mocker.patch.dict(
+            os.environ,
+            {"PARTS_CALL_FIFO": "call_fifo", "PARTS_FEEDBACK_FIFO": "feedback_fifo"},
+        )
+        ctl.client("pull", ["whatever"])
+
+        msg = call_fifo.read_text()
+        assert msg == '{"function": "pull", "args": ["whatever"]}'
+
+    def test_call_function_with_feedback(self, new_dir, mocker):
+        call_fifo = Path("call_fifo")
+        feedback_fifo = Path("feedback_fifo")
+
+        call_fifo.touch()
+        feedback_fifo.write_text("hello there!")
+
+        mocker.patch.dict(
+            os.environ,
+            {"PARTS_CALL_FIFO": "call_fifo", "PARTS_FEEDBACK_FIFO": "feedback_fifo"},
+        )
+        with pytest.raises(RuntimeError) as raised:
+            ctl.client("pull", ["whatever"])
+
+        assert str(raised.value) == "hello there!"
+
+    def test_call_function_without_call_fifo(self, new_dir, mocker):
+        call_fifo = Path("call_fifo")
+        feedback_fifo = Path("feedback_fifo")
+
+        call_fifo.touch()
+        feedback_fifo.touch()
+
+        mocker.patch.dict(os.environ, {"PARTS_FEEDBACK_FIFO": "feedback_fifo"})
+        with pytest.raises(RuntimeError) as raised:
+            ctl.client("pull", ["whatever"])
+
+        assert str(raised.value) == (
+            "'PARTS_CALL_FIFO' environment variable must be defined.\n"
+            "Note that this utility is designed for use only in part scriptlets."
+        )
+
+    def test_call_function_without_feedback_fifo(self, new_dir, mocker):
+        call_fifo = Path("call_fifo")
+        feedback_fifo = Path("feedback_fifo")
+
+        call_fifo.touch()
+        feedback_fifo.touch()
+
+        mocker.patch.dict(os.environ, {"PARTS_CALL_FIFO": "call_fifo"})
+        with pytest.raises(RuntimeError) as raised:
+            ctl.client("pull", ["whatever"])
+
+        assert str(raised.value) == (
+            "'PARTS_FEEDBACK_FIFO' environment variable must be defined.\n"
+            "Note that this utility is designed for use only in part scriptlets."
+        )
+
+    def test_call_invalid_function(self, new_dir):
+        with pytest.raises(RuntimeError) as raised:
+            ctl.client("grok", ["whatever"])
+
+        assert str(raised.value) == "invalid command 'grok'"

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -89,6 +89,21 @@ def test_project_info_invalid_custom_args():
     assert str(raised.value) == "'ProjectInfo' has no attribute 'custom1'"
 
 
+def test_project_info_set_custom_args():
+    info = ProjectInfo(custom="foo")
+
+    info.set_custom_argument("custom", "bar")
+    assert info.custom == "bar"
+
+
+def test_project_info_set_invalid_custom_args():
+    info = ProjectInfo()
+
+    with pytest.raises(ValueError) as raised:
+        info.set_custom_argument("custom", "bar")
+    assert str(raised.value) == "'custom' not in project custom arguments"
+
+
 def test_project_info_default():
     x = ProjectInfo()
 
@@ -135,6 +150,25 @@ def test_part_info_invalid_custom_args():
     assert str(raised.value) == "'PartInfo' has no attribute 'custom1'"
 
 
+def test_part_info_set_custom_args():
+    info = ProjectInfo(custom="foo")
+    part = Part("p1", {})
+    x = PartInfo(project_info=info, part=part)
+
+    x.set_custom_argument("custom", "bar")
+    assert x.custom == "bar"
+
+
+def test_part_info_set_invalid_custom_args():
+    info = ProjectInfo()
+    part = Part("p1", {})
+    x = PartInfo(project_info=info, part=part)
+
+    with pytest.raises(ValueError) as raised:
+        x.set_custom_argument("custom", "bar")
+    assert str(raised.value) == "'custom' not in project custom arguments"
+
+
 def test_step_info(new_dir):
     info = ProjectInfo(custom1="foobar", custom2=[1, 2])
     part = Part("foo", {})
@@ -169,3 +203,24 @@ def test_step_info_invalid_custom_args():
     with pytest.raises(AttributeError) as raised:
         print(x.custom1)
     assert str(raised.value) == "'StepInfo' has no attribute 'custom1'"
+
+
+def test_step_info_set_custom_args():
+    info = ProjectInfo(custom="foo")
+    part = Part("p1", {})
+    part_info = PartInfo(project_info=info, part=part)
+    x = StepInfo(part_info=part_info, step=Step.PULL)
+
+    x.set_custom_argument("custom", "bar")
+    assert x.custom == "bar"
+
+
+def test_step_info_set_invalid_custom_args():
+    info = ProjectInfo()
+    part = Part("p1", {})
+    part_info = PartInfo(project_info=info, part=part)
+    x = StepInfo(part_info=part_info, step=Step.PULL)
+
+    with pytest.raises(ValueError) as raised:
+        x.set_custom_argument("custom", "bar")
+    assert str(raised.value) == "'custom' not in project custom arguments"


### PR DESCRIPTION
The control protocol client allows a user scriptlet to execute the
default handler for a step in the running application context, or set
the value of a custom variable previously passed as an argument to
`LifecycleManager`.
    
The `craft_parts.ctl` module can be imported by application-defined
clients, or invoked as a utility from the command line using the
supplied `partsctl` tool.
    

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
