### PR TITLE
utils: add filesystem mounting calls (CRAFT-460)

### DIFF
--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -226,6 +226,24 @@ def get_system_info() -> str:
     return uname
 
 
+def mount(device: str, mountpoint: str, *args) -> None:
+    """Mount a filesystem.
+
+    :param device: The device to mount.
+    :param mountpoint: Where the device will be mounted.
+    :param *args: Additional arguments to ``mount(8)``.
+    """
+    subprocess.check_call(["/bin/mount", *args, device, mountpoint])
+
+
+def umount(mountpoint: str) -> None:
+    """Unmount a filesystem.
+
+    :param mountpoint: The mount point or device to unmount.
+    """
+    subprocess.check_call(["/bin/umount", mountpoint])
+
+
 _ID_TO_UBUNTU_CODENAME = {
     "17.10": "artful",
     "17.04": "zesty",

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -232,6 +232,8 @@ def mount(device: str, mountpoint: str, *args) -> None:
     :param device: The device to mount.
     :param mountpoint: Where the device will be mounted.
     :param *args: Additional arguments to ``mount(8)``.
+
+    :raises subprocess.CalledProcessError: on error.
     """
     subprocess.check_call(["/bin/mount", *args, device, mountpoint])
 
@@ -240,6 +242,8 @@ def umount(mountpoint: str) -> None:
     """Unmount a filesystem.
 
     :param mountpoint: The mount point or device to unmount.
+
+    :raises subprocess.CalledProcessError: on error.
     """
     subprocess.check_call(["/bin/umount", mountpoint])
 

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -383,3 +383,19 @@ class TestEnvironment:
     def test_is_inside_container_no_files(self, mocker):
         mocker.patch("os.path.exists", new=lambda x: False)
         assert os_utils.is_inside_container() is False
+
+
+class TestMount:
+    """Check mount and unmount calls."""
+
+    def test_mount(self, mocker):
+        mock_call = mocker.patch("subprocess.check_call")
+        os_utils.mount("/dev/node", "/mountpoint", "some", "args")
+        mock_call.assert_called_once_with(
+            ["/bin/mount", "some", "args", "/dev/node", "/mountpoint"]
+        )
+
+    def test_umount(self, mocker):
+        mock_call = mocker.patch("subprocess.check_call")
+        os_utils.umount("/mountpoint")
+        mock_call.assert_called_once_with(["/bin/umount", "/mountpoint"])


### PR DESCRIPTION
Add utilities to mount and unmount filesystems. These are thin wrappers
around the system mount and umount commands.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
