### PR TITLE
plugins: add go plugin (CRAFT-48)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,6 +74,9 @@ jobs:
         run: |
           pip install .[dev]
           pip install -e .
+      - name: Install additional test dependencies
+        run: |
+          sudo apt install -y golang
       - name: Run unit tests
         run: |
           make test-units

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -123,13 +123,11 @@ class GoPlugin(Plugin):
 
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
-        return {"gcc"}
+        return set()
 
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
-            "PARTS_GO_LDFLAGS": "-ldflags -linkmode=external",
-            "CGO_ENABLED": "1",
             "GOBIN": "{}/bin".format(self._part_info.part_install_dir),
         }
 
@@ -144,8 +142,5 @@ class GoPlugin(Plugin):
 
         return [
             "go mod download",
-            'go install -p "{}" {} ${{PARTS_GO_LDFLAGS}} ./...'.format(
-                self._part_info.parallel_build_count,
-                tags,
-            ),
+            f'go install -p "{self._part_info.parallel_build_count}" {tags} ./...',
         ]

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -22,9 +22,9 @@ from typing import Any, Dict, List, Optional, Set, cast
 
 from craft_parts import errors
 
+from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
-from .validator import PluginEnvironmentValidator
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class GoPluginProperties(PluginProperties, PluginModel):
         return cls(**plugin_data)
 
 
-class GoPluginEnvironmentValidator(PluginEnvironmentValidator):
+class GoPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     """Check the execution environment for the Go plugin.
 
     :param part_name: The part whose build environment is being validated.
@@ -76,7 +76,7 @@ class GoPluginEnvironmentValidator(PluginEnvironmentValidator):
                 )
             logger.debug("found %s", version)
         except subprocess.CalledProcessError as err:
-            if err.returncode != PluginEnvironmentValidator.COMMAND_NOT_FOUND:
+            if err.returncode != validator.COMMAND_NOT_FOUND:
                 raise errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason=f"go compiler failed with error code {err.returncode}",

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -1,0 +1,151 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The Go plugin."""
+
+import logging
+import subprocess
+from typing import Any, Dict, List, Optional, Set, cast
+
+from craft_parts import errors
+
+from .base import Plugin, PluginModel, extract_plugin_properties
+from .properties import PluginProperties
+from .validator import PluginEnvironmentValidator
+
+logger = logging.getLogger(__name__)
+
+
+class GoPluginProperties(PluginProperties, PluginModel):
+    """The part properties used by the Go plugin."""
+
+    go_buildtags: List[str] = []
+
+    # part properties required by the plugin
+    source: str
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        """Populate make properties from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+
+        :raise pydantic.ValidationError: If validation fails.
+        """
+        plugin_data = extract_plugin_properties(
+            data, plugin_name="go", required=["source"]
+        )
+        return cls(**plugin_data)
+
+
+class GoPluginEnvironmentValidator(PluginEnvironmentValidator):
+    """Check the execution environment for the Go plugin.
+
+    :param part_name: The part whose build environment is being validated.
+    :param env: A string containing the build step environment setup.
+    """
+
+    def validate_environment(self, *, part_dependencies: Optional[List[str]] = None):
+        """Ensure the environment contains dependencies needed by the plugin.
+
+        :param part_dependencies: A list of the parts this part depends on.
+
+        :raises PluginEnvironmentValidationError: If the environment is invalid.
+        """
+        try:
+            version = self._execute("go version").strip()
+            if not version.startswith("go version"):
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=f"invalid go compiler version {version!r}",
+                )
+            logger.debug("found %s", version)
+        except subprocess.CalledProcessError as err:
+            if err.returncode != PluginEnvironmentValidator.COMMAND_NOT_FOUND:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=f"go compiler failed with error code {err.returncode}",
+                ) from err
+
+            if part_dependencies is None:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="go compiler not found",
+                ) from err
+
+            if "go" not in part_dependencies:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=(
+                        f"go compiler not found and part {self._part_name!r} "
+                        f"does not depend on a part named 'go'"
+                    ),
+                ) from err
+
+
+class GoPlugin(Plugin):
+    """A plugin for go projects using go.mod.
+
+    The go plugin requires a go compiler installed on your system. This can
+    be achieved by adding the appropriate golang package to ``build-packages``,
+    or to have it installed or built in a different part. In this case, the
+    name of the part supplying the go compiler must be "go".
+
+    The go plugin uses the common plugin keywords as well as those for "sources".
+    Additionally, the following plugin-specific keywords can be used:
+
+    - ``go-buildtags``
+      (list of strings)
+      Tags to use during the go build. Default is not to use any build tags.
+    """
+
+    properties_class = GoPluginProperties
+    validator_class = GoPluginEnvironmentValidator
+
+    def get_build_snaps(self) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+        return {"gcc"}
+
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+        return {
+            "PARTS_GO_LDFLAGS": "-ldflags -linkmode=external",
+            "CGO_ENABLED": "1",
+            "GOBIN": "{}/bin".format(self._part_info.part_install_dir),
+        }
+
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        options = cast(GoPluginProperties, self._options)
+
+        if options.go_buildtags:
+            tags = "-tags={}".format(",".join(options.go_buildtags))
+        else:
+            tags = ""
+
+        return [
+            "go mod download",
+            'go install -p "{}" {} ${{PARTS_GO_LDFLAGS}} ./...'.format(
+                self._part_info.parallel_build_count,
+                tags,
+            ),
+        ]

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, Type
 from .autotools_plugin import AutotoolsPlugin
 from .base import Plugin
 from .dump_plugin import DumpPlugin
+from .go_plugin import GoPlugin
 from .make_plugin import MakePlugin
 from .nil_plugin import NilPlugin
 from .properties import PluginProperties
@@ -39,6 +40,7 @@ PluginType = Type[Plugin]
 _BUILTIN_PLUGINS: Dict[str, PluginType] = {
     "autotools": AutotoolsPlugin,
     "dump": DumpPlugin,
+    "go": GoPlugin,
     "make": MakePlugin,
     "nil": NilPlugin,
     "python": PythonPlugin,

--- a/craft_parts/plugins/validator.py
+++ b/craft_parts/plugins/validator.py
@@ -33,7 +33,13 @@ class PluginEnvironmentValidator:
     deb package, a snap, built from sources or even built by a different
     part. Plugin environment validators allow a plugin to ensure its
     execution environment is correct before building a part.
+
+    :param part_name: The part whose build environment is being validated.
+    :param env: A string containing the build step environment setup.
     """
+
+    COMMAND_NOT_FOUND = 127
+    """The shell error code for command not found."""
 
     def __init__(self, *, part_name: str, env: str):
         self._part_name = part_name

--- a/craft_parts/plugins/validator.py
+++ b/craft_parts/plugins/validator.py
@@ -24,6 +24,10 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 
+COMMAND_NOT_FOUND = 127
+"""The shell error code for command not found."""
+
+
 class PluginEnvironmentValidator:
     """Base class for plugin environment validators.
 
@@ -37,9 +41,6 @@ class PluginEnvironmentValidator:
     :param part_name: The part whose build environment is being validated.
     :param env: A string containing the build step environment setup.
     """
-
-    COMMAND_NOT_FOUND = 127
-    """The shell error code for command not found."""
 
     def __init__(self, *, part_name: str, env: str):
         self._part_name = part_name

--- a/tests/integration/plugins/test_go.py
+++ b/tests/integration/plugins/test_go.py
@@ -1,0 +1,74 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import yaml
+
+from craft_parts import LifecycleManager, Step
+
+
+def test_go_plugin(new_dir, mocker):
+    parts_yaml = textwrap.dedent(
+        """
+        parts:
+          foo:
+            plugin: go
+            source: .
+            go-buildtags: [my_tag]
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    Path("go.mod").write_text(
+        textwrap.dedent(
+            """
+            module example.com/hello
+            go 1.13
+            require rsc.io/quote v1.5.2
+            """
+        )
+    )
+
+    Path("hello.go").write_text(
+        textwrap.dedent(
+            """
+            // +build my_tag
+            package main
+
+            import "fmt"
+            import "rsc.io/quote"
+
+            func main() {
+                fmt.Printf("%s", quote.Glass())
+            }
+            """
+        )
+    )
+
+    # the go compiler is installed in the ci test setup
+    lf = LifecycleManager(parts, application_name="test_go", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    binary = Path(lf.project_info.prime_dir, "bin", "hello")
+
+    output = subprocess.check_output([str(binary)], text=True)
+    assert output == "I can eat glass and it doesn't hurt me."

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -53,9 +53,6 @@ def mytool_error(new_dir):
     yield tool
 
 
-_COMMAND_NOT_FOUND = 127  # shell return code for command not found
-
-
 class AppPluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """The application-defined plugin properties."""
 
@@ -80,7 +77,7 @@ class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):
                     reason="mytool is expected to print ok",
                 )
         except subprocess.CalledProcessError as err:
-            if err.returncode != _COMMAND_NOT_FOUND:
+            if err.returncode != plugins.PluginEnvironmentValidator.COMMAND_NOT_FOUND:
                 raise errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason=f"mytool failed with error code {err.returncode}",

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -77,7 +77,7 @@ class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):
                     reason="mytool is expected to print ok",
                 )
         except subprocess.CalledProcessError as err:
-            if err.returncode != plugins.PluginEnvironmentValidator.COMMAND_NOT_FOUND:
+            if err.returncode != plugins.validator.COMMAND_NOT_FOUND:
                 raise errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason=f"mytool failed with error code {err.returncode}",

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -140,7 +140,7 @@ def test_get_build_packages(part_info):
     properties = GoPlugin.properties_class.unmarshal({"source": "."})
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
-    assert plugin.get_build_packages() == {"gcc"}
+    assert plugin.get_build_packages() == set()
 
 
 def test_get_build_environment(new_dir, part_info):
@@ -148,9 +148,7 @@ def test_get_build_environment(new_dir, part_info):
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_environment() == {
-        "CGO_ENABLED": "1",
         "GOBIN": f"{new_dir}/parts/my-part/install/bin",
-        "PARTS_GO_LDFLAGS": "-ldflags -linkmode=external",
     }
 
 
@@ -160,7 +158,7 @@ def test_get_build_commands(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
-        'go install -p "1"  ${PARTS_GO_LDFLAGS} ./...',
+        'go install -p "1"  ./...',
     ]
 
 
@@ -172,7 +170,7 @@ def test_get_build_commands_with_buildtags(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
-        'go install -p "1" -tags=dev,debug ${PARTS_GO_LDFLAGS} ./...',
+        'go install -p "1" -tags=dev,debug ./...',
     ]
 
 

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -1,0 +1,194 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2020-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from craft_parts import errors
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins.go_plugin import GoPlugin
+
+
+@pytest.fixture
+def go_exe(new_dir):
+    go_bin = Path(new_dir, "mock_bin", "go")
+    go_bin.parent.mkdir(exist_ok=True)
+    go_bin.write_text('#!/bin/sh\necho "go version go1.13.8 linux/amd64"')
+    go_bin.chmod(0o755)
+    yield go_bin
+
+
+@pytest.fixture
+def broken_go_exe(new_dir):
+    go_bin = Path(new_dir, "mock_bin", "go")
+    go_bin.parent.mkdir(exist_ok=True)
+    go_bin.write_text("#!/bin/sh\nexit 33")
+    go_bin.chmod(0o755)
+    yield go_bin
+
+
+@pytest.fixture
+def invalid_go_exe(new_dir):
+    go_bin = Path(new_dir, "mock_bin", "go")
+    go_bin.parent.mkdir(exist_ok=True)
+    go_bin.touch()
+    go_bin.chmod(0o755)
+    yield go_bin
+
+
+@pytest.fixture
+def part_info(new_dir):
+    yield PartInfo(
+        project_info=ProjectInfo(application_name="test", cache_dir=new_dir),
+        part=Part("my-part", {}),
+    )
+
+
+def test_validate_environment(go_exe, part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(go_exe.parent)}"
+    )
+    validator.validate_environment()
+
+
+def test_validate_environment_missing_go(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "go compiler not found"
+
+
+def test_validate_environment_broken_go(broken_go_exe, part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(broken_go_exe.parent)}"
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "go compiler failed with error code 33"
+
+
+def test_validate_environment_invalid_go(invalid_go_exe, part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(invalid_go_exe.parent)}"
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "invalid go compiler version ''"
+
+
+def test_validate_environment_with_go_part(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator.validate_environment(part_dependencies=["go"])
+
+
+def test_validate_environment_without_go_part(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment(part_dependencies=[])
+
+    assert raised.value.reason == (
+        "go compiler not found and part 'my-part' "
+        "does not depend on a part named 'go'"
+    )
+
+
+def test_get_build_snaps(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_snaps() == set()
+
+
+def test_get_build_packages(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_packages() == {"gcc"}
+
+
+def test_get_build_environment(new_dir, part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_environment() == {
+        "CGO_ENABLED": "1",
+        "GOBIN": f"{new_dir}/parts/my-part/install/bin",
+        "PARTS_GO_LDFLAGS": "-ldflags -linkmode=external",
+    }
+
+
+def test_get_build_commands(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_commands() == [
+        "go mod download",
+        'go install -p "1"  ${PARTS_GO_LDFLAGS} ./...',
+    ]
+
+
+def test_get_build_commands_with_buildtags(part_info):
+    properties = GoPlugin.properties_class.unmarshal(
+        {"source": ".", "go-buildtags": ["dev", "debug"]}
+    )
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_commands() == [
+        "go mod download",
+        'go install -p "1" -tags=dev,debug ${PARTS_GO_LDFLAGS} ./...',
+    ]
+
+
+def test_invalid_parameters():
+    with pytest.raises(ValidationError) as raised:
+        GoPlugin.properties_class.unmarshal({"source": ".", "go-invalid": True})
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("go-invalid",)
+    assert err[0]["type"] == "value_error.extra"
+
+
+def test_missing_parameters():
+    with pytest.raises(ValidationError) as raised:
+        GoPlugin.properties_class.unmarshal({})
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("source",)
+    assert err[0]["type"] == "value_error.missing"


### PR DESCRIPTION
Add a plugin for go projects using go.mod.  Plugin build definitions
are based on the Snapcraft V2 go plugin.
    
Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
