### PR TITLE
cli: add a main entry point (CRAFT-34)

### DIFF
--- a/craft_parts/__main__.py
+++ b/craft_parts/__main__.py
@@ -1,0 +1,22 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The main entry point."""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/craft_parts/__main__.py
+++ b/craft_parts/__main__.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2021 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """The main entry point."""

--- a/craft_parts/__main__.py
+++ b/craft_parts/__main__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2021 Canonical Ltd
+# Copyright 2021 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -75,6 +75,12 @@ class LifecycleManager:
         if not re.match("^[A-Za-z][0-9A-Za-z_]*$", application_name):
             raise errors.InvalidApplicationName(application_name)
 
+        if not isinstance(all_parts, dict):
+            raise TypeError("parts definition must be a dictionary")
+
+        if "parts" not in all_parts:
+            raise ValueError("parts definition is missing")
+
         project_dirs = ProjectDirs(work_dir=work_dir)
 
         project_info = ProjectInfo(

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -19,7 +19,7 @@
 This is the main entry point for the craft_parts package, invoked
 when running `python -mcraft_parts`. It provides basic functionality
 to process a parts specification and display the planned sequence
-of actions (using `--plan-only`) or execute them,
+of actions (using `--dry-run`) or execute them.
 """
 
 import argparse
@@ -105,7 +105,7 @@ def _do_step(lcm: craft_parts.LifecycleManager, options: argparse.Namespace) -> 
 
     actions = lcm.plan(target_step, part_names)
 
-    if options.plan_only:
+    if options.dry_run:
         printed = False
         for action in actions:
             if options.show_skipped or action.action_type != ActionType.SKIP:
@@ -123,8 +123,8 @@ def _do_step(lcm: craft_parts.LifecycleManager, options: argparse.Namespace) -> 
 
 
 def _do_clean(lcm: craft_parts.LifecycleManager, options: argparse.Namespace) -> None:
-    if options.plan_only:
-        raise ValueError("Clean operations cannot be planned.")
+    if options.dry_run:
+        return
 
     if not options.parts:
         print("Clean all parts.")
@@ -205,7 +205,7 @@ def _parse_arguments() -> argparse.Namespace:
         help="Update the stage packages list before procceeding.",
     )
     parser.add_argument(
-        "--plan-only",
+        "--dry-run",
         action="store_true",
         help="Show planned actions to be executed and exit.",
     )

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -1,0 +1,304 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Part crafting command line tool.
+
+This is the main entry point for the craft_parts package, invoked
+when running `python -mcraft_parts`. It provides basic functionality
+to process a parts specification and display the planned sequence
+of actions (using `--plan-only`) or execute them,
+"""
+
+import argparse
+import logging
+import sys
+from functools import partial
+
+import yaml
+from xdg import BaseDirectory  # type: ignore
+
+import craft_parts
+import craft_parts.errors
+from craft_parts import ActionType, Step
+
+
+def main():
+    """Run the command-line interface."""
+    options = _parse_arguments()
+
+    if options.version:
+        print(f"craft-parts {craft_parts.__version__}")
+        sys.exit()
+
+    if options.debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+
+    logging.basicConfig(level=log_level)
+
+    try:
+        _process_parts(options)
+    except OSError as err:
+        msg = err.strerror
+        if err.filename:
+            msg = f"{err.filename}: {msg}"
+        print(f"Error: {msg}.", file=sys.stderr)
+        sys.exit(1)
+    except craft_parts.errors.PartSpecificationError:
+        print("Error: invalid parts specification.", file=sys.stderr)
+        sys.exit(2)
+    except craft_parts.errors.PartsError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(3)
+    except (ValueError, TypeError) as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(4)
+    except RuntimeError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(5)
+
+
+def _process_parts(options: argparse.Namespace) -> None:
+    with open(options.file) as opt_file:
+        part_data = yaml.safe_load(opt_file)
+
+    cache_dir = options.cache_dir
+    if not cache_dir:
+        cache_dir = BaseDirectory.save_cache_path("craft-parts")
+
+    lcm = craft_parts.LifecycleManager(
+        part_data,
+        application_name=options.application_name,
+        work_dir=options.work_dir,
+        cache_dir=cache_dir,
+        base=options.base,
+    )
+
+    command = options.command if options.command else "prime"
+    if command == "clean":
+        _do_clean(lcm, options)
+        sys.exit()
+
+    _do_step(lcm, options)
+
+
+def _do_step(lcm: craft_parts.LifecycleManager, options: argparse.Namespace) -> None:
+    target_step = _parse_step(options.command) if options.command else Step.PRIME
+    part_names = vars(options).get("parts", [])
+
+    if options.refresh:
+        lcm.refresh_packages_list()
+
+    actions = lcm.plan(target_step, part_names)
+
+    if options.plan_only:
+        printed = False
+        for action in actions:
+            if options.show_skipped or action.action_type != ActionType.SKIP:
+                print(_action_message(action))
+                printed = True
+        if not printed:
+            print("No actions to execute.")
+        sys.exit()
+
+    with lcm.action_executor() as ctx:
+        for action in actions:
+            if options.show_skipped or action.action_type != ActionType.SKIP:
+                print(f"Execute: {_action_message(action)}")
+                ctx.execute(action)
+
+
+def _do_clean(lcm: craft_parts.LifecycleManager, options: argparse.Namespace) -> None:
+    if options.plan_only:
+        raise ValueError("Clean operations cannot be planned.")
+
+    if not options.parts:
+        print("Clean all parts.")
+
+    lcm.clean(Step.PULL, part_names=options.parts)
+
+
+def _action_message(action: craft_parts.Action) -> str:
+    msg = {
+        Step.PULL: {
+            ActionType.RUN: "Pull",
+            ActionType.RERUN: "Repull",
+            ActionType.SKIP: "Skip pull",
+            ActionType.UPDATE: "Update sources for",
+        },
+        Step.BUILD: {
+            ActionType.RUN: "Build",
+            ActionType.RERUN: "Rebuild",
+            ActionType.SKIP: "Skip build",
+            ActionType.UPDATE: "Update build for",
+        },
+        Step.STAGE: {
+            ActionType.RUN: "Stage",
+            ActionType.RERUN: "Restage",
+            ActionType.SKIP: "Skip stage",
+        },
+        Step.PRIME: {
+            ActionType.RUN: "Prime",
+            ActionType.RERUN: "Re-prime",
+            ActionType.SKIP: "Skip prime",
+        },
+    }
+
+    message = f"{msg[action.step][action.action_type]} {action.part_name}"
+
+    if action.reason:
+        message += f" ({action.reason})"
+
+    return message
+
+
+def _parse_step(name: str) -> Step:
+    step_map = {
+        "pull": Step.PULL,
+        "build": Step.BUILD,
+        "stage": Step.STAGE,
+        "prime": Step.PRIME,
+    }
+
+    return step_map.get(name, Step.PRIME)
+
+
+def _parse_arguments() -> argparse.Namespace:
+    prog = "python -m craft_parts"
+    description = (
+        "A command line interface for the craft_parts module to build "
+        "parts-based projects."
+    )
+
+    parser = argparse.ArgumentParser(prog=prog, description=description, add_help=False)
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="Show this help message and exit.",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        metavar="filename",
+        default="parts.yaml",
+        help="The parts specification file. Default is 'parts.yaml'.",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Update the stage packages list before procceeding.",
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Show planned actions to be executed and exit.",
+    )
+    parser.add_argument(
+        "--show-skipped",
+        action="store_true",
+        help="Also display skipped actions.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        metavar="dirname",
+        default=".",
+        help="Use the specified work directory. Defaults to current dir.",
+    )
+    parser.add_argument(
+        "--application-name",
+        metavar="name",
+        default="craft_parts",
+        help="Set the application name. Default is 'craft_parts'.",
+    )
+    parser.add_argument(
+        "--base",
+        metavar="name",
+        default="",
+        help="Use the specified build base. Defaults to host system.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        metavar="dirname",
+        default="",
+        help="Set an alternate cache directory location.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug messages.",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Display the craft-parts version and exit.",
+    )
+
+    help_parser = argparse.ArgumentParser(add_help=False)
+    help_parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="Show this help message and exit.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_subparser = partial(
+        subparsers.add_parser, add_help=False, parents=[help_parser]
+    )
+
+    pull_parser = add_subparser("pull", help="Retrieve artifacts defined for a part.")
+    pull_parser.add_argument(
+        "parts",
+        nargs="*",
+        help="The list of parts to pull. Default is all parts.",
+    )
+
+    build_parser = add_subparser("build", help="Build artifacts defined for a part.")
+    build_parser.add_argument(
+        "parts",
+        nargs="*",
+        help="The list of parts to build. Default is all parts.",
+    )
+
+    stage_parser = add_subparser("stage", help="Stage artifacts built by a part.")
+    stage_parser.add_argument(
+        "parts",
+        nargs="*",
+        help="The list of parts to stage. Default is all parts.",
+    )
+
+    prime_parser = add_subparser(
+        "prime", help="Refine stage and prepare final payload."
+    )
+    prime_parser.add_argument(
+        "parts",
+        nargs="*",
+        help="The list of parts to prime. Default is all parts.",
+    )
+
+    clean_parser = add_subparser("clean", help="Remove a part's assets and state.")
+    clean_parser.add_argument(
+        "parts",
+        nargs="*",
+        help="The list of parts to clean. Default is all parts.",
+    )
+
+    return parser.parse_args()

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2021 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Part crafting command line tool.

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -448,6 +448,7 @@ class Ubuntu(BaseRepository):
             stage_packages_path.mkdir(exist_ok=True)
 
         stage_cache_dir, deb_cache_dir = get_cache_dirs(cache_dir)
+        deb_cache_dir.mkdir(parents=True, exist_ok=True)
 
         installed: Set[str] = set()
 
@@ -478,6 +479,7 @@ class Ubuntu(BaseRepository):
     def refresh_stage_packages_list(cls, *, cache_dir: Path, target_arch: str):
         """Refresh the list of packages available in the repository."""
         stage_cache_dir, _ = get_cache_dirs(cache_dir)
+        stage_cache_dir.mkdir(parents=True, exist_ok=True)
 
         with AptCache(
             stage_cache=stage_cache_dir, stage_cache_arch=target_arch

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -150,10 +150,10 @@ def test_main_version(mocker, capfd):
     assert out == f"craft-parts {craft_parts.__version__}\n"
 
 
-def test_main_plan_only(mocker, capfd):
+def test_main_dry_run(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -214,7 +214,7 @@ def test_main_invalid_application_name(mocker):
     Path("work_dir").mkdir()
 
     mocker.patch.object(
-        sys, "argv", ["cmd", "--plan-only", "--application-name", "znap-craft", "clean"]
+        sys, "argv", ["cmd", "--dry-run", "--application-name", "znap-craft", "clean"]
     )
     with pytest.raises(SystemExit) as raised:
         main.main()
@@ -227,7 +227,7 @@ def test_main_cache_dir(new_dir, mocker):
     mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
 
     mocker.patch.object(
-        sys, "argv", ["cmd", "--plan-only", "--cache-dir", "cache_dir", "--refresh"]
+        sys, "argv", ["cmd", "--dry-run", "--cache-dir", "cache_dir", "--refresh"]
     )
     with pytest.raises(SystemExit) as raised:
         main.main()
@@ -263,7 +263,7 @@ def test_main_alternative_work_dir(mocker, capfd):
 def test_main_alternative_parts_file(mocker, capfd, opt):
     Path("other.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", opt, "other.yaml"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", opt, "other.yaml"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -276,7 +276,7 @@ def test_main_alternative_parts_file(mocker, capfd, opt):
 def test_main_alternative_parts_invalid_file(mocker, capfd):
     Path("other.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "-f", "missing.yaml"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "-f", "missing.yaml"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code == 1
@@ -291,7 +291,7 @@ def test_main_refresh(new_dir, mocker, capfd):
 
     mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "--refresh"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "--refresh"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -336,10 +336,10 @@ def test_main_step(mocker, capfd, step, result):
         ("prime", plan_result[3]),
     ],
 )
-def test_main_step_plan_only(mocker, capfd, step, result):
+def test_main_step_dry_run(mocker, capfd, step, result):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", step])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", step])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -350,7 +350,7 @@ def test_main_step_plan_only(mocker, capfd, step, result):
     assert Path("parts").is_dir() is False
 
 
-def test_main_step_plan_only_skip(mocker, capfd):
+def test_main_step_dry_run_skip(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
     # run it once to build state
@@ -361,7 +361,7 @@ def test_main_step_plan_only_skip(mocker, capfd):
     assert err == ""
 
     # run it again on the existing state
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "prime"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "prime"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -371,7 +371,7 @@ def test_main_step_plan_only_skip(mocker, capfd):
     assert out == "No actions to execute.\n"
 
 
-def test_main_step_plan_only_show_skip(mocker, capfd):
+def test_main_step_dry_run_show_skip(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
     # run it once to build state
@@ -382,7 +382,7 @@ def test_main_step_plan_only_show_skip(mocker, capfd):
     assert err == ""
 
     # run it again on the existing state
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "--show-skip", "prime"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "--show-skip", "prime"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -406,10 +406,10 @@ def test_main_step_specify_part(mocker, capfd):
     )
 
 
-def test_main_step_specify_part_plan_only(mocker, capfd):
+def test_main_step_specify_part_dry_run(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "prime", "foo"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "prime", "foo"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -444,7 +444,7 @@ def test_main_step_specify_part_plan_only(mocker, capfd):
 def test_main_step_specify_multiple_parts(mocker, capfd, step, result):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", step, "foo", "bar"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", step, "foo", "bar"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -488,10 +488,10 @@ def test_main_step_invalid_multiple_parts(mocker, capfd):
     assert Path("parts").is_dir() is False
 
 
-def test_main_step_invalid_part_plan_only(mocker, capfd):
+def test_main_step_invalid_part_dry_run(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "pull", "invalid"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "pull", "invalid"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code == 3
@@ -505,10 +505,10 @@ def test_main_step_invalid_part_plan_only(mocker, capfd):
     assert Path("parts").is_dir() is False
 
 
-def test_main_step_invalid_multiple_parts_plan_only(mocker, capfd):
+def test_main_step_invalid_multiple_parts_dry_run(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "pull", "foo", "invalid"])
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "pull", "foo", "invalid"])
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code == 3
@@ -589,17 +589,20 @@ def test_main_clean_workdir(mocker, capfd):
     assert sorted(os.listdir(".")) == [".cache", "parts.yaml", "work_dir"]
 
 
-def test_main_clean_plan_only(mocker, capfd):
+def test_main_clean_dry_run(mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "clean"])
+    Path("parts").mkdir()
+    Path("stage").mkdir()
+    Path("prime").mkdir()
+
+    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "clean"])
     with pytest.raises(SystemExit) as raised:
         main.main()
-    assert raised.value.code == 4
+    assert raised.value.code is None
 
-    out, err = capfd.readouterr()
-    assert err == "Error: Clean operations cannot be planned.\n"
-    assert out == ""
+    # work dirs are not removed
+    assert set(os.listdir(".")).issuperset({"parts", "prime", "stage"})
 
 
 def test_main_clean_part(mocker, capfd):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,0 +1,720 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import runpy
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import craft_parts
+from craft_parts import main
+
+parts_yaml = textwrap.dedent(
+    """
+    parts:
+      foo:
+        plugin: nil
+      bar:
+        after: [foo]
+        plugin: nil
+"""
+)
+
+plan_steps = [
+    "Pull foo\nPull bar\n",
+    "Build foo\nStage foo (required to build 'bar')\nBuild bar\n",
+    "Stage bar\n",
+    "Prime foo\nPrime bar\n",
+]
+
+plan_result = ["".join(plan_steps[0:n]) for n in range(1, 5)]
+
+
+# pylint: disable=line-too-long
+
+execute_steps = [
+    "Execute: Pull foo\nExecute: Pull bar\n",
+    "Execute: Build foo\nExecute: Stage foo (required to build 'bar')\nExecute: Build bar\n",
+    "Execute: Stage bar\n",
+    "Execute: Prime foo\nExecute: Prime bar\n",
+]
+
+execute_result = ["".join(execute_steps[0:n]) for n in range(1, 5)]
+
+skip_steps = [
+    "Skip pull foo (already ran)\nSkip pull bar (already ran)\n",
+    "Skip build foo (already ran)\nSkip build bar (already ran)\n",
+    "Skip stage foo (already ran)\nSkip stage bar (already ran)\n",
+    "Skip prime foo (already ran)\nSkip prime bar (already ran)\n",
+]
+
+skip_result = ["".join(skip_steps[0:n]) for n in range(1, 5)]
+
+
+@pytest.fixture(autouse=True)
+def setup_new_dir(new_dir):  # pylint: disable=unused-argument
+    pass
+
+
+def test_main_no_args(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == execute_result[3]
+    assert Path("parts").is_dir()
+    assert Path("parts/foo").is_dir()
+    assert Path("parts/bar").is_dir()
+    assert Path("stage").is_dir()
+    assert Path("prime").is_dir()
+
+
+def test_main_missing_parts_file(mocker, capfd):
+    mocker.patch.object(sys, "argv", ["cmd"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 1
+
+    out, err = capfd.readouterr()
+    assert err == "Error: parts.yaml: No such file or directory.\n"
+    assert out == ""
+
+
+def test_main_unreadable_parts_file(mocker, capfd):
+    Path("parts.yaml").touch()
+    Path("parts.yaml").chmod(0o111)
+
+    mocker.patch.object(sys, "argv", ["cmd"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 1
+
+    out, err = capfd.readouterr()
+    assert err == "Error: parts.yaml: Permission denied.\n"
+    assert out == ""
+
+
+def test_main_invalid_parts_file(mocker, capfd):
+    Path("parts.yaml").write_text("not yaml data")
+
+    mocker.patch.object(sys, "argv", ["cmd"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 4
+
+    out, err = capfd.readouterr()
+    assert err == "Error: parts definition must be a dictionary\n"
+    assert out == ""
+
+
+def test_main_missing_parts_entry(mocker, capfd):
+    Path("parts.yaml").write_text("name: file")
+
+    mocker.patch.object(sys, "argv", ["cmd"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 4
+
+    out, err = capfd.readouterr()
+    assert err == "Error: parts definition is missing\n"
+    assert out == ""
+
+
+def test_main_version(mocker, capfd):
+    mocker.patch.object(sys, "argv", ["cmd", "--version"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == f"craft-parts {craft_parts.__version__}\n"
+
+
+def test_main_plan_only(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == plan_result[3]
+    assert Path("parts").is_dir() is False
+    assert Path("stage").is_dir() is False
+    assert Path("prime").is_dir() is False
+
+
+def test_main_application_name(new_dir, mocker, capfd):
+    my_parts_yaml = textwrap.dedent(
+        """
+        parts:
+          foo:
+            plugin: nil
+            override-pull: env | grep ^ZNAPCRAFT_ | cut -f1 -d= | sort
+        """
+    )
+    Path("parts.yaml").write_text(my_parts_yaml)
+
+    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
+
+    mocker.patch.object(
+        sys, "argv", ["cmd", "--application-name", "znapcraft", "--refresh", "pull"]
+    )
+    main.main()
+
+    # check environment variables
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == textwrap.dedent(
+        """\
+        Execute: Pull foo
+        ZNAPCRAFT_ARCH_TRIPLET
+        ZNAPCRAFT_PARALLEL_BUILD_COUNT
+        ZNAPCRAFT_PART_BUILD
+        ZNAPCRAFT_PART_BUILD_WORK
+        ZNAPCRAFT_PART_INSTALL
+        ZNAPCRAFT_PART_NAME
+        ZNAPCRAFT_PART_SRC
+        ZNAPCRAFT_PRIME
+        ZNAPCRAFT_STAGE
+        ZNAPCRAFT_TARGET_ARCH
+        """
+    )
+
+    # check cache location
+    assert Path(".cache/craft-parts/stage-packages").is_dir()
+
+    mock_update.assert_called_with()
+
+
+def test_main_invalid_application_name(mocker):
+    Path("parts.yaml").write_text(parts_yaml)
+    Path("work_dir").mkdir()
+
+    mocker.patch.object(
+        sys, "argv", ["cmd", "--plan-only", "--application-name", "znap-craft", "clean"]
+    )
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+
+def test_main_cache_dir(new_dir, mocker):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
+
+    mocker.patch.object(
+        sys, "argv", ["cmd", "--plan-only", "--cache-dir", "cache_dir", "--refresh"]
+    )
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    # check cache location
+    assert Path("cache_dir/stage-packages").is_dir()
+
+    mock_update.assert_called_with()
+
+
+def test_main_alternative_work_dir(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+    Path("work_dir").mkdir()
+
+    mocker.patch.object(sys, "argv", ["cmd", "--work-dir", "work_dir"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == execute_result[3]
+
+    # work dirs are in the new location
+    assert Path("work_dir/parts").is_dir()
+    assert Path("work_dir/stage").is_dir()
+    assert Path("work_dir/prime").is_dir()
+
+    # no new entries in the current dir
+    assert sorted(os.listdir(".")) == [".cache", "parts.yaml", "work_dir"]
+
+
+@pytest.mark.parametrize("opt", ["--f", "--file"])
+def test_main_alternative_parts_file(mocker, capfd, opt):
+    Path("other.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", opt, "other.yaml"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == plan_result[3]
+
+
+def test_main_alternative_parts_invalid_file(mocker, capfd):
+    Path("other.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "-f", "missing.yaml"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 1
+
+    out, err = capfd.readouterr()
+    assert err == "Error: missing.yaml: No such file or directory.\n"
+    assert out == ""
+
+
+def test_main_refresh(new_dir, mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "--refresh"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == plan_result[3]
+
+    # check cache location
+    assert Path(".cache/craft-parts/stage-packages").is_dir()
+
+    mock_update.assert_called_with()
+
+
+@pytest.mark.parametrize(
+    "step,result",
+    [
+        ("pull", execute_result[0]),
+        ("build", execute_result[1]),
+        ("stage", execute_result[2]),
+        ("prime", execute_result[3]),
+    ],
+)
+def test_main_step(mocker, capfd, step, result):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", step])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == result
+    assert Path("parts").is_dir()
+
+
+@pytest.mark.parametrize(
+    "step,result",
+    [
+        ("pull", plan_result[0]),
+        ("build", plan_result[1]),
+        ("stage", plan_result[2]),
+        ("prime", plan_result[3]),
+    ],
+)
+def test_main_step_plan_only(mocker, capfd, step, result):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", step])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == result
+    assert Path("parts").is_dir() is False
+
+
+def test_main_step_plan_only_skip(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+
+    # run it again on the existing state
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "prime"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == "No actions to execute.\n"
+
+
+def test_main_step_plan_only_show_skip(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+
+    # run it again on the existing state
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "--show-skip", "prime"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == skip_result[3]
+
+
+def test_main_step_specify_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "prime", "foo"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert (
+        out
+        == "Execute: Pull foo\nExecute: Build foo\nExecute: Stage foo\nExecute: Prime foo\n"
+    )
+
+
+def test_main_step_specify_part_plan_only(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "prime", "foo"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == "Pull foo\nBuild foo\nStage foo\nPrime foo\n"
+
+    assert Path("parts").is_dir() is False
+
+
+@pytest.mark.parametrize(
+    "step,result",
+    [
+        ("pull", plan_result[0]),
+        ("build", plan_result[1]),
+        (
+            "stage",
+            (
+                "Pull foo\n"
+                "Pull bar\n"
+                "Build foo\n"
+                "Stage foo (required to build 'bar')\n"
+                "Build bar\n"
+                "Restage foo (requested step)\n"
+                "Stage bar\n"
+            ),
+        ),
+        ("prime", plan_result[3]),
+    ],
+)
+def test_main_step_specify_multiple_parts(mocker, capfd, step, result):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", step, "foo", "bar"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == result
+    assert Path("parts").is_dir() is False
+
+
+def test_main_step_invalid_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "pull", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+
+
+def test_main_step_invalid_multiple_parts(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "pull", "foo", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+    assert Path("parts").is_dir() is False
+
+
+def test_main_step_invalid_part_plan_only(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "pull", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+    assert Path("parts").is_dir() is False
+
+
+def test_main_step_invalid_multiple_parts_plan_only(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "pull", "foo", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+    assert Path("parts").is_dir() is False
+
+
+def test_main_clean(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert Path("parts").is_dir()
+    assert Path("stage").is_dir()
+    assert Path("prime").is_dir()
+
+    # clean the existing work dirs
+    mocker.patch.object(sys, "argv", ["cmd", "clean"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == "Clean all parts.\n"
+    assert Path("parts").is_dir() is False
+    assert Path("stage").is_dir() is False
+    assert Path("prime").is_dir() is False
+
+    # clean again should not fail
+    mocker.patch.object(sys, "argv", ["cmd", "clean"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+    assert err == ""
+    assert out == "Clean all parts.\n"
+
+
+def test_main_clean_workdir(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+    Path("work_dir").mkdir()
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd", "--work-dir", "work_dir"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert Path("work_dir/parts").is_dir()
+    assert Path("work_dir/stage").is_dir()
+    assert Path("work_dir/prime").is_dir()
+
+    assert sorted(os.listdir(".")) == [".cache", "parts.yaml", "work_dir"]
+
+    # clean the existing work dirs
+    mocker.patch.object(sys, "argv", ["cmd", "--work-dir", "work_dir", "clean"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == "Clean all parts.\n"
+    assert Path("work_dir/parts").is_dir() is False
+    assert Path("work_dir/stage").is_dir() is False
+    assert Path("work_dir/prime").is_dir() is False
+
+    assert sorted(os.listdir(".")) == [".cache", "parts.yaml", "work_dir"]
+
+
+def test_main_clean_plan_only(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    mocker.patch.object(sys, "argv", ["cmd", "--plan-only", "clean"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 4
+
+    out, err = capfd.readouterr()
+    assert err == "Error: Clean operations cannot be planned.\n"
+    assert out == ""
+
+
+def test_main_clean_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert Path("parts").is_dir()
+    assert Path("stage").is_dir()
+    assert Path("prime").is_dir()
+
+    # clean the existing work dirs
+    mocker.patch.object(sys, "argv", ["cmd", "clean", "foo"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == ""
+    assert Path("parts/foo/state/pull").is_file() is False
+    assert Path("parts/foo/state/build").is_file() is False
+    assert Path("parts/foo/state/state").is_file() is False
+    assert Path("parts/foo/state/prime").is_file() is False
+    assert Path("parts/bar/state/pull").is_file()
+    assert Path("parts/bar/state/build").is_file()
+    assert Path("parts/bar/state/stage").is_file()
+    assert Path("parts/bar/state/prime").is_file()
+    assert Path("stage").is_dir()
+    assert Path("prime").is_dir()
+
+    # clean the again should not fail
+    mocker.patch.object(sys, "argv", ["cmd", "clean", "foo"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+    assert err == ""
+    assert out == ""
+
+
+def test_main_clean_multiple_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd"])
+    main.main()
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert Path("parts").is_dir()
+    assert Path("stage").is_dir()
+    assert Path("prime").is_dir()
+
+    # clean the existing work dirs
+    mocker.patch.object(sys, "argv", ["cmd", "clean", "foo", "bar"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code is None
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out == ""
+    assert Path("parts/foo/state/pull").is_file() is False
+    assert Path("parts/foo/state/build").is_file() is False
+    assert Path("parts/foo/state/state").is_file() is False
+    assert Path("parts/foo/state/prime").is_file() is False
+    assert Path("parts/bar/state/pull").is_file() is False
+    assert Path("parts/bar/state/build").is_file() is False
+    assert Path("parts/bar/state/stage").is_file() is False
+    assert Path("parts/bar/state/prime").is_file() is False
+
+
+def test_main_clean_invalid_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd", "clean", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+
+
+def test_main_clean_invalid_multiple_part(mocker, capfd):
+    Path("parts.yaml").write_text(parts_yaml)
+
+    # run it once to build state
+    mocker.patch.object(sys, "argv", ["cmd", "clean", "foo", "invalid"])
+    with pytest.raises(SystemExit) as raised:
+        main.main()
+    assert raised.value.code == 3
+
+    out, err = capfd.readouterr()
+    assert err == (
+        "Error: A part named 'invalid' is not defined in the parts list.\n"
+        "Review the parts definition and make sure it's correct.\n"
+    )
+    assert out == ""
+
+
+def test_main_import(mocker, capfd):
+    mocker.patch.object(sys, "argv", ["cmd", "--version"])
+    with pytest.raises(SystemExit):
+        runpy.run_module("craft_parts", run_name="__main__")
+
+    out, err = capfd.readouterr()
+    assert out == f"craft-parts {craft_parts.__version__}\n"
+    assert err == ""

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -2,16 +2,16 @@
 #
 # Copyright 2021 Canonical Ltd.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
-# published by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os


### PR DESCRIPTION
Provide a basic tool to execute part building according to a yaml
file containing a parts-based project. This can be executed from the
command line with `python3 -mcraft_parts -f <yaml_file>` (`parts.yaml`
is assumed if no file is specified).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
