### PR TITLE
plugins: strip plugin properties in non-destructive way (CRAFT-394)

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -223,7 +223,7 @@ def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> P
     except ValueError as err:
         raise errors.PartSpecificationError(part_name=name, message=str(err)) from err
 
-    plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
+    spec = plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
 
     # initialize part and unmarshal part specs
     part = Part(name, spec, project_dirs=project_dirs, plugin_properties=properties)

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -223,9 +223,11 @@ def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> P
     except ValueError as err:
         raise errors.PartSpecificationError(part_name=name, message=str(err)) from err
 
-    spec = plugins.strip_plugin_properties(spec, plugin_name=plugin_name)
+    part_spec = plugins.extract_part_properties(spec, plugin_name=plugin_name)
 
     # initialize part and unmarshal part specs
-    part = Part(name, spec, project_dirs=project_dirs, plugin_properties=properties)
+    part = Part(
+        name, part_spec, project_dirs=project_dirs, plugin_properties=properties
+    )
 
     return part

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -20,9 +20,9 @@ from .base import PluginModel, extract_plugin_properties  # noqa: F401
 from .plugins import (  # noqa: F401
     Plugin,
     PluginProperties,
+    extract_part_properties,
     get_plugin,
     get_plugin_class,
     register,
-    strip_plugin_properties,
     unregister_all,
 )

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -97,13 +97,13 @@ def unregister_all() -> None:
     _PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)
 
 
-def strip_plugin_properties(data: Dict[str, Any], *, plugin_name: str) -> None:
+def strip_plugin_properties(
+    data: Dict[str, Any], *, plugin_name: str
+) -> Dict[str, Any]:
     """Remove plugin-specific entries from part properties.
 
     :param data: A dictionary containing all part properties.
     :param plugin_name: The name of the plugin.
     """
     prefix = f"{plugin_name}-"
-    for key in list(data):
-        if key.startswith(prefix):
-            del data[key]
+    return {k: v for k, v in data.items() if not k.startswith(prefix)}

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -97,13 +97,15 @@ def unregister_all() -> None:
     _PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)
 
 
-def strip_plugin_properties(
+def extract_part_properties(
     data: Dict[str, Any], *, plugin_name: str
 ) -> Dict[str, Any]:
-    """Remove plugin-specific entries from part properties.
+    """Get common part properties without plugin-specific entries.
 
     :param data: A dictionary containing all part properties.
     :param plugin_name: The name of the plugin.
+
+    :return: A dictionary containing only common part properties.
     """
     prefix = f"{plugin_name}-"
     return {k: v for k, v in data.items() if not k.startswith(prefix)}

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -83,6 +83,7 @@ def test_application_plugin_happy(caplog, new_dir, mocker):
     plugins.register({"app": AppPlugin})
 
     parts = yaml.safe_load(_parts_yaml)
+    old_parts = parts.copy()
 
     lf = craft_parts.LifecycleManager(
         parts, application_name="test_application_plugin", cache_dir=new_dir
@@ -108,6 +109,9 @@ def test_application_plugin_happy(caplog, new_dir, mocker):
 
     mock_install_build_packages.assert_called_once_with(["build_package"])
     mock_install_build_snaps.assert_called_once_with({"build_snap"})
+
+    # make sure parts data was not changed
+    assert parts == old_parts
 
 
 def test_application_plugin_missing_stuff(new_dir):

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -149,10 +149,14 @@ class TestHelpers:
             "test-two": 2,
             "not-test-three": 3,
         }
+        old_data = data.copy()
 
-        plugins.strip_plugin_properties(data, plugin_name="test")
-        assert data == {
+        new_data = plugins.strip_plugin_properties(data, plugin_name="test")
+        assert new_data == {
             "foo": True,
             "test": "yes",
             "not-test-three": 3,
         }
+
+        # make sure we don't destroy original data
+        assert data == old_data

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -141,7 +141,7 @@ class TestPluginRegistry:
 class TestHelpers:
     """Verify plugin helper functions."""
 
-    def test_strip_plugin_properties(self):
+    def test_extract_part_properties(self):
         data = {
             "foo": True,
             "test": "yes",
@@ -151,7 +151,7 @@ class TestHelpers:
         }
         old_data = data.copy()
 
-        new_data = plugins.strip_plugin_properties(data, plugin_name="test")
+        new_data = plugins.extract_part_properties(data, plugin_name="test")
         assert new_data == {
             "foo": True,
             "test": "yes",


### PR DESCRIPTION
Stripping plugin properties shouldn't change original parts data that
has been supplied by the application using craft-parts.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
