### PR TITLE
packages: normalize unpacked stage packages (CRAFT-33)

### DIFF
--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -17,6 +17,7 @@
 """Handle the execution of built-in or user specified step commands."""
 
 import dataclasses
+import functools
 import json
 import os
 import subprocess

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -17,19 +17,17 @@
 """Handle the execution of built-in or user specified step commands."""
 
 import dataclasses
-import fileinput
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
 import textwrap
 import time
 from pathlib import Path
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Set
 
-from craft_parts import errors
+from craft_parts import errors, packages
 from craft_parts.executor import collisions
 from craft_parts.infos import StepInfo
 from craft_parts.parts import Part
@@ -137,7 +135,7 @@ class StepHandler:
                 return
             if not file_path.endswith(".pc"):
                 return
-            _fix_pkg_config(
+            packages.fix_pkg_config(
                 root=self._part.stage_dir,
                 pkg_config_file=file_path,
                 prefix_trim=self._part.part_install_dir,
@@ -336,34 +334,3 @@ def _check_conflicts(
         raise errors.StageFilesConflict(
             part_name=part_name, conflicting_files=conflict_files
         )
-
-
-def _fix_pkg_config(
-    root: Union[str, Path],
-    pkg_config_file: Union[str, Path],
-    prefix_trim: Optional[Union[str, Path]] = None,
-) -> None:
-    """Rewrite the prefix entry in a pkg-config file.
-
-    :param root: The root to add to the configuration prefix.
-    :param pkg_config_file: The pkg-config file to process.
-    :param prefix_trim: The initial path to remove from the configuration prefix.
-    """
-    # FIXME: see https://bugs.launchpad.net/snapcraft/+bug/1916281
-    pattern_trim = None
-    if prefix_trim:
-        pattern_trim = re.compile("^prefix={}(?P<prefix>.*)".format(prefix_trim))
-    pattern = re.compile("^prefix=(?P<prefix>.*)")
-
-    with fileinput.input(pkg_config_file, inplace=True) as input_file:
-        match_trim = None
-        for line in input_file:
-            match = pattern.search(str(line))
-            if prefix_trim is not None and pattern_trim is not None:
-                match_trim = pattern_trim.search(str(line))
-            if prefix_trim is not None and match_trim is not None:
-                print("prefix={}{}".format(root, match_trim.group("prefix")))
-            elif match:
-                print("prefix={}{}".format(root, match.group("prefix")))
-            else:
-                print(line, end="")

--- a/craft_parts/packages/__init__.py
+++ b/craft_parts/packages/__init__.py
@@ -18,6 +18,7 @@
 
 from . import errors  # noqa: F401
 from . import snaps  # noqa: F401
+from .normalize import fix_pkg_config  # noqa: F401
 from .platform import is_deb_based
 
 # pylint: disable=import-outside-toplevel

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -34,6 +34,7 @@ from craft_parts.utils import file_utils, os_utils
 from . import errors
 from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
 from .deb_package import DebPackage
+from .normalize import normalize
 
 if sys.platform == "linux":
     # Ensure importing works on non-Linux.
@@ -500,8 +501,7 @@ class Ubuntu(BaseRepository):
                 mark_origin_stage_package(extract_dir, marked_name)
                 # Stage files to install_dir.
                 file_utils.link_or_copy_tree(extract_dir, install_path.as_posix())
-        # XXX: normalization of stage packages done by the application
-        # cls.normalize(str(install_path))
+        normalize(str(install_path), repository=cls)
 
     @classmethod
     def is_package_installed(cls, package_name) -> bool:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -505,7 +505,7 @@ class Ubuntu(BaseRepository):
                 file_utils.link_or_copy_tree(extract_dir, install_path.as_posix())
 
         if pkg_path:
-            normalize(str(install_path), repository=cls)
+            normalize(install_path, repository=cls)
 
     @classmethod
     def is_package_installed(cls, package_name) -> bool:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -490,12 +490,9 @@ class Ubuntu(BaseRepository):
         cls, *, stage_packages_path: pathlib.Path, install_path: pathlib.Path
     ) -> None:
         """Unpack stage packages to install_path."""
-        stage_packages = stage_packages_path.glob("*.deb")
+        pkg_path = None
 
-        if not stage_packages:
-            return
-
-        for pkg_path in stage_packages:
+        for pkg_path in stage_packages_path.glob("*.deb"):
             with tempfile.TemporaryDirectory(
                 suffix="deb-extract", dir=install_path.parent
             ) as extract_dir:
@@ -507,7 +504,8 @@ class Ubuntu(BaseRepository):
                 # Stage files to install_dir.
                 file_utils.link_or_copy_tree(extract_dir, install_path.as_posix())
 
-        normalize(str(install_path), repository=cls)
+        if pkg_path:
+            normalize(str(install_path), repository=cls)
 
     @classmethod
     def is_package_installed(cls, package_name) -> bool:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -490,7 +490,12 @@ class Ubuntu(BaseRepository):
         cls, *, stage_packages_path: pathlib.Path, install_path: pathlib.Path
     ) -> None:
         """Unpack stage packages to install_path."""
-        for pkg_path in stage_packages_path.glob("*.deb"):
+        stage_packages = stage_packages_path.glob("*.deb")
+
+        if not stage_packages:
+            return
+
+        for pkg_path in stage_packages:
             with tempfile.TemporaryDirectory(
                 suffix="deb-extract", dir=install_path.parent
             ) as extract_dir:
@@ -501,6 +506,7 @@ class Ubuntu(BaseRepository):
                 mark_origin_stage_package(extract_dir, marked_name)
                 # Stage files to install_dir.
                 file_utils.link_or_copy_tree(extract_dir, install_path.as_posix())
+
         normalize(str(install_path), repository=cls)
 
     @classmethod

--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -1,0 +1,259 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definition and helpers for the repository base class."""
+
+import contextlib
+import fileinput
+import glob
+import itertools
+import logging
+import os
+import re
+import shutil
+import stat
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Pattern, Union
+
+if TYPE_CHECKING:
+    from .base import RepositoryType
+
+
+logger = logging.getLogger(__name__)
+
+
+def normalize(unpack_dir: str, *, repository: "RepositoryType") -> None:
+    """Normalize unpacked artifacts.
+
+    Repository-specific packages are generally created to live in a specific
+    distro. Normalize scans through the unpacked artifacts and slightly modifies
+    them to work better in the Craft Parts build environment.
+
+    :param unpack_dir: Directory containing unpacked files to normalize.
+    :param repository: The package format handler.
+    """
+    _remove_useless_files(unpack_dir)
+    _fix_artifacts(unpack_dir, repository)
+    _fix_xml_tools(unpack_dir)
+    _fix_shebangs(unpack_dir)
+
+
+def _remove_useless_files(unpack_dir: str) -> None:
+    """Remove files that aren't useful or will clash with other parts.
+
+    :param unpack_dir: Directory containing unpacked files to normalize.
+    """
+    sitecustomize_files = glob.glob(
+        os.path.join(unpack_dir, "usr", "lib", "python*", "sitecustomize.py")
+    )
+    for sitecustomize_file in sitecustomize_files:
+        os.remove(sitecustomize_file)
+
+
+def _fix_artifacts(unpack_dir: str, repository: "RepositoryType") -> None:
+    """Perform various modifications to unpacked artifacts.
+
+    Sometimes distro packages will contain absolute symlinks (e.g. if the
+    relative path would go all the way to root, they just do absolute). We
+    can't have that, so instead clean those absolute symlinks.
+
+    Some unpacked items will also contain suid binaries which we do not
+    want in the resulting environment.
+
+    :param unpack_dir: Directory containing unpacked files to normalize.
+    """
+    for root, dirs, files in os.walk(unpack_dir):
+        # Symlinks to directories will be in dirs, while symlinks to
+        # non-directories will be in files.
+        for entry in itertools.chain(files, dirs):
+            path = os.path.join(root, entry)
+            if os.path.islink(path) and os.path.isabs(os.readlink(path)):
+                _fix_symlink(path, unpack_dir, root, repository)
+            elif os.path.exists(path):
+                _fix_filemode(path)
+
+            if path.endswith(".pc") and not os.path.islink(path):
+                fix_pkg_config(unpack_dir, path)
+
+
+def _fix_xml_tools(unpack_dir: str) -> None:
+    """Adjust the path in XML tools.
+
+    :param unpack_dir: Directory containing unpacked files to normalize.
+    """
+    xml2_config_path = os.path.join(unpack_dir, "usr", "bin", "xml2-config")
+    with contextlib.suppress(FileNotFoundError):
+        _search_and_replace_contents(
+            xml2_config_path,
+            re.compile(r"prefix=/usr"),
+            "prefix={}/usr".format(unpack_dir),
+        )
+
+    xslt_config_path = os.path.join(unpack_dir, "usr", "bin", "xslt-config")
+    with contextlib.suppress(FileNotFoundError):
+        _search_and_replace_contents(
+            xslt_config_path,
+            re.compile(r"prefix=/usr"),
+            "prefix={}/usr".format(unpack_dir),
+        )
+
+
+def _fix_symlink(
+    path: str, unpack_dir: str, root: str, repository: "RepositoryType"
+) -> None:
+    host_target = os.readlink(path)
+    if host_target in repository.get_package_libraries("libc6"):
+        logger.debug("Not fixing symlink %s: it's pointing to libc", host_target)
+        return
+
+    target = os.path.join(unpack_dir, os.readlink(path)[1:])
+    if not os.path.exists(target) and not _try_copy_local(path, target):
+        return
+    os.remove(path)
+    os.symlink(os.path.relpath(target, root), path)
+
+
+def _fix_shebangs(unpack_dir: str) -> None:
+    """Change hard-coded shebangs in unpacked files to use env."""
+    _rewrite_python_shebangs(unpack_dir)
+
+
+def _try_copy_local(path: str, target: str) -> bool:
+    real_path = os.path.realpath(path)
+    if os.path.exists(real_path):
+        logger.warning("Copying needed target link from the system: %s", real_path)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copyfile(os.readlink(path), target)
+        return True
+
+    logger.warning("%s will be a dangling symlink", path)
+    return False
+
+
+def fix_pkg_config(
+    root: Union[str, Path],
+    pkg_config_file: Union[str, Path],
+    prefix_trim: Optional[Union[str, Path]] = None,
+) -> None:
+    """Rewrite the prefix entry in a pkg-config file.
+
+    :param root: The root to add to the configuration prefix.
+    :param pkg_config_file: The pkg-config file to process.
+    :param prefix_trim: The initial path to remove from the configuration prefix.
+    """
+    # FIXME: see https://bugs.launchpad.net/snapcraft/+bug/1916281
+    pattern_trim = None
+    if prefix_trim:
+        pattern_trim = re.compile("^prefix={}(?P<prefix>.*)".format(prefix_trim))
+    pattern = re.compile("^prefix=(?P<prefix>.*)")
+
+    with fileinput.input(pkg_config_file, inplace=True) as input_file:
+        match_trim = None
+        for line in input_file:
+            match = pattern.search(str(line))
+            if prefix_trim is not None and pattern_trim is not None:
+                match_trim = pattern_trim.search(str(line))
+            if prefix_trim is not None and match_trim is not None:
+                print("prefix={}{}".format(root, match_trim.group("prefix")))
+            elif match:
+                print("prefix={}{}".format(root, match.group("prefix")))
+            else:
+                print(line, end="")
+
+
+def _fix_filemode(path: str) -> None:
+    mode = stat.S_IMODE(os.stat(path, follow_symlinks=False).st_mode)
+    if mode & 0o4000 or mode & 0o2000:
+        logger.warning("Removing suid/guid from %s", path)
+        os.chmod(path, mode & 0o1777)
+
+
+def _rewrite_python_shebangs(root_dir):
+    """Recursively change #!/usr/bin/pythonX shebangs to #!/usr/bin/env pythonX.
+
+    :param str root_dir: Directory that will be crawled for shebangs.
+    """
+    file_pattern = re.compile(r"")
+    argless_shebang_pattern = re.compile(r"\A#!.*(python\S*)$", re.MULTILINE)
+    shebang_pattern_with_args = re.compile(
+        r"\A#!.*(python\S*)[ \t\f\v]+(\S+)$", re.MULTILINE
+    )
+
+    _replace_in_file(
+        root_dir, file_pattern, argless_shebang_pattern, r"#!/usr/bin/env \1"
+    )
+
+    # The above rewrite will barf if the shebang includes any args to python.
+    # For example, if the shebang was `#!/usr/bin/python3 -Es`, just replacing
+    # that with `#!/usr/bin/env python3 -Es` isn't going to work as `env`
+    # doesn't support arguments like that.
+    #
+    # The solution is to replace the shebang with one pointing to /bin/sh, and
+    # then exec the original shebang with included arguments. This requires
+    # some quoting hacks to ensure the file can be interpreted by both sh as
+    # well as python, but it's better than shipping our own `env`.
+    _replace_in_file(
+        root_dir,
+        file_pattern,
+        shebang_pattern_with_args,
+        r"""#!/bin/sh\n''''exec \1 \2 -- "$0" "$@" # '''""",
+    )
+
+
+def _replace_in_file(
+    directory: str, file_pattern: Pattern, search_pattern: Pattern, replacement: str
+) -> None:
+    """Search and replaces patterns that match a file pattern.
+
+    :param directory: The directory to look for files.
+    :param file_pattern: The file pattern to match inside directory.
+    :param search_pattern: A re.compile'd pattern to search for within matching files.
+    :param replacement: The string to replace the matching search_pattern with.
+    """
+    for root, _, files in os.walk(directory):
+        for file_name in files:
+            if file_pattern.match(file_name):
+                file_path = os.path.join(root, file_name)
+                # Don't bother trying to rewrite a symlink. It's either invalid
+                # or the linked file will be rewritten on its own.
+                if not os.path.islink(file_path):
+                    _search_and_replace_contents(file_path, search_pattern, replacement)
+
+
+def _search_and_replace_contents(
+    file_path: str, search_pattern: Pattern, replacement: str
+) -> None:
+    """Search file and replace any occurrence of pattern with replacement.
+
+    :param file_path: Path of file to be searched.
+    :param re.RegexObject search_pattern: Pattern for which to search.
+    :param replacement: The string to replace pattern.
+    """
+    try:
+        with open(file_path, "r+") as fil:
+            try:
+                original = fil.read()
+            except UnicodeDecodeError:
+                # This was probably a binary file. Skip it.
+                return
+
+            replaced = search_pattern.sub(replacement, original)
+            if replaced != original:
+                fil.seek(0)
+                fil.truncate()
+                fil.write(replaced)
+    except PermissionError as err:
+        logger.warning("Unable to open %s for writing: %s", file_path, err)

--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -85,7 +85,11 @@ def _fix_artifacts(unpack_dir: str, repository: "RepositoryType") -> None:
             elif os.path.exists(path):
                 _fix_filemode(path)
 
-            if path.endswith(".pc") and not os.path.islink(path):
+            if (
+                path.endswith(".pc")
+                and os.path.isfile(path)
+                and not os.path.islink(path)
+            ):
                 fix_pkg_config(unpack_dir, path)
 
 

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -1,0 +1,288 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2017-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import stat
+import textwrap
+
+import pytest
+
+from craft_parts.packages.base import DummyRepository
+from craft_parts.packages.normalize import normalize
+
+
+@pytest.mark.parametrize(
+    "tc",
+    [
+        [  # fix_xml2_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xml2-config"),
+                "content": "prefix=/usr/foo",
+                "expected": "prefix=root/usr/foo",
+            }
+        ],
+        [  # no_fix_xml2_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xml2-config"),
+                "content": "prefix=/foo",
+                "expected": "prefix=/foo",
+            }
+        ],
+        [  # fix_xslt_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xslt-config"),
+                "content": "prefix=/usr/foo",
+                "expected": "prefix=root/usr/foo",
+            }
+        ],
+        [  # no_fix_xslt_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xslt-config"),
+                "content": "prefix=/foo",
+                "expected": "prefix=/foo",
+            }
+        ],
+        [  # fix_xml2_xslt_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xml2-config"),
+                "content": "prefix=/usr/foo",
+                "expected": "prefix=root/usr/foo",
+            },
+            {
+                "path": os.path.join("root", "usr", "bin", "xslt-config"),
+                "content": "prefix=/usr/foo",
+                "expected": "prefix=root/usr/foo",
+            },
+        ],
+        [  # no_fix_xml2_xslt_config
+            {
+                "path": os.path.join("root", "usr", "bin", "xml2-config"),
+                "content": "prefix=/foo",
+                "expected": "prefix=/foo",
+            },
+            {
+                "path": os.path.join("root", "usr", "bin", "xslt-config"),
+                "content": "prefix=/foo",
+                "expected": "prefix=/foo",
+            },
+        ],
+    ],
+)
+@pytest.mark.usefixtures("new_dir")
+class TestFixXmlTools:
+    """Check the normalization of pathnames in XML tools."""
+
+    def test_fix_xmltools(self, tc):
+        for test_file in tc:
+            path = test_file["path"]
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as f:
+                f.write(test_file["content"])
+
+        normalize("root", repository=DummyRepository)
+
+        for test_file in tc:
+            with open(test_file["path"], "r") as f:
+                assert f.read() == test_file["expected"]
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestFixShebang:
+    """Check the normalization of script interpreter lines."""
+
+    scenarios = [
+        (
+            "python bin dir",
+            {
+                "file_path": os.path.join("root", "bin", "a"),
+                "content": "#!/usr/bin/python\nimport this",
+                "expected": "#!/usr/bin/env python\nimport this",
+            },
+        ),
+        (
+            "python3 bin dir",
+            {
+                "file_path": os.path.join("root", "bin", "d"),
+                "content": "#!/usr/bin/python3\nimport this",
+                "expected": "#!/usr/bin/env python3\nimport this",
+            },
+        ),
+        (
+            "sbin dir",
+            {
+                "file_path": os.path.join("root", "sbin", "b"),
+                "content": "#!/usr/bin/python\nimport this",
+                "expected": "#!/usr/bin/env python\nimport this",
+            },
+        ),
+        (
+            "usr/bin dir",
+            {
+                "file_path": os.path.join("root", "usr", "bin", "c"),
+                "content": "#!/usr/bin/python\nimport this",
+                "expected": "#!/usr/bin/env python\nimport this",
+            },
+        ),
+        (
+            "usr/sbin dir",
+            {
+                "file_path": os.path.join("root", "usr", "sbin", "d"),
+                "content": "#!/usr/bin/python\nimport this",
+                "expected": "#!/usr/bin/env python\nimport this",
+            },
+        ),
+        (
+            "opt/bin dir",
+            {
+                "file_path": os.path.join("root", "opt", "bin", "e"),
+                "content": "#!/usr/bin/python\nraise Exception()",
+                "expected": "#!/usr/bin/env python\nraise Exception()",
+            },
+        ),
+    ]
+
+    def test_fix_shebang(self):
+        for _, data in self.scenarios:
+            os.makedirs(os.path.dirname(data["file_path"]), exist_ok=True)
+            with open(data["file_path"], "w") as fd:
+                fd.write(data["content"])
+
+        normalize("root", repository=DummyRepository)
+
+        for _, data in self.scenarios:
+            with open(data["file_path"], "r") as fd:
+                assert fd.read() == data["expected"]
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestRemoveUselessFiles:
+    """Check the removal of unnecessary files."""
+
+    def create(self, file_path: str) -> str:
+        path = os.path.join("root", file_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, "w").close()
+
+        return path
+
+    def test_remove(self):
+        paths = [
+            self.create(p)
+            for p in [
+                os.path.join("usr", "lib", "python3.5", "sitecustomize.py"),
+                os.path.join("usr", "lib", "python2.7", "sitecustomize.py"),
+                os.path.join("usr", "lib", "python", "sitecustomize.py"),
+            ]
+        ]
+        normalize("root", repository=DummyRepository)
+
+        for p in paths:
+            assert os.path.exists(p) is False
+
+    def test_no_remove(self):
+        path = self.create(os.path.join("opt", "python3.5", "sitecustomize.py"))
+        normalize("root", repository=DummyRepository)
+
+        assert os.path.exists(path)
+
+
+class TestFixPkgConfig:
+    """Check the normalization of pkg-config files."""
+
+    def test_fix_pkg_config(self, tmpdir):
+        pc_file = tmpdir / "granite.pc"
+
+        pc_file.write_text(
+            textwrap.dedent(
+                """\
+                prefix=/usr
+                exec_prefix=${prefix}
+                libdir=${prefix}/lib
+                includedir=${prefix}/include
+
+                Name: granite
+                Description: elementary\'s Application Framework
+                Version: 0.4
+                Libs: -L${libdir} -lgranite
+                Cflags: -I${includedir}/granite
+                Requires: cairo gee-0.8 glib-2.0 gio-unix-2.0 gobject-2.0
+                """
+            ),
+            encoding=None,
+        )
+
+        normalize(tmpdir, repository=DummyRepository)
+
+        expected_pc_file_content = textwrap.dedent(
+            f"""\
+            prefix={tmpdir}/usr
+            exec_prefix=${{prefix}}
+            libdir=${{prefix}}/lib
+            includedir=${{prefix}}/include
+
+            Name: granite
+            Description: elementary's Application Framework
+            Version: 0.4
+            Libs: -L${{libdir}} -lgranite
+            Cflags: -I${{includedir}}/granite
+            Requires: cairo gee-0.8 glib-2.0 gio-unix-2.0 gobject-2.0
+            """
+        )
+
+        assert pc_file.read_text(encoding=None) == expected_pc_file_content
+
+
+@pytest.mark.parametrize(
+    "src,dst",
+    [
+        ("a", "rel-to-a"),
+        # disabled: calls BaseRepository.get_package_libraries()
+        # ("/a", "abs-to-a"),
+    ],
+)
+class TestFixSymlinks:
+    """Check the normalization of symbolic links."""
+
+    def test_fix_symlinks(self, src, dst, new_dir):
+        os.makedirs("a")
+        open("1", mode="w").close()
+
+        os.symlink(src, dst)
+        normalize(new_dir, repository=DummyRepository)
+
+        assert os.readlink(dst) == src
+
+
+class TestFixSUID:
+    """Check the normalization of suid bits in file mode."""
+
+    @pytest.mark.parametrize(
+        "key,test_mod,expected_mod",
+        [
+            ("suid_file", 0o4765, 0o0765),
+            ("guid_file", 0o2777, 0o0777),
+            ("suid_guid_file", 0o6744, 0o0744),
+            ("suid_guid_sticky_file", 0o7744, 0o1744),
+        ],
+    )
+    def test_mode(self, key, test_mod, expected_mod, tmpdir):
+        f = os.path.join(tmpdir, key)
+        open(f, mode="w").close()
+        os.chmod(f, test_mod)
+
+        normalize(tmpdir, repository=DummyRepository)
+
+        assert stat.S_IMODE(os.stat(f).st_mode) == expected_mod

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -244,6 +244,13 @@ class TestFixPkgConfig:
 
         assert pc_file.read_text(encoding=None) == expected_pc_file_content
 
+    def test_fix_pkg_config_is_dir(self, tmpdir):
+        pc_file = tmpdir / "granite.pc"
+        pc_file.mkdir()
+
+        # this shouldn't crash
+        normalize(tmpdir, repository=DummyRepository)
+
 
 @pytest.mark.parametrize(
     "src,dst",

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -17,6 +17,7 @@
 import os
 import stat
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -92,7 +93,7 @@ class TestFixXmlTools:
             with open(path, "w") as f:
                 f.write(test_file["content"])
 
-        normalize("root", repository=DummyRepository)
+        normalize(Path("root"), repository=DummyRepository)
 
         for test_file in tc:
             with open(test_file["path"], "r") as f:
@@ -160,7 +161,7 @@ class TestFixShebang:
             with open(data["file_path"], "w") as fd:
                 fd.write(data["content"])
 
-        normalize("root", repository=DummyRepository)
+        normalize(Path("root"), repository=DummyRepository)
 
         for _, data in self.scenarios:
             with open(data["file_path"], "r") as fd:
@@ -187,14 +188,14 @@ class TestRemoveUselessFiles:
                 os.path.join("usr", "lib", "python", "sitecustomize.py"),
             ]
         ]
-        normalize("root", repository=DummyRepository)
+        normalize(Path("root"), repository=DummyRepository)
 
         for p in paths:
             assert os.path.exists(p) is False
 
     def test_no_remove(self):
         path = self.create(os.path.join("opt", "python3.5", "sitecustomize.py"))
-        normalize("root", repository=DummyRepository)
+        normalize(Path("root"), repository=DummyRepository)
 
         assert os.path.exists(path)
 


### PR DESCRIPTION
Packages unpacked in the stage area may contain files that need to be
patched to work correctly. Patches include replacing absolute pathnames
to the python interpreter in script shebangs, converting absolute
symlinks to relative, cleaning suid/guid bits, and changing path names
in pkg-config and xml2/xslt config files to reflect the new installation
root.

The implementation of package normalization and tests is ported from
Snapcraft, and will be replaced by an upcoming stand-alone package
containing repository and package operations.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
