### PR TITLE
sources: verify deleted files in outdated check (CRAFT-440)

### DIFF
--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -21,6 +21,7 @@ import functools
 import glob
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import List, Optional
 
@@ -60,6 +61,7 @@ class LocalSource(SourceHandler):
         )
         self._updated_files = set()
         self._updated_directories = set()
+        self._deleted_entries = []
 
     def pull(self):
         """Retrieve the local source files."""
@@ -122,7 +124,16 @@ class LocalSource(SourceHandler):
                     else:
                         self._updated_directories.add(relpath)
 
-        return len(self._updated_files) > 0 or len(self._updated_directories) > 0
+        # XXX: remove pathlib.Path conversions when implementing CRAFT-43
+        self._deleted_entries = _check_deleted_sources(
+            srcdir=Path(self.source_abspath), destdir=Path(self.part_src_dir)
+        )
+
+        return (
+            len(self._updated_files) > 0
+            or len(self._updated_directories) > 0
+            or len(self._deleted_entries) > 0
+        )
 
     def update(self):
         """Update pulled source.
@@ -145,6 +156,50 @@ class LocalSource(SourceHandler):
                 os.path.join(self.source, file_path),
                 os.path.join(self.part_src_dir, file_path),
             )
+
+        # And remove deleted entries
+        for entry in self._deleted_entries:
+            path = Path(self.part_src_dir, entry)
+            if path.is_dir():
+                shutil.rmtree(str(path))
+            else:
+                path.unlink()
+
+
+def _check_deleted_sources(srcdir: Path, destdir: Path) -> List[Path]:
+    """Look for files or directories removed from source.
+
+    Scan entries in the destination directory and check if the equivalent file
+    in the source directory exists. If not, remove it from destination.
+
+    :param srcdir: The source directory.
+    :param destdir: The destination directory.
+
+    :returns: The list of deleted entries.
+    """
+    deleted_entries: List[Path] = []
+
+    for (root, directories, files) in os.walk(destdir, topdown=True):
+        for file_name in files:
+            path = Path(root, file_name)
+            relpath = path.relative_to(destdir)
+            srcpath = srcdir / relpath
+            if not srcpath.exists():
+                logger.debug("deleted file: %s", relpath)
+                deleted_entries.append(relpath)
+
+        for directory in directories:
+            path = Path(root, directory)
+            relpath = path.relative_to(destdir)
+            srcpath = srcdir / relpath
+            if not srcpath.exists():
+                logger.debug("deleted dir: %s", relpath)
+                # Don't descend into this directory-- we'll just delete it
+                # entirely.
+                directories.remove(directory)
+                deleted_entries.append(relpath)
+
+    return deleted_entries
 
 
 def _ignore(

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -186,6 +186,7 @@ class TestPartUpdateHandler:
 
         source_file = Path("subdir/foo.txt")
         os_utils.TimedWriter.write_text(source_file, "change")
+        Path("subdir/bar.txt").touch()
         Path("parts/foo/src/bar.txt").touch()
 
         self._handler.run_action(Action("foo", Step.PULL, ActionType.UPDATE))

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -16,6 +16,7 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -385,3 +386,75 @@ class TestLocalUpdate:
 
         local.update()
         assert os.path.isfile(os.path.join(destination, "dir", "file2"))
+
+    def test_file_removed(self, new_dir):
+        source = Path("source")
+        destination = Path("destination")
+        source.mkdir()
+        destination.mkdir()
+
+        source_file = source / "file1"
+        source_file.write_text("1")
+
+        # Now make a reference file with a timestamp later than the file was
+        # created. We'll ensure this by setting it ourselves
+        shutil.copy2(source_file, "reference")
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime("reference", (access_time, modify_time + 1))
+
+        local = LocalSource(source, destination, cache_dir=new_dir)
+        local.pull()
+
+        # Expect no updates to be available
+        assert local.check_if_outdated("reference") is False
+
+        destination_file = destination / "file1"
+        assert destination_file.is_file()
+
+        # Now remove the file from the source directory
+        source_file.unlink()
+
+        # Expect update to be available
+        assert local.check_if_outdated("reference")
+
+        local.update()
+        assert destination_file.is_file() is False
+
+    def test_directory_removed(self, new_dir):
+        source = Path("source")
+        destination = Path("destination")
+        source.mkdir()
+        destination.mkdir()
+
+        source_directory = source / "dir1"
+        source_directory.mkdir()
+        source_file = source_directory / "file1"
+        source_file.write_text("1")
+
+        # Now make a reference file with a timestamp later than the file was
+        # created. We'll ensure this by setting it ourselves
+        shutil.copy2(source_file, "reference")
+        access_time = os.stat("reference").st_atime
+        modify_time = os.stat("reference").st_mtime
+        os.utime("reference", (access_time, modify_time + 1))
+
+        local = LocalSource(source, destination, cache_dir=new_dir)
+        local.pull()
+
+        # Expect no updates to be available
+        assert local.check_if_outdated("reference") is False
+
+        destination_directory = destination / "dir1"
+        destination_file = destination_directory / "file1"
+        assert destination_directory.is_dir()
+        assert destination_file.is_file()
+
+        # Now remove the file from the source directory
+        shutil.rmtree(source_directory)
+
+        # Expect update to be available
+        assert local.check_if_outdated("reference")
+
+        local.update()
+        assert destination_directory.is_dir() is False


### PR DESCRIPTION
When verifying if a pulled source is outdated, also check for files
or directories that might have been deleted from the source directory.
If this is the case, also remove the files or directories from the
part source directory.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
