### PR TITLE
packages: address issues raised by pyright 1.1.151 (CRAFT-303)

### DIFF
--- a/tests/fake_snapd.py
+++ b/tests/fake_snapd.py
@@ -76,8 +76,9 @@ class FakeSnapd:
         return server_thread
 
     def stop_fake_server(self, thread):
-        self.server.shutdown()
-        self.server.socket.close()
+        if self.server:
+            self.server.shutdown()
+            self.server.socket.close()
         thread.join()
 
 

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -154,6 +154,7 @@ class TestStateDB:
         assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is False
 
         rewrapped_stw = sdb.get(part_name="foo", step=Step.PULL)
+        assert rewrapped_stw is not None
         assert rewrapped_stw.serial == 3
 
     def test_set_step_updated(self):
@@ -175,6 +176,7 @@ class TestStateDB:
         assert sdb.is_step_updated(part_name="foo", step=Step.PULL) is True
 
         rewrapped_stw = sdb.get(part_name="foo", step=Step.PULL)
+        assert rewrapped_stw is not None
         assert rewrapped_stw.serial == 2
 
 
@@ -335,6 +337,8 @@ class TestStateManager:
 
         # make the build step dirty
         stw = sm._state_db.get(part_name="p1", step=Step.BUILD)
+        assert stw is not None
+
         stw.state.part_properties["build-packages"] = ["new_pkg"]
 
         # now build should run again
@@ -443,6 +447,8 @@ class TestStepDirty:
 
         # make the build step dirty
         stw = sm._state_db.get(part_name="p1", step=Step.BUILD)
+        assert stw is not None
+
         stw.state.part_properties["build-packages"] = ["new_pkg"]
 
         # now check again if dirty
@@ -484,6 +490,8 @@ class TestStepDirty:
 
         # make p2 stage step dirty
         stw = sm._state_db.get(part_name="p2", step=Step.STAGE)
+        assert stw is not None
+
         stw.state.part_properties["stage"] = ["new_entry"]
 
         # now check if p1:build is dirty

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -62,6 +62,8 @@ def test_sequencer_run_step(step, state_class):
     seq._run_step(p1, step)
 
     stw = seq._sm._state_db.get(part_name="p1", step=step)
+    assert stw is not None
+
     state = stw.state
     assert isinstance(state, state_class)
 
@@ -112,6 +114,8 @@ def test_sequencer_rerun_step(mocker, step, state_class):
     mock_clean_part.assert_called_once_with(p1, step)
 
     stw = seq._sm._state_db.get(part_name="p1", step=step)
+    assert stw is not None
+
     state = stw.state
     assert isinstance(state, state_class)
 


### PR DESCRIPTION
Pyright 1.1.151 warns about many instances of None indexing that were
ignored by previous versions, address them.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
