### PR TITLE
packages: handle packages with no candidate (CRAFT-219)

### DIFF
--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -19,6 +19,7 @@
 from typing import Sequence
 
 from craft_parts.errors import PartsError
+from craft_parts.utils import formatting_utils
 
 
 class PackagesError(PartsError):
@@ -33,6 +34,20 @@ class PackageNotFound(PackagesError):
         brief = f"Package not found: {package_name}."
 
         super().__init__(brief=brief)
+
+
+class PackagesNotFound(PackagesError):
+    """Requested package doesn't exist in the remote repository."""
+
+    def __init__(self, packages: Sequence[str]):
+        self.packages = packages
+        missing_pkgs = formatting_utils.humanize_list(packages, "and")
+        brief = f"Failed to find installation candidate for packages: {missing_pkgs}."
+        resolution = (
+            "Make sure the repository configuration and package names are correct."
+        )
+
+        super().__init__(brief=brief, resolution=resolution)
 
 
 class PackageFetchError(PackagesError):

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -20,15 +20,27 @@ from craft_parts.packages import errors
 def test_package_not_found():
     err = errors.PackageNotFound("foobar")
     assert err.package_name == "foobar"
-    assert err.brief == ("Package not found: foobar.")
+    assert err.brief == "Package not found: foobar."
     assert err.details is None
     assert err.resolution is None
+
+
+def test_packages_not_found():
+    err = errors.PackagesNotFound(["foo", "bar"])
+    assert err.packages == ["foo", "bar"]
+    assert err.brief == (
+        "Failed to find installation candidate for packages: 'bar' and 'foo'."
+    )
+    assert err.details is None
+    assert err.resolution == (
+        "Make sure the repository configuration and package names are correct."
+    )
 
 
 def test_package_fetch_error():
     err = errors.PackageFetchError("something bad happened")
     assert err.message == "something bad happened"
-    assert err.brief == ("Failed to fetch package: something bad happened.")
+    assert err.brief == "Failed to fetch package: something bad happened."
     assert err.details is None
     assert err.resolution is None
 
@@ -36,7 +48,7 @@ def test_package_fetch_error():
 def test_package_list_refresh_error():
     err = errors.PackageListRefreshError("something bad happened")
     assert err.message == "something bad happened"
-    assert err.brief == ("Failed to refresh package list: something bad happened.")
+    assert err.brief == "Failed to refresh package list: something bad happened."
     assert err.details is None
     assert err.resolution is None
 
@@ -45,7 +57,7 @@ def test_package_broken():
     err = errors.PackageBroken("foobar", deps=["foo", "bar"])
     assert err.package_name == "foobar"
     assert err.deps == ["foo", "bar"]
-    assert err.brief == ("Package 'foobar' has unmet dependencies: foo, bar.")
+    assert err.brief == "Package 'foobar' has unmet dependencies: foo, bar."
     assert err.details is None
     assert err.resolution is None
 


### PR DESCRIPTION
A port of the snapcraft PR #3528 by Chris Patterson. Original
description follows:

* Add some checks to ensure package.candidate is not None before using
  it. If it is None, when expected to not be `None`, raise a
  `PackageNotFoundError` with the name of the package in question.

* Do not iterate over all packages when unmarking. This is the cause of
  https://forum.snapcraft.io/t/snapcraft-crash-when-esm-repositories-are-present/24587/8
  where a package was being inspected that did not have an available candidate,
  causing Snapcraft to fail unnecessarily.

Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
