### PR TITLE
packages: add test to ensure unnecessary normalize not called (CRAFT-221)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,5 @@ sphinx
 sphinx-autodoc-typehints
 sphinx-pydantic
 sphinx-rtd-theme
+types-PyYAML
+types-requests

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -191,6 +191,22 @@ class TestPackages:
             )
         assert raised.value.message == "foo"
 
+    def test_unpack_stage_packages_dont_normalize(self, tmpdir, mocker):
+        packages_path = Path(tmpdir, "pkg")
+        install_path = Path(tmpdir, "install")
+
+        mock_normalize = mocker.patch("craft_parts.packages.normalize.normalize")
+
+        # no packages in packages_path, no need to normalize
+        packages_path.mkdir()
+        install_path.mkdir()
+
+        deb.Ubuntu.unpack_stage_packages(
+            stage_packages_path=packages_path, install_path=install_path
+        )
+
+        mock_normalize.assert_not_called()
+
 
 class TestBuildPackages:
     def test_install_build_packages(self, fake_apt_cache, fake_run):


### PR DESCRIPTION
When unpacking stage packages, it's not necessary to normalize unpacked
files if nothing was unpacked. This test verifies if no such call is
made in this case.

This is a follow-up to PR #76, and adds the normalization call test included in
https://github.com/snapcore/snapcraft/pull/3534.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
