### PR TITLE
lifecycle: add part validator (CRAFT-367)

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -22,5 +22,6 @@ from .actions import Action, ActionType  # noqa: F401
 from .dirs import ProjectDirs  # noqa: F401
 from .infos import PartInfo, ProjectInfo, StepInfo  # noqa: F401
 from .lifecycle_manager import LifecycleManager  # noqa: F401
+from .lifecycle_manager import validate_part  # noqa: F401
 from .parts import Part  # noqa: F401
 from .steps import Step  # noqa: F401

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -229,6 +229,9 @@ def validate_part(data: Dict[str, Any], part_name: str) -> None:
     """
     logger.debug("validate part %r", part_name)
 
+    if not isinstance(data, dict):
+        raise TypeError(f"part {part_name!r} must be a dictionary")
+
     spec = data.copy()
     plugin_name = spec.get("plugin", "")
 


### PR DESCRIPTION
Validate the given part data against the common parts model and the
part's plugin model before creating the lifecycle manager. This allows
the validation to happen on the host while the lifecycle manager is
created later in a managed environment.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
