### PR TITLE
executor: fix rerun action to clean subsequent steps (CRAFT-441)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -90,7 +90,8 @@ class PartHandler:
             return
 
         if action.action_type == ActionType.RERUN:
-            self.clean_step(step=action.step)
+            for step in [action.step] + action.step.next_steps():
+                self.clean_step(step=step)
 
         handler: Callable[[StepInfo], StepState]
 

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -304,9 +304,9 @@ class TestRerunStep:
         mock.attach_mock(mock_callback, "run_pre_step")
 
         handler.run_action(Action("p1", step, ActionType.RERUN))
-        mock.assert_has_calls(
-            [mocker.call.clean_step(step=step), mocker.call.run_pre_step(mocker.ANY)]
-        )
+        calls = [mocker.call.clean_step(step=x) for x in [step] + step.next_steps()]
+        calls.append(mocker.call.run_pre_step(mocker.ANY))
+        mock.assert_has_calls(calls)
 
 
 @pytest.mark.usefixtures("new_dir")


### PR DESCRIPTION
Rerunning a part step should invalidate not only its state but also
the state of subsequent steps in the same part. This is correctly
implemented in action planning but not in execution. Fix the action
executor to clean all the necessary steps and not only the step being
re-executed.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
