### PR TITLE
packages: remove sudo calls (CRAFT-384)

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -310,7 +310,7 @@ class Ubuntu(BaseRepository):
     def refresh_build_packages_list(cls) -> None:
         """Refresh the list of packages available in the repository."""
         try:
-            cmd = ["sudo", "--preserve-env", "apt-get", "update"]
+            cmd = ["apt-get", "update"]
             logger.debug("Executing: %s", cmd)
             process_run(cmd)
         except subprocess.CalledProcessError as call_error:
@@ -398,8 +398,6 @@ class Ubuntu(BaseRepository):
         )
 
         apt_command = [
-            "sudo",
-            "--preserve-env",
             "apt-get",
             "--no-install-recommends",
             "-y",
@@ -415,7 +413,7 @@ class Ubuntu(BaseRepository):
 
         versionless_names = [get_pkg_name_parts(p)[0] for p in package_names]
         try:
-            process_run(["sudo", "apt-mark", "auto"] + versionless_names, env=env)
+            process_run(["apt-mark", "auto"] + versionless_names, env=env)
         except subprocess.CalledProcessError as err:
             logger.warning("Impossible to mark packages as auto-installed: %s", err)
 

--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -211,10 +211,7 @@ class SnapPackage:
 
     def install(self):
         """Installs the snap onto the system."""
-        snap_install_cmd = []
-        if _snap_command_requires_sudo():
-            snap_install_cmd = ["sudo"]
-        snap_install_cmd.extend(["snap", "install", self.name])
+        snap_install_cmd = ["snap", "install", self.name]
         if self._original_channel:
             snap_install_cmd.extend(["--channel", self._original_channel])
         try:
@@ -236,12 +233,7 @@ class SnapPackage:
 
     def refresh(self):
         """Refresh a snap onto a channel on the system."""
-        snap_refresh_cmd = []
-        if _snap_command_requires_sudo():
-            snap_refresh_cmd = ["sudo"]
-        snap_refresh_cmd.extend(
-            ["snap", "refresh", self.name, "--channel", self.channel]
-        )
+        snap_refresh_cmd = ["snap", "refresh", self.name, "--channel", self.channel]
         try:
             if self.is_classic():
                 # TODO make this a user explicit choice
@@ -308,21 +300,6 @@ def install_snaps(snaps_list: Union[Sequence[str], Set[str]]) -> List[str]:
                 "{}={}".format(snap_pkg.name, local_snap_info["revision"])
             )
     return snaps_installed
-
-
-def _snap_command_requires_sudo():
-    # snap whoami returns - if the user is not logged in.
-    output = check_output(["snap", "whoami"])
-    whoami = output.decode(sys.getfilesystemencoding())
-    requires_root = False
-    try:
-        requires_root = whoami.split(":")[1].strip() == "-"
-    # A safeguard if the output changes
-    except IndexError:
-        requires_root = True
-    if requires_root:
-        logger.warning("snapd is not logged in, snap install commands will use sudo")
-    return requires_root
 
 
 def get_assertion(assertion_params: Sequence[str]) -> bytes:

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -231,11 +231,9 @@ class TestBuildPackages:
         ]
         fake_run.assert_has_calls(
             [
-                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(["apt-get", "update"]),
                 call(
                     [
-                        "sudo",
-                        "--preserve-env",
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
@@ -255,7 +253,6 @@ class TestBuildPackages:
                 ),
                 call(
                     [
-                        "sudo",
                         "apt-mark",
                         "auto",
                         "dependency-package",
@@ -314,11 +311,9 @@ class TestBuildPackages:
         assert build_packages == ["package-installed=3.0"]
         fake_run.assert_has_calls(
             [
-                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(["apt-get", "update"]),
                 call(
                     [
-                        "sudo",
-                        "--preserve-env",
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
@@ -334,7 +329,7 @@ class TestBuildPackages:
                     },
                 ),
                 call(
-                    ["sudo", "apt-mark", "auto", "package-installed"],
+                    ["apt-mark", "auto", "package-installed"],
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -356,11 +351,9 @@ class TestBuildPackages:
         assert build_packages == ["package=1.0"]
         fake_run.assert_has_calls(
             [
-                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(["apt-get", "update"]),
                 call(
                     [
-                        "sudo",
-                        "--preserve-env",
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
@@ -376,7 +369,7 @@ class TestBuildPackages:
                     },
                 ),
                 call(
-                    ["sudo", "apt-mark", "auto", "package"],
+                    ["apt-mark", "auto", "package"],
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -398,11 +391,9 @@ class TestBuildPackages:
 
         fake_run.assert_has_calls(
             [
-                call(["sudo", "--preserve-env", "apt-get", "update"]),
+                call(["apt-get", "update"]),
                 call(
                     [
-                        "sudo",
-                        "--preserve-env",
                         "apt-get",
                         "--no-install-recommends",
                         "-y",
@@ -418,7 +409,7 @@ class TestBuildPackages:
                     },
                 ),
                 call(
-                    ["sudo", "apt-mark", "auto", "package"],
+                    ["apt-mark", "auto", "package"],
                     env={
                         "DEBIAN_FRONTEND": "noninteractive",
                         "DEBCONF_NONINTERACTIVE_SEEN": "true",
@@ -450,21 +441,17 @@ class TestBuildPackages:
     def test_refresh_build_packages_list(self, fake_run):
         deb.Ubuntu.refresh_build_packages_list()
 
-        fake_run.assert_called_once_with(
-            ["sudo", "--preserve-env", "apt-get", "update"]
-        )
+        fake_run.assert_called_once_with(["apt-get", "update"])
 
     def test_refresh_build_packages_list_fails(self, fake_run):
         fake_run.side_effect = CalledProcessError(
-            returncode=1, cmd=["sudo", "--preserve-env", "apt-get", "update"]
+            returncode=1, cmd=["apt-get", "update"]
         )
 
         with pytest.raises(errors.PackageListRefreshError):
             deb.Ubuntu.refresh_build_packages_list()
 
-        fake_run.assert_has_calls(
-            [call(["sudo", "--preserve-env", "apt-get", "update"])]
-        )
+        fake_run.assert_has_calls([call(["apt-get", "update"])])
 
 
 @pytest.fixture

--- a/tests/unit/packages/test_snaps.py
+++ b/tests/unit/packages/test_snaps.py
@@ -255,9 +255,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
         snap_pkg.install()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "install",
                 "fake-snap",
@@ -275,9 +273,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
         snap_pkg.install()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "install",
                 "fake-snap",
@@ -292,9 +288,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
         snap_pkg.install()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "install",
                 "fake-snap",
@@ -307,9 +301,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
         snap_pkg.install()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "install",
                 "fake-snap",
@@ -327,7 +319,6 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
         snap_pkg.install()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             ["snap", "install", "fake-snap", "--channel", "strict/stable"],
         ]
 
@@ -345,9 +336,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
         snap_pkg.refresh()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "refresh",
                 "fake-snap",
@@ -360,9 +349,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
         snap_pkg.refresh()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "refresh",
                 "fake-snap",
@@ -449,9 +436,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
         snap_pkg.refresh()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "refresh",
                 "fake-snap",
@@ -467,9 +452,7 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/classic/stable")
         snap_pkg.refresh()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             [
-                "sudo",
                 "snap",
                 "refresh",
                 "fake-snap",
@@ -487,7 +470,6 @@ class TestSnapPackageLifecycle:
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable")
         snap_pkg.refresh()
         assert fake_snap_command.calls == [
-            ["snap", "whoami"],
             ["snap", "refresh", "fake-snap", "--channel", "strict/stable"],
         ]
 


### PR DESCRIPTION
Remove sudo calls from apt and snap install calls, and fail instead
if permission to run is insufficient. Sudo is not necessary in the
provider environment because the application already runs as root.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
