### PR TITLE
craft_parts: export PartsError in base package (CRAFT-456)

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -20,6 +20,7 @@ __version__ = "1.0.0"  # noqa: F401
 
 from .actions import Action, ActionType  # noqa: F401
 from .dirs import ProjectDirs  # noqa: F401
+from .errors import PartsError  # noqa: F401
 from .infos import PartInfo, ProjectInfo, StepInfo  # noqa: F401
 from .lifecycle_manager import LifecycleManager  # noqa: F401
 from .parts import Part  # noqa: F401


### PR DESCRIPTION
Once applications want to catch this exception, it should probably be exposed from the package rather than require reference to the module.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
