### PR TITLE
utils: fix snap environment detection and add tests (CRAFT-376)

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -81,6 +81,8 @@ class LifecycleManager:
         if "parts" not in all_parts:
             raise ValueError("parts definition is missing")
 
+        packages.Repository.configure(application_name)
+
         project_dirs = ProjectDirs(work_dir=work_dir)
 
         project_info = ProjectInfo(

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -18,7 +18,7 @@
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from pydantic import ValidationError
 
@@ -55,6 +55,8 @@ class LifecycleManager:
         to the system where Craft Parts is being executed.
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
+    :param package_name: The name of the application package, if required by the
+        package manager used by the platform. Defaults to the application name.
     :param custom_args: Any additional arguments that will be passed directly
         to :ref:`callbacks<callbacks>`.
     """
@@ -70,6 +72,7 @@ class LifecycleManager:
         base: str = "",
         parallel_build_count: int = 1,
         extra_build_packages: List[str] = None,
+        application_package_name: Optional[str] = None,
         **custom_args,  # custom passthrough args
     ):
         if not re.match("^[A-Za-z][0-9A-Za-z_]*$", application_name):
@@ -78,10 +81,13 @@ class LifecycleManager:
         if not isinstance(all_parts, dict):
             raise TypeError("parts definition must be a dictionary")
 
+        if not application_package_name:
+            application_package_name = application_name
+
         if "parts" not in all_parts:
             raise ValueError("parts definition is missing")
 
-        packages.Repository.configure(application_name)
+        packages.Repository.configure(application_package_name)
 
         project_dirs = ProjectDirs(work_dir=work_dir)
 

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -104,7 +104,7 @@ class AptCache(ContextDecorator):
         self.cache.close()
 
     @classmethod
-    def configure_apt(cls, application_name: str) -> None:
+    def configure_apt(cls, application_package_name: str) -> None:
         """Set up apt options and directories."""
         # Do not install recommends.
         apt.apt_pkg.config.set("Apt::Install-Recommends", "False")
@@ -114,7 +114,11 @@ class AptCache(ContextDecorator):
 
         # Methods and solvers dir for when in the SNAP.
         snap_dir = os.getenv("SNAP")
-        if os_utils.is_snap(application_name) and snap_dir and os.path.exists(snap_dir):
+        if (
+            os_utils.is_snap(application_package_name)
+            and snap_dir
+            and os.path.exists(snap_dir)
+        ):
             apt_dir = os.path.join(snap_dir, "usr", "lib", "apt")
             apt.apt_pkg.config.set("Dir", apt_dir)
             # yes apt is broken like that we need to append os.path.sep

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -33,6 +33,11 @@ class BaseRepository(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
+    def configure(cls, application_name: str) -> None:
+        """Set up the repository."""
+
+    @classmethod
+    @abc.abstractmethod
     def get_package_libraries(cls, package_name: str) -> Set[str]:
         """Return a list of libraries in package_name.
 
@@ -161,6 +166,10 @@ RepositoryType = Type[BaseRepository]
 
 class DummyRepository(BaseRepository):
     """A dummy repository."""
+
+    @classmethod
+    def configure(cls, application_name: str) -> None:
+        """Set up the repository."""
 
     @classmethod
     def get_package_libraries(cls, package_name: str) -> Set[str]:

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -33,7 +33,7 @@ class BaseRepository(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def configure(cls, application_name: str) -> None:
+    def configure(cls, application_package_name: str) -> None:
         """Set up the repository."""
 
     @classmethod
@@ -168,7 +168,7 @@ class DummyRepository(BaseRepository):
     """A dummy repository."""
 
     @classmethod
-    def configure(cls, application_name: str) -> None:
+    def configure(cls, application_package_name: str) -> None:
         """Set up the repository."""
 
     @classmethod

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -280,6 +280,11 @@ class Ubuntu(BaseRepository):
     """Repository management for Ubuntu packages."""
 
     @classmethod
+    def configure(cls, application_name: str) -> None:
+        """Set up apt options and directories."""
+        AptCache.configure_apt(application_name)
+
+    @classmethod
     def get_package_libraries(cls, package_name: str) -> Set[str]:
         """Return a list of libraries in package_name."""
         return _run_dpkg_query_list_files(package_name)

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -280,9 +280,9 @@ class Ubuntu(BaseRepository):
     """Repository management for Ubuntu packages."""
 
     @classmethod
-    def configure(cls, application_name: str) -> None:
+    def configure(cls, application_package_name: str) -> None:
         """Set up apt options and directories."""
-        AptCache.configure_apt(application_name)
+        AptCache.configure_apt(application_package_name)
 
     @classmethod
     def get_package_libraries(cls, package_name: str) -> Set[str]:

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -172,13 +172,9 @@ def is_snap(*, application_name: Optional[str] = None) -> bool:
     if application_name:
         res = snap_name == application_name
     else:
-        res = snap_name is not None
+        res = snap_name != ""
 
-    logger.debug(
-        "craft_parts is is snap: %s, SNAP_NAME set to %s",
-        res,
-        snap_name,
-    )
+    logger.debug("is_snap: %s, SNAP_NAME set to %s", res, snap_name)
 
     return res
 

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -162,17 +162,14 @@ def is_dumb_terminal() -> bool:
     return not is_stdout_tty or is_term_dumb
 
 
-def is_snap(*, application_name: Optional[str] = None) -> bool:
+def is_snap(application_name: str) -> bool:
     """Verify whether we're running as a snap.
 
     :application_name: The snap application name. If provided, check
         if it matches the snap name.
     """
-    snap_name = os.environ.get("SNAP_NAME", "")
-    if application_name:
-        res = snap_name == application_name
-    else:
-        res = snap_name != ""
+    snap_name = os.environ.get("SNAP_NAME")
+    res = snap_name == application_name
 
     logger.debug("is_snap: %s, SNAP_NAME set to %s", res, snap_name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ min-similarity-lines=13
 max-line-length = "88"
 max-attributes = 15
 max-args= 6
-max-locals = 16
+max-locals = 18
 
 [tool.pylint.MASTER]
 extension-pkg-whitelist = [

--- a/tests/unit/packages/test_base.py
+++ b/tests/unit/packages/test_base.py
@@ -23,6 +23,7 @@ class TestBaseRepository:
 
     def test_abstract_methods(self):
         assert BaseRepository.__abstractmethods__ == {  # type: ignore
+            "configure",
             "get_installed_packages",
             "get_package_libraries",
             "is_package_installed",

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -355,23 +355,22 @@ class TestOsRelease:
 class TestEnvironment:
     """Running on snap or container must be detected."""
 
-    def test_is_snap(self, mocker):
-        mocker.patch.dict(os.environ, {"SNAP_NAME": "mysnap"})
-        assert os_utils.is_snap()
+    @pytest.mark.parametrize(
+        "snap_var,app_name,result",
+        [
+            (None, "myapp", False),
+            ("", "myapp", False),
+            ("other", "myapp", False),
+            ("myapp", "myapp", True),
+        ],
+    )
+    def test_is_snap(self, mocker, snap_var, app_name, result):
+        if snap_var is not None:
+            mocker.patch.dict(os.environ, {"SNAP_NAME": snap_var}, clear=True)
+        else:
+            mocker.patch.dict(os.environ, {}, clear=True)
 
-    def test_is_snap_no_snap_name(self, mocker):
-        assert os_utils.is_snap() is False
-
-    def test_is_snap_application_name(self, mocker):
-        mocker.patch.dict(os.environ, {"SNAP_NAME": "othersnap"})
-        assert os_utils.is_snap(application_name="othersnap")
-
-    def test_is_snap_application_name_bad_snap_name(self, mocker):
-        mocker.patch.dict(os.environ, {"SNAP_NAME": "mysnap"})
-        assert os_utils.is_snap(application_name="othersnap") is False
-
-    def test_is_snap_application_name_no_snap_name(self, mocker):
-        assert os_utils.is_snap(application_name="othersnap") is False
+        assert os_utils.is_snap(app_name) == result
 
     def test_is_inside_container_has_dockerenv(self, mocker):
         mocker.patch("os.path.exists", new=lambda x: "/.dockerenv" in x)

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -350,3 +350,37 @@ class TestOsRelease:
 
         with pytest.raises(errors.OsReleaseCodenameError):
             release.version_codename()
+
+
+class TestEnvironment:
+    """Running on snap or container must be detected."""
+
+    def test_is_snap(self, mocker):
+        mocker.patch.dict(os.environ, {"SNAP_NAME": "mysnap"})
+        assert os_utils.is_snap()
+
+    def test_is_snap_no_snap_name(self, mocker):
+        assert os_utils.is_snap() is False
+
+    def test_is_snap_application_name(self, mocker):
+        mocker.patch.dict(os.environ, {"SNAP_NAME": "othersnap"})
+        assert os_utils.is_snap(application_name="othersnap")
+
+    def test_is_snap_application_name_bad_snap_name(self, mocker):
+        mocker.patch.dict(os.environ, {"SNAP_NAME": "mysnap"})
+        assert os_utils.is_snap(application_name="othersnap") is False
+
+    def test_is_snap_application_name_no_snap_name(self, mocker):
+        assert os_utils.is_snap(application_name="othersnap") is False
+
+    def test_is_inside_container_has_dockerenv(self, mocker):
+        mocker.patch("os.path.exists", new=lambda x: "/.dockerenv" in x)
+        assert os_utils.is_inside_container()
+
+    def test_is_inside_container_has_containerenv(self, mocker):
+        mocker.patch("os.path.exists", new=lambda x: "/run/.containerenv" in x)
+        assert os_utils.is_inside_container()
+
+    def test_is_inside_container_no_files(self, mocker):
+        mocker.patch("os.path.exists", new=lambda x: False)
+        assert os_utils.is_inside_container() is False


### PR DESCRIPTION
Snap environment detection returned false positives and was not being
properly tested. Fix snap environment detection and add tests for
`is_snap()` and `is_inside_container()`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
