### PR TITLE
platform: compatibility fixes for python 3.7 and 3.9 (CRAFT-315)

### DIFF
--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -16,6 +16,7 @@
 
 """Helpers and definitions for lifecycle states."""
 
+import contextlib
 import logging
 from pathlib import Path
 from typing import Optional
@@ -73,7 +74,8 @@ def remove(part: Part, step: Step) -> None:
     :param step: The step whose state is to be removed.
     """
     state_file = part.part_state_dir / step.name.lower()
-    state_file.unlink(missing_ok=True)
+    with contextlib.suppress(FileNotFoundError):  # no missing_ok in python 3.7
+        state_file.unlink()
 
 
 def state_file_path(part: Part, step: Step) -> Path:

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,13 @@ test_requirements = [
 setup(
     author="Canonical Ltd",
     author_email="Canonical Ltd",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Natural Language :: English",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     description="Craft parts tooling",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     description="Craft parts tooling",
     entry_points={

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 from pathlib import Path
 
 import pytest
@@ -69,8 +70,13 @@ class TestSourceHandler:
             FaultySource(  # type: ignore
                 source=Path(), part_src_dir=Path(), cache_dir=Path()
             )
-        assert str(raised.value) == (
-            "Can't instantiate abstract class FaultySource with abstract methods pull"
+        assert (
+            re.match(
+                "^Can't instantiate abstract class FaultySource with "
+                "abstract methods? pull$",
+                str(raised.value),
+            )
+            is not None
         )
 
 
@@ -226,7 +232,11 @@ class TestFileSourceHandler:
             FaultyFileSource(
                 source=None, part_src_dir=None, cache_dir=Path()  # type: ignore
             )
-        assert str(raised.value) == (
-            "Can't instantiate abstract class FaultyFileSource with abstract "
-            "methods provision"
+        assert (
+            re.match(
+                "^Can't instantiate abstract class FaultyFileSource with "
+                "abstract methods? provision",
+                str(raised.value),
+            )
+            is not None
         )

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
 from pathlib import Path
 
 import pytest
@@ -65,19 +64,15 @@ class TestSourceHandler:
         class FaultySource(SourceHandler):
             """A source handler that doesn't implement abstract methods."""
 
-        with pytest.raises(TypeError) as raised:
+        expected = (
+            "^Can't instantiate abstract class FaultySource with "
+            "abstract methods? pull$"
+        )
+        with pytest.raises(TypeError, match=expected):
             # pylint: disable=abstract-class-instantiated
             FaultySource(  # type: ignore
                 source=Path(), part_src_dir=Path(), cache_dir=Path()
             )
-        assert (
-            re.match(
-                "^Can't instantiate abstract class FaultySource with "
-                "abstract methods? pull$",
-                str(raised.value),
-            )
-            is not None
-        )
 
 
 class BarFileSource(FileSourceHandler):
@@ -227,16 +222,12 @@ class TestFileSourceHandler:
         class FaultyFileSource(FileSourceHandler):
             """A file source handler that doesn't implement abstract methods."""
 
-        with pytest.raises(TypeError) as raised:
+        expected = (
+            "^Can't instantiate abstract class FaultyFileSource with "
+            "abstract methods? provision$"
+        )
+        with pytest.raises(TypeError, match=expected):
             # pylint: disable=abstract-class-instantiated
             FaultyFileSource(
                 source=None, part_src_dir=None, cache_dir=Path()  # type: ignore
             )
-        assert (
-            re.match(
-                "^Can't instantiate abstract class FaultyFileSource with "
-                "abstract methods? provision",
-                str(raised.value),
-            )
-            is not None
-        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38
+envlist = py37,py38,py39
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py37,py38
 
 [testenv]
 setenv =
@@ -17,8 +17,9 @@ commands = make docs
 [testenv:lint]
 commands = make lint
 
+[testenv:units]
+commands = make test-units
+
 [testenv:integrations]
 commands = make test-integrations
 
-[testenv:units]
-commands = make test-units


### PR DESCRIPTION
Make craft-parts compatible with Python 3.7. Also fix tests to accept
error messages that changed in Python 3.9, and update tox configuration.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
