### PR TITLE
parts: add validators for stage and prime filesets (CRAFT-366)

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -67,7 +67,7 @@ class PartSpec(BaseModel):
     @validator("stage_files", "prime_files", each_item=True)
     def validate_relative_path_list(cls, item):
         """Check if the list does not contain empty of absolute paths."""
-        assert item != "", f"{item!r} must be a relative path (cannot be empty)"
+        assert item != "", "path cannot be empty"
         assert (
             item[0] != "/"
         ), f"{item!r} must be a relative path (cannot start with '/')"

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -19,7 +19,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, validator
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
@@ -62,6 +62,18 @@ class PartSpec(BaseModel):
         extra = "forbid"
         allow_mutation = False
         alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+    # pylint: disable=no-self-argument,no-self-use
+    @validator("stage_files", "prime_files", each_item=True)
+    def validate_relative_path_list(cls, item):
+        """Check if the list does not contain empty of absolute paths."""
+        assert item != "", f"{item!r} must be a relative path (cannot be empty)"
+        assert (
+            item[0] != "/"
+        ), f"{item!r} must be a relative path (cannot start with '/')"
+        return item
+
+    # pylint: enable=no-self-argument,no-self-use
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "PartSpec":

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -293,6 +293,16 @@ class TestPartUnmarshal:
         assert raised.value.part_name == "foo"
         assert raised.value.message == "'plugin': str type expected"
 
+    @pytest.mark.parametrize("fileset", ["stage", "prime"])
+    def test_relative_path_validation(self, fileset):
+        with pytest.raises(errors.PartSpecificationError) as raised:
+            Part("foo", {fileset: ["bar", "/baz", ""]})
+        assert raised.value.part_name == "foo"
+        assert raised.value.message == (
+            f"{fileset!r},1: '/baz' must be a relative path (cannot start with '/')\n"
+            f"{fileset!r},2: '' must be a relative path (cannot be empty)"
+        )
+
 
 class TestPartHelpers:
     """Test part-related helper functions."""

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -300,7 +300,7 @@ class TestPartUnmarshal:
         assert raised.value.part_name == "foo"
         assert raised.value.message == (
             f"{fileset!r},1: '/baz' must be a relative path (cannot start with '/')\n"
-            f"{fileset!r},2: '' must be a relative path (cannot be empty)"
+            f"{fileset!r},2: path cannot be empty"
         )
 
 


### PR DESCRIPTION
Validate stage and prime to detect absolute paths on unmarshal, instead
of doing it at execution time when the filter is used.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
