### PR TITLE
sequencer: improve dirty state report message (CRAFT-302)

### DIFF
--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -136,7 +136,7 @@ class DirtyReport:
             else:
                 part_name = self.changed_dependencies[0].part_name
                 step_name = self.changed_dependencies[0].step.name.lower()
-                reasons.append(f"part {part_name!r} {step_name}")
+                reasons.append(f"{step_name} for part {part_name!r}")
 
         if not reasons:
             return ""

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -134,7 +134,9 @@ class DirtyReport:
             if reasons_count > 1 or len(self.changed_dependencies) > 1:
                 reasons.append("dependencies")
             else:
-                reasons.append(f"{self.changed_dependencies[0].part_name!r}")
+                part_name = self.changed_dependencies[0].part_name
+                step_name = self.changed_dependencies[0].step.name.lower()
+                reasons.append(f"part {part_name!r} {step_name}")
 
         if not reasons:
             return ""

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -143,7 +143,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="required to build 'bar'"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="part 'foo' stage changed"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
         Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on
     ]

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -143,7 +143,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="required to build 'bar'"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="'foo' changed"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="part 'foo' stage changed"),
         Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on
     ]

--- a/tests/unit/state_manager/test_reports.py
+++ b/tests/unit/state_manager/test_reports.py
@@ -46,7 +46,7 @@ def test_outdated_report(step, source_modified, result):
         (None, ["c"], None, "'c' option changed"),
         (None, ["c", "d"], None, "options changed"),
         (["a"], ["c"], None, "options and properties changed"),
-        (None, None, [Dependency("e", Step.STAGE)], "'e' changed"),
+        (None, None, [Dependency("e", Step.STAGE)], "part 'e' stage changed"),
         (
             None,
             None,

--- a/tests/unit/state_manager/test_reports.py
+++ b/tests/unit/state_manager/test_reports.py
@@ -46,7 +46,7 @@ def test_outdated_report(step, source_modified, result):
         (None, ["c"], None, "'c' option changed"),
         (None, ["c", "d"], None, "options changed"),
         (["a"], ["c"], None, "options and properties changed"),
-        (None, None, [Dependency("e", Step.STAGE)], "part 'e' stage changed"),
+        (None, None, [Dependency("e", Step.STAGE)], "stage for part 'e' changed"),
         (
             None,
             None,

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -499,7 +499,7 @@ class TestStepDirty:
             report = sm.check_if_dirty(p1, step)
             if step == Step.BUILD:
                 assert report is not None
-                assert report.reason() == "part 'p2' stage changed"
+                assert report.reason() == "stage for part 'p2' changed"
             else:
                 assert report is None
 
@@ -531,7 +531,7 @@ class TestStepDirty:
             report = sm.check_if_dirty(p1, step)
             if step == Step.BUILD:
                 assert report is not None
-                assert report.reason() == "part 'p2' stage changed"
+                assert report.reason() == "stage for part 'p2' changed"
             else:
                 assert report is None
 

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -491,7 +491,7 @@ class TestStepDirty:
             report = sm.check_if_dirty(p1, step)
             if step == Step.BUILD:
                 assert report is not None
-                assert report.reason() == "'p2' changed"
+                assert report.reason() == "part 'p2' stage changed"
             else:
                 assert report is None
 
@@ -523,7 +523,7 @@ class TestStepDirty:
             report = sm.check_if_dirty(p1, step)
             if step == Step.BUILD:
                 assert report is not None
-                assert report.reason() == "'p2' changed"
+                assert report.reason() == "part 'p2' stage changed"
             else:
                 assert report is None
 


### PR DESCRIPTION
Clarify the message to include the dependency step name in the reason
why the step is being re-executed.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
