### PR TITLE
errors: reformat pydantic validation error (CRAFT-368)

### DIFF
--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -131,7 +131,7 @@ def test_application_plugin_missing_stuff(new_dir):
         )
 
     assert raised.value.part_name == "foo"
-    assert raised.value.message == "'app-stuff': field required"
+    assert raised.value.message == "- field 'app-stuff' is required"
 
 
 def test_application_plugin_type_error(new_dir):
@@ -156,7 +156,7 @@ def test_application_plugin_type_error(new_dir):
         )
 
     assert raised.value.part_name == "foo"
-    assert raised.value.message == "'app-stuff': value is not a valid list"
+    assert raised.value.message == "- value is not a valid list in field 'app-stuff'"
 
 
 def test_application_plugin_extra_property(new_dir):
@@ -182,7 +182,7 @@ def test_application_plugin_extra_property(new_dir):
         )
 
     assert raised.value.part_name == "foo"
-    assert raised.value.message == "'app-other': extra fields not permitted"
+    assert raised.value.message == "- extra field 'app-other' not permitted"
 
 
 def test_application_plugin_not_registered(new_dir):

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -85,15 +85,20 @@ def test_part_specification_error():
 
 def test_part_specification_error_from_validation_error():
     error_list = [
-        {"loc": ("field-1",), "msg": "something is wrong"},
-        {"loc": ("field-2",), "msg": "something is wrong"},
+        {"loc": ("field-1", 0), "msg": "something is wrong"},
+        {"loc": ("field-2",), "msg": "field required"},
+        {"loc": ("field-3",), "msg": "extra fields not permitted"},
     ]
     err = errors.PartSpecificationError.from_validation_error(
         part_name="foo", error_list=error_list
     )
     assert err.part_name == "foo"
     assert err.brief == "Part 'foo' validation failed."
-    assert err.details == "'field-1': something is wrong\n'field-2': something is wrong"
+    assert err.details == (
+        "- something is wrong in field 'field-1[0]'\n"
+        "- field 'field-2' is required\n"
+        "- extra field 'field-3' not permitted"
+    )
     assert err.resolution == "Review part 'foo' and make sure it's correct."
 
 

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -278,7 +278,7 @@ class TestPartUnmarshal:
             Part("foo", data)
         assert raised.value.part_name == "foo"
         assert raised.value.message == (
-            "'a': extra fields not permitted\n'b': extra fields not permitted"
+            "- extra field 'a' not permitted\n- extra field 'b' not permitted"
         )
 
     def test_part_spec_not_dict(self):
@@ -291,7 +291,7 @@ class TestPartUnmarshal:
         with pytest.raises(errors.PartSpecificationError) as raised:
             Part("foo", {"plugin": []})
         assert raised.value.part_name == "foo"
-        assert raised.value.message == "'plugin': str type expected"
+        assert raised.value.message == "- str type expected in field 'plugin'"
 
     @pytest.mark.parametrize("fileset", ["stage", "prime"])
     def test_relative_path_validation(self, fileset):
@@ -299,8 +299,9 @@ class TestPartUnmarshal:
             Part("foo", {fileset: ["bar", "/baz", ""]})
         assert raised.value.part_name == "foo"
         assert raised.value.message == (
-            f"{fileset!r},1: '/baz' must be a relative path (cannot start with '/')\n"
-            f"{fileset!r},2: path cannot be empty"
+            "- '/baz' must be a relative path (cannot start with '/') "
+            f"in field '{fileset}[1]'\n"
+            f"- path cannot be empty in field '{fileset}[2]'"
         )
 
 


### PR DESCRIPTION
Change formatting of pydantic errors to be more human-readable. The
new format is similar to the one used in Charmcraft. Specifically,
this changes

```
'foo',1: some error happened
'bar': field required
'baz': extra fields not permitted
```
to
```
- some error happened in field 'foo[1]'
- field 'bar' is required'
- extra field 'baz' not permitted
```
    
Co-authored-by: Chris Patterson <chris.patterson@canonical.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
