### PR TITLE
many: send craft-parts output to logger (CRAFT-365)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -20,7 +20,6 @@ import logging
 import os
 import os.path
 import shutil
-import sys
 from glob import iglob
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set
@@ -40,24 +39,6 @@ from .organize import organize_files
 from .step_handler import StepContents, StepHandler
 
 logger = logging.getLogger(__name__)
-
-
-class OutputLogger:
-    """Redirect stdout to logger."""
-
-    def __init__(self):
-        self._save_stdout = sys.stdout
-
-    def __enter__(self):
-        sys.stdout = self
-
-    def __exit__(self, *exc):
-        sys.stdout = self._save_stdout
-
-    def write(self, msg: str):  # pylint: disable=no-self-use
-        """Write lines to logger."""
-        for line in msg.rstrip().splitlines():
-            logger.debug(line.rstrip())
 
 
 class PartHandler:
@@ -255,14 +236,13 @@ class PartHandler:
             source_handler=self._source_handler,
         )
         scriptlet = self._part.spec.get_scriptlet(step_info.step)
-        with OutputLogger():
-            if scriptlet:
-                step_handler.run_scriptlet(
-                    scriptlet, scriptlet_name=scriptlet_name, work_dir=work_dir
-                )
-                return StepContents()
+        if scriptlet:
+            step_handler.run_scriptlet(
+                scriptlet, scriptlet_name=scriptlet_name, work_dir=work_dir
+            )
+            return StepContents()
 
-            return step_handler.run_builtin()
+        return step_handler.run_builtin()
 
     def _update_action(self, action: Action, *, step_info: StepInfo) -> None:
         handler: Callable[[StepInfo], None]

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -364,6 +364,8 @@ def _check_conflicts(
         )
 
 
+# XXX: this will be removed when user messages support is implemented.
 def process_run(command: List[str], **kwargs) -> None:
     """Run a command and log its output."""
+    # Pass logger so messages can be logged as originating from this package.
     os_utils.process_run(command, logger.debug, **kwargs)

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -364,6 +364,7 @@ def _check_conflicts(
         )
 
 
+# XXX: this is a temporary solution, replace with user messaging when available
 def process_run(command: List[Union[Path, str]], **kwargs) -> None:
     """Run a command, logging stdout and stderr."""
     with subprocess.Popen(

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -65,7 +65,7 @@ class LifecycleManager:
         *,
         application_name: str,
         cache_dir: Union[Path, str],
-        work_dir: str = ".",
+        work_dir: Union[Path, str] = ".",
         arch: str = "",
         base: str = "",
         parallel_build_count: int = 1,

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -55,8 +55,8 @@ class LogProgress(apt.progress.base.AcquireProgress):
         if item.owner.status == item.owner.STAT_DONE:
             logger.debug("Ign %s", item.description)
         else:
-            logger.error("Err %s", item.description)
-            logger.error("  %s", item.owner.error_text)
+            logger.debug("Err %s", item.description)
+            logger.debug("  %s", item.owner.error_text)
 
     def fetch(self, item: apt.apt_pkg.AcquireItemDesc) -> None:
         """Handle item's data is fetch."""

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -30,7 +30,7 @@ import apt
 import apt.cache
 import apt.package
 import apt.progress
-import apt.progress.text
+import apt.progress.base
 
 from craft_parts.utils import os_utils
 
@@ -41,6 +41,36 @@ logger = logging.getLogger(__name__)
 
 
 _HASHSUM_MISMATCH_PATTERN = re.compile(r"(E:Failed to fetch.+Hash Sum mismatch)+")
+
+
+class LogProgress(apt.progress.base.AcquireProgress):
+    """Internal Base class for text progress classes."""
+
+    def __init__(self):
+        self._id = 1
+
+    def fail(self, item: apt.apt_pkg.AcquireItemDesc) -> None:
+        """Handle failed item."""
+        apt.progress.base.AcquireProgress.fail(self, item)
+        if item.owner.status == item.owner.STAT_DONE:
+            logger.debug("Ign %s", item.description)
+        else:
+            logger.error("Err %s", item.description)
+            logger.error("  %s", item.owner.error_text)
+
+    def fetch(self, item: apt.apt_pkg.AcquireItemDesc) -> None:
+        """Handle item's data is fetch."""
+        apt.progress.base.AcquireProgress.fetch(self, item)
+        # It's complete already (e.g. Hit)
+        if item.owner.complete:
+            return
+        item.owner.id = self._id
+        self._id += 1
+        line = "Get: {} {}".format(item.owner.id, item.description)
+        if item.owner.filesize:
+            line += " [{}B]".format(apt.apt_pkg.size_to_str(item.owner.filesize))
+
+        logger.debug(line)
 
 
 class AptCache(ContextDecorator):
@@ -102,11 +132,7 @@ class AptCache(ContextDecorator):
         # on the system.
         apt.apt_pkg.config.clear("APT::Update::Post-Invoke-Success")
 
-        self.progress = apt.progress.text.AcquireProgress()
-        if os_utils.is_dumb_terminal():
-            # Make output more suitable for logging.
-            self.progress.pulse = lambda owner: True
-            self.progress._width = 0  # pylint: disable=protected-access
+        self.progress = LogProgress()
 
     def _populate_stage_cache_dir(self) -> None:
         """Create/refresh cache configuration.
@@ -209,14 +235,14 @@ class AptCache(ContextDecorator):
                 continue
 
             try:
-                dl_path = package.candidate.fetch_binary(str(download_path))
+                dl_path = self.fetch_binary(package.candidate, download_path)
             except apt.package.FetchError as err:
                 raise errors.PackageFetchError(str(err))
 
             if package.candidate is None:
                 raise errors.PackageNotFound(package.name)
 
-            downloaded.append((package.name, package.candidate.version, Path(dl_path)))
+            downloaded.append((package.name, package.candidate.version, dl_path))
         return downloaded
 
     def get_installed_packages(self) -> Dict[str, str]:
@@ -338,6 +364,46 @@ class AptCache(ContextDecorator):
             raise errors.PackageListRefreshError(str(err))
 
     # pylint: enable=attribute-defined-outside-init
+
+    def fetch_binary(self, package_candidate, destination: Path) -> Path:
+        """Fetch a binary package."""
+        # pylint: disable=line-too-long
+        # This is a workaround for the overly verbose python-apt we use.
+        # There is an unreleased patch which once released could replace this code
+        # https://salsa.debian.org/apt-team/python-apt/commit/d122f9142df614dbb5f7644112280140dc155ecc
+        # What follows is almost a tit for tat implementation of upstream's
+        # fetch_binary logic.
+        # pylint: enable=line-too-long
+
+        # pylint: disable=protected-access
+        base = os.path.basename(package_candidate._records.filename)
+        destfile = destination / base
+        if apt.package._file_is_same(
+            str(destfile), package_candidate.size, package_candidate._records.md5_hash
+        ):
+            logging.debug("Ignoring already existing file: %s", destfile)
+            return os.path.abspath(destfile)
+        acq = apt.apt_pkg.Acquire(self.progress)
+        acqfile = apt.apt_pkg.AcquireFile(
+            acq,
+            package_candidate.uri,
+            package_candidate._records.md5_hash,
+            package_candidate.size,
+            base,
+            destfile=str(destfile),
+        )
+        acq.run()
+
+        if acqfile.status != acqfile.STAT_DONE:
+            raise apt.package.FetchError(
+                "The item {!r} could not be fetched: {}".format(
+                    acqfile.destfile, acqfile.error_text
+                )
+            )
+
+        # pylint: enable=protected-access
+
+        return destfile.absolute()
 
 
 def _verify_marked_install(package: apt.package.Package):

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -548,6 +548,8 @@ def get_cache_dirs(cache_dir: Path):
     return (stage_cache_dir, deb_cache_dir)
 
 
+# XXX: this will be removed when user messages support is implemented.
 def process_run(command: List[str], **kwargs) -> None:
     """Run a command and log its output."""
+    # Pass logger so messages can be logged as originating from this package.
     os_utils.process_run(command, logger.debug, **kwargs)

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -28,7 +28,7 @@ import tempfile
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
-from craft_parts.utils import file_utils
+from craft_parts.utils import file_utils, os_utils
 
 from . import errors
 from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
@@ -548,21 +548,6 @@ def get_cache_dirs(cache_dir: Path):
     return (stage_cache_dir, deb_cache_dir)
 
 
-# XXX: this is a temporary solution, replace with user messaging when available
 def process_run(command: List[str], **kwargs) -> None:
-    """Run a command, logging stdout and stderr."""
-    with subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True,
-        **kwargs,
-    ) as proc:
-        if not proc.stdout:
-            return
-        for line in iter(proc.stdout.readline, ""):
-            logger.debug(line.strip())
-        ret = proc.wait()
-
-    if ret:
-        raise subprocess.CalledProcessError(ret, command)
+    """Run a command and log its output."""
+    os_utils.process_run(command, logger.debug, **kwargs)

--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -272,7 +272,7 @@ def download_snaps(*, snaps_list: Sequence[str], directory: str) -> None:
         snap_pkg = SnapPackage(snap)
 
         # TODO: use dependency injected echoer
-        logger.info("Downloading snap %s", snap_pkg.name)
+        logger.debug("Downloading snap %s", snap_pkg.name)
         snap_pkg.download(directory=directory)
 
 

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -22,7 +22,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from craft_parts import errors
 
@@ -302,3 +302,22 @@ class OsRelease:
             return _ID_TO_UBUNTU_CODENAME[self._os_release["VERSION_ID"]]
 
         raise errors.OsReleaseCodenameError()
+
+
+def process_run(command: List[str], log_func: Callable[[str], None], **kwargs) -> None:
+    """Run a command and handle its output."""
+    with subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        **kwargs,
+    ) as proc:
+        if not proc.stdout:
+            return
+        for line in iter(proc.stdout.readline, ""):
+            log_func(line.strip())
+        ret = proc.wait()
+
+    if ret:
+        raise subprocess.CalledProcessError(ret, command)

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -316,7 +316,7 @@ def process_run(command: List[str], log_func: Callable[[str], None], **kwargs) -
         if not proc.stdout:
             return
         for line in iter(proc.stdout.readline, ""):
-            log_func(line.strip())
+            log_func(":: " + line.strip())
         ret = proc.wait()
 
     if ret:

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -16,14 +16,14 @@
 
 """URL parsing and downloading helpers."""
 
+import logging
 import os
 import urllib.parse
 import urllib.request
 
-# TODO:stdmsg: refactor to use the standard message library once available
-import progressbar  # type: ignore
-
 from craft_parts.utils import os_utils
+
+logger = logging.getLogger(__name__)
 
 
 def get_url_scheme(url: str) -> str:
@@ -56,8 +56,11 @@ def download_request(
         if os.path.exists(destination):
             total_length += total_read
 
-    progress_bar = _init_progress_bar(total_length, destination, message)
-    progress_bar.start()
+    logger.debug("Downloading %r", destination)
+
+    # FIXME: re-impement progress bar support when messages to user support is ready
+    # progress_bar = _init_progress_bar(total_length, destination, message)
+    # progress_bar.start()
 
     if os.path.exists(destination):
         mode = "ab"
@@ -68,35 +71,5 @@ def download_request(
             destination_file.write(buf)
             if not os_utils.is_dumb_terminal():
                 total_read += len(buf)
-                progress_bar.update(total_read)
-    progress_bar.finish()
-
-
-def _init_progress_bar(
-    total_length: int, destination: str, message=None
-) -> progressbar.ProgressBar:
-    if not message:
-        message = "Downloading {!r}".format(os.path.basename(destination))
-
-    valid_length = total_length and total_length > 0
-    dumb_terminal = os_utils.is_dumb_terminal()
-
-    if valid_length and dumb_terminal:
-        widgets = [message, " ", progressbar.Percentage()]
-        maxval = total_length
-    elif valid_length and not dumb_terminal:
-        widgets = [
-            message,
-            progressbar.Bar(marker="=", left="[", right="]"),
-            " ",
-            progressbar.Percentage(),
-        ]
-        maxval = total_length
-    elif not valid_length and dumb_terminal:
-        widgets = [message]
-        maxval = progressbar.UnknownLength
-    else:
-        widgets = [message, progressbar.AnimatedMarker()]
-        maxval = progressbar.UnknownLength
-
-    return progressbar.ProgressBar(widgets=widgets, maxval=maxval)
+                # progress_bar.update(total_read)
+    # progress_bar.finish()

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -56,7 +56,10 @@ def download_request(
         if os.path.exists(destination):
             total_length += total_read
 
-    logger.debug("Downloading %r", destination)
+    if message:
+        logger.debug(message)
+    else:
+        logger.debug("Downloading %r", destination)
 
     # FIXME: re-impement progress bar support when messages to user support is ready
     # progress_bar = _init_progress_bar(total_length, destination, message)

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import textwrap
 from typing import Any, Dict, List, Set
 
@@ -56,11 +57,6 @@ class AppPlugin(plugins.Plugin):
         return ["echo hello ${PARTS_TEST_VAR}"]
 
 
-@pytest.fixture(autouse=True)
-def output_logger(mocker):
-    return mocker.patch("craft_parts.executor.part_handler.OutputLogger.write")
-
-
 def setup_function():
     plugins.unregister_all()
 
@@ -69,7 +65,7 @@ def teardown_module():
     plugins.unregister_all()
 
 
-def test_application_plugin_happy(output_logger, new_dir, mocker):
+def test_application_plugin_happy(caplog, new_dir, mocker):
     _parts_yaml = textwrap.dedent(
         """\
         parts:
@@ -105,17 +101,10 @@ def test_application_plugin_happy(output_logger, new_dir, mocker):
 
     mock_install_build_snaps = mocker.patch("craft_parts.packages.snaps.install_snaps")
 
-    with lf.action_executor() as exe:
+    with lf.action_executor() as exe, caplog.at_level(logging.DEBUG):
         exe.execute(actions[1])
 
-    output_logger.assert_has_calls(
-        [
-            mocker.call("+ echo hello application plugin"),
-            mocker.call("\n"),
-            mocker.call("hello application plugin"),
-            mocker.call("\n"),
-        ]
-    )
+    assert "hello application plugin" in caplog.text
 
     mock_install_build_packages.assert_called_once_with(["build_package"])
     mock_install_build_snaps.assert_called_once_with({"build_snap"})

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -86,7 +86,7 @@ class TestStepHandlerBuiltins:
         assert result == StepContents()
 
     def test_run_builtin_build(self, new_dir, mocker):
-        mock_run = mocker.patch("subprocess.run")
+        mock_run = mocker.patch("craft_parts.executor.step_handler.process_run")
 
         Path("parts/p1/run").mkdir(parents=True)
         sh = _step_handler_for_step(Step.BUILD, cache_dir=new_dir)
@@ -94,7 +94,6 @@ class TestStepHandlerBuiltins:
 
         mock_run.assert_called_once_with(
             [Path(new_dir / "parts/p1/run/build.sh")],
-            check=True,
             cwd=Path(new_dir / "parts/p1/build"),
         )
         assert result == StepContents()

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -93,7 +93,7 @@ class TestStepHandlerBuiltins:
         result = sh.run_builtin()
 
         mock_run.assert_called_once_with(
-            [Path(new_dir / "parts/p1/run/build.sh")],
+            [str(new_dir / "parts/p1/run/build.sh")],
             cwd=Path(new_dir / "parts/p1/build"),
         )
         assert result == StepContents()

--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -157,7 +157,6 @@ class TestMockedApt:
                 "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
             ),
             call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
-            call.progress.text.AcquireProgress(),
             call.cache.Cache(rootdir=str(stage_cache), memonly=True),
             call.cache.Cache().update(fetch_progress=mocker.ANY, sources_list=None),
             call.cache.Cache().close(),
@@ -203,7 +202,6 @@ class TestMockedApt:
                 "Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"
             ),
             call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
-            call.progress.text.AcquireProgress(),
             call.cache.Cache(rootdir=str(stage_cache), memonly=True),
             call.cache.Cache().update(fetch_progress=mocker.ANY, sources_list=None),
             call.cache.Cache().close(),

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -51,7 +51,7 @@ def fake_apt_cache(mocker):
 
 @pytest.fixture
 def fake_run(mocker):
-    return mocker.patch("subprocess.check_call")
+    return mocker.patch("craft_parts.packages.deb.process_run")
 
 
 @pytest.fixture
@@ -239,6 +239,7 @@ class TestBuildPackages:
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
+                        "-oDpkg::Use-Pty=0",
                         "--allow-downgrades",
                         "install",
                         "dependency-package=1.0",
@@ -321,6 +322,7 @@ class TestBuildPackages:
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
+                        "-oDpkg::Use-Pty=0",
                         "--allow-downgrades",
                         "install",
                         "package-installed=3.0",
@@ -362,6 +364,7 @@ class TestBuildPackages:
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
+                        "-oDpkg::Use-Pty=0",
                         "--allow-downgrades",
                         "install",
                         "package=1.0",
@@ -403,9 +406,8 @@ class TestBuildPackages:
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
+                        "-oDpkg::Use-Pty=0",
                         "--allow-downgrades",
-                        "-o",
-                        "Dpkg::Progress-Fancy=1",
                         "install",
                         "package=1.0",
                     ],


### PR DESCRIPTION
Craft-parts shouldn't pollute the application output with its own
messages. This is an interim solution, send the output to the log
until the user message handling library is available.

Output example ("Execute" messages are printed by the cli utility):
```
$ python3 -mcraft_parts -fparts-mpg123.yaml 
WARNING:craft_parts.packages.apt_cache:libasound-dev is a virtual package, use non-virtual packages for deterministic results.
Execute: Pull mpg123
Execute: Build mpg123
Execute: Stage mpg123
Execute: Prime mpg123
```

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
