### PR TITLE
overlay: add overlayfs helpers (CRAFT-462)

### DIFF
--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -1,0 +1,20 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Overlay filesystem management and helpers."""
+
+from .overlay_fs import is_opaque_dir  # noqa: F401
+from .overlay_fs import is_whiteout_file  # noqa: F401

--- a/craft_parts/overlays/errors.py
+++ b/craft_parts/overlays/errors.py
@@ -1,0 +1,53 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Overlay error definitions."""
+
+from craft_parts import errors
+
+
+class OverlayError(errors.PartsError):
+    """Base class for overlay handler errors."""
+
+
+class OverlayMountError(OverlayError):
+    """Failed to mount an overlay filesystem.
+
+    :param mountpoint: The filesystem mount point.
+    :param message: The error message.
+    """
+
+    def __init__(self, mountpoint: str, message: str):
+        self.mountpoint = mountpoint
+        self.message = message
+        brief = f"Failed to mount overlay on {mountpoint}: {message}"
+
+        super().__init__(brief=brief)
+
+
+class OverlayUnmountError(OverlayError):
+    """Failed to unmount an overlay filesystem.
+
+    :param mountpoint: The filesystem mount point.
+    :param message: The error message.
+    """
+
+    def __init__(self, mountpoint: str, message: str):
+        self.mountpoint = mountpoint
+        self.message = message
+        brief = f"Failed to unmount {mountpoint}: {message}"
+
+        super().__init__(brief=brief)

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -1,0 +1,109 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Low level interface to OS overlayfs."""
+
+import logging
+import os
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import List, Optional, Union
+
+from craft_parts.utils import os_utils
+
+from . import errors
+
+logger = logging.getLogger(__name__)
+
+
+class OverlayFS:
+    """Linux overlayfs operations."""
+
+    def __init__(
+        self, *, lower_dir: Union[Path, List[Path]], upper_dir: Path, work_dir: Path
+    ):
+        if not isinstance(lower_dir, list):
+            lower_dir = [lower_dir]
+
+        self._lower_dir = lower_dir
+        self._upper_dir = upper_dir
+        self._work_dir = work_dir
+        self._mountpoint: Optional[Path] = None
+
+    def mount(self, mountpoint: Path) -> None:
+        """Mount an overlayfs."""
+        logger.debug("mount overlayfs on %s", self._mountpoint)
+        lower_dir = ":".join([str(p) for p in self._lower_dir])
+
+        try:
+            os_utils.mount(
+                "overlay",
+                str(mountpoint),
+                "-toverlay",
+                "-olowerdir={!s},upperdir={!s},workdir={!s}".format(
+                    lower_dir, self._upper_dir, self._work_dir
+                ),
+            )
+        except CalledProcessError as err:
+            raise errors.OverlayMountError(str(mountpoint), message=str(err))
+
+        self._mountpoint = mountpoint
+
+    def unmount(self) -> None:
+        """Umount an overlayfs."""
+        if not self._mountpoint:
+            return
+
+        logger.debug("unmount overlayfs from %s", self._mountpoint)
+        try:
+            os_utils.umount(str(self._mountpoint))
+        except CalledProcessError as err:
+            raise errors.OverlayMountError(str(self._mountpoint), message=str(err))
+
+        self._mountpoint = None
+
+
+def is_whiteout_file(path: Path) -> bool:
+    """Verify if the given path corresponds to a whiteout file.
+
+    :param path: The path of the file to verify.
+
+    :return: Whether the given path is an overlayfs whiteout.
+    """
+    if not path.is_char_device() or path.is_symlink():
+        return False
+
+    rdev = os.stat(path).st_rdev
+
+    return os.major(rdev) == 0 and os.minor(rdev) == 0
+
+
+def is_opaque_dir(path: Path) -> bool:
+    """Verify if the given path corresponds to an opaque directory.
+
+    :param path: The path of the file to verify.
+
+    :return: Whether the given path is an overlayfs opaque directory.
+    """
+    if not path.is_dir() or path.is_symlink():
+        return False
+
+    try:
+        value = os.getxattr(path, "trusted.overlay.opaque")
+    except OSError:
+        return False
+
+    return value == b"y"

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -74,7 +74,7 @@ class OverlayFS:
         try:
             os_utils.umount(str(self._mountpoint))
         except CalledProcessError as err:
-            raise errors.OverlayMountError(str(self._mountpoint), message=str(err))
+            raise errors.OverlayUnmountError(str(self._mountpoint), message=str(err))
 
         self._mountpoint = None
 

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -58,7 +58,7 @@ class OverlayFS:
                 ),
             )
         except CalledProcessError as err:
-            raise errors.OverlayMountError(str(mountpoint), message=str(err))
+            raise errors.OverlayMountError(str(mountpoint), message=str(err)) from err
 
         self._mountpoint = mountpoint
 
@@ -74,7 +74,9 @@ class OverlayFS:
         try:
             os_utils.umount(str(self._mountpoint))
         except CalledProcessError as err:
-            raise errors.OverlayUnmountError(str(self._mountpoint), message=str(err))
+            raise errors.OverlayUnmountError(
+                str(self._mountpoint), message=str(err)
+            ) from err
 
         self._mountpoint = None
 

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -44,7 +44,12 @@ class OverlayFS:
         self._mountpoint: Optional[Path] = None
 
     def mount(self, mountpoint: Path) -> None:
-        """Mount an overlayfs."""
+        """Mount an overlayfs.
+
+        :param mountpoint: The filesystem mount point.
+
+        :raises OverlayMountError: on mount error.
+        """
         logger.debug("mount overlayfs on %s", self._mountpoint)
         lower_dir = ":".join([str(p) for p in self._lower_dir])
 
@@ -63,7 +68,10 @@ class OverlayFS:
         self._mountpoint = mountpoint
 
     def unmount(self) -> None:
-        """Umount an overlayfs."""
+        """Umount an overlayfs.
+
+        :raises OverlayUnmountError: on unmount error.
+        """
         if not self._mountpoint:
             return
 
@@ -84,7 +92,7 @@ def is_whiteout_file(path: Path) -> bool:
 
     :param path: The path of the file to verify.
 
-    :return: Whether the given path is an overlayfs whiteout.
+    :returns: Whether the given path is an overlayfs whiteout.
     """
     if not path.is_char_device() or path.is_symlink():
         return False
@@ -102,7 +110,7 @@ def is_opaque_dir(path: Path) -> bool:
 
     :param path: The path of the file to verify.
 
-    :return: Whether the given path is an overlayfs opaque directory.
+    :returns: Whether the given path is an overlayfs opaque directory.
     """
     if not path.is_dir() or path.is_symlink():
         return False

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -79,6 +79,9 @@ class OverlayFS:
 def is_whiteout_file(path: Path) -> bool:
     """Verify if the given path corresponds to a whiteout file.
 
+    Overlayfs whiteout files are represented as character devices
+    with major and minor numbers set to 0.
+
     :param path: The path of the file to verify.
 
     :return: Whether the given path is an overlayfs whiteout.
@@ -93,6 +96,9 @@ def is_whiteout_file(path: Path) -> bool:
 
 def is_opaque_dir(path: Path) -> bool:
     """Verify if the given path corresponds to an opaque directory.
+
+    Overlayfs opaque directories are represented by directories with the
+    extended attribute `trusted.overlay.opaque` set to `y`.
 
     :param path: The path of the file to verify.
 

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -20,7 +20,7 @@ import logging
 import os
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from craft_parts.utils import os_utils
 
@@ -32,13 +32,8 @@ logger = logging.getLogger(__name__)
 class OverlayFS:
     """Linux overlayfs operations."""
 
-    def __init__(
-        self, *, lower_dir: Union[Path, List[Path]], upper_dir: Path, work_dir: Path
-    ):
-        if not isinstance(lower_dir, list):
-            lower_dir = [lower_dir]
-
-        self._lower_dir = lower_dir
+    def __init__(self, *, lower_dirs: List[Path], upper_dir: Path, work_dir: Path):
+        self._lower_dirs = lower_dirs
         self._upper_dir = upper_dir
         self._work_dir = work_dir
         self._mountpoint: Optional[Path] = None
@@ -51,7 +46,7 @@ class OverlayFS:
         :raises OverlayMountError: on mount error.
         """
         logger.debug("mount overlayfs on %s", self._mountpoint)
-        lower_dir = ":".join([str(p) for p in self._lower_dir])
+        lower_dir = ":".join([str(p) for p in self._lower_dirs])
 
         try:
             os_utils.mount(

--- a/tests/unit/overlays/test_errors.py
+++ b/tests/unit/overlays/test_errors.py
@@ -32,6 +32,6 @@ def test_overlay_unmount_error():
     err = errors.OverlayUnmountError("/mountpoint", "something wrong happened")
     assert err.mountpoint == "/mountpoint"
     assert err.message == "something wrong happened"
-    assert err.brief == ("Failed to unmount /mountpoint: something wrong happened")
+    assert err.brief == "Failed to unmount /mountpoint: something wrong happened"
     assert err.details is None
     assert err.resolution is None

--- a/tests/unit/overlays/test_errors.py
+++ b/tests/unit/overlays/test_errors.py
@@ -1,0 +1,37 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts.overlays import errors
+
+
+def test_overlay_mount_error():
+    err = errors.OverlayMountError("/mountpoint", "something wrong happened")
+    assert err.mountpoint == "/mountpoint"
+    assert err.message == "something wrong happened"
+    assert err.brief == (
+        "Failed to mount overlay on /mountpoint: something wrong happened"
+    )
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_overlay_unmount_error():
+    err = errors.OverlayUnmountError("/mountpoint", "something wrong happened")
+    assert err.mountpoint == "/mountpoint"
+    assert err.message == "something wrong happened"
+    assert err.brief == ("Failed to unmount /mountpoint: something wrong happened")
+    assert err.details is None
+    assert err.resolution is None

--- a/tests/unit/overlays/test_overlay_fs.py
+++ b/tests/unit/overlays/test_overlay_fs.py
@@ -111,7 +111,7 @@ class TestOverlayFS:
         ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
 
-        with pytest.raises(errors.OverlayMountError) as err:
+        with pytest.raises(errors.OverlayUnmountError) as err:
             ovfs.unmount()
         assert err.value.mountpoint == "/mountpoint"
         assert (

--- a/tests/unit/overlays/test_overlay_fs.py
+++ b/tests/unit/overlays/test_overlay_fs.py
@@ -1,0 +1,190 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import List, Union
+
+import pytest
+
+from craft_parts.overlays import errors, overlay_fs
+
+
+class TestOverlayFS:
+    """Mount and unmount an overlayfs."""
+
+    @staticmethod
+    def _make_overlay_fs(lower: Union[Path, List[Path]]) -> overlay_fs.OverlayFS:
+        return overlay_fs.OverlayFS(
+            lower_dir=lower,
+            upper_dir=Path("/upper"),
+            work_dir=Path("/work"),
+        )
+
+    def test_mount_single_lower(self, mocker):
+        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs.mount(Path("/mountpoint"))
+        mock_mount.assert_called_once_with(
+            "overlay",
+            "/mountpoint",
+            "-toverlay",
+            "-olowerdir=/lower,upperdir=/upper,workdir=/work",
+        )
+
+    def test_mount_multiple_lower(self, mocker):
+        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+
+        ovfs = self._make_overlay_fs([Path("/lower1"), Path("/lower2")])
+        ovfs.mount(Path("/mountpoint"))
+        mock_mount.assert_called_once_with(
+            "overlay",
+            "/mountpoint",
+            "-toverlay",
+            "-olowerdir=/lower1:/lower2,upperdir=/upper,workdir=/work",
+        )
+
+    def test_mount_error(self, mocker):
+        mocker.patch(
+            "craft_parts.utils.os_utils.mount",
+            side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),
+        )
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        with pytest.raises(errors.OverlayMountError) as err:
+            ovfs.mount(Path("/mountpoint"))
+        assert err.value.mountpoint == "/mountpoint"
+        assert (
+            err.value.message
+            == "Command '['some', 'command']' returned non-zero exit status 42."
+        )
+
+    def test_unmount(self, mocker):
+        mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs.mount(Path("/mountpoint"))
+        ovfs.unmount()
+        mock_umount.assert_called_once_with("/mountpoint")
+
+    def test_unmount_not_mounted(self, mocker):
+        mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs.unmount()
+        mock_umount.assert_not_called()
+
+    def test_unmount_multiple(self, mocker):
+        mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs.mount(Path("/mountpoint"))
+        ovfs.unmount()
+        ovfs.unmount()
+        ovfs.unmount()
+        mock_umount.assert_called_once_with("/mountpoint")
+
+    def test_unmount_error(self, mocker):
+        mocker.patch("craft_parts.utils.os_utils.mount")
+        mocker.patch(
+            "craft_parts.utils.os_utils.umount",
+            side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),
+        )
+
+        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs.mount(Path("/mountpoint"))
+
+        with pytest.raises(errors.OverlayMountError) as err:
+            ovfs.unmount()
+        assert err.value.mountpoint == "/mountpoint"
+        assert (
+            err.value.message
+            == "Command '['some', 'command']' returned non-zero exit status 42."
+        )
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestHelpers:
+    """Verify overlayfs utility functions."""
+
+    @pytest.mark.parametrize(
+        "is_chardev,is_symlink,rdev,result",
+        [
+            (True, False, os.makedev(0, 0), True),
+            (True, True, os.makedev(0, 0), False),
+            (False, False, os.makedev(0, 0), False),
+            (True, False, os.makedev(1, 0), False),
+            (True, False, os.makedev(0, 1), False),
+        ],
+    )
+    def test_is_whiteout_file(self, mocker, is_chardev, is_symlink, rdev, result):
+        fake_stats = mocker.Mock()
+        fake_stats.st_rdev = rdev
+        mocker.patch("os.stat", return_value=fake_stats)
+        mocker.patch("pathlib.Path.is_char_device", return_value=is_chardev)
+
+        if is_symlink:
+            Path("target").touch()
+            Path("whiteout_file").symlink_to("target")
+        else:
+            Path("whiteout_file").touch()
+
+        mocker.patch("pathlib.Path.is_symlink", return_value=is_symlink)
+
+        assert overlay_fs.is_whiteout_file(Path("whiteout_file")) == result
+
+    def test_not_whiteout_file(self):
+        Path("regular_file").touch()
+        assert overlay_fs.is_whiteout_file(Path("regular_file")) is False
+
+    def test_whiteout_file_missing(self):
+        assert Path("missing_file").exists() is False
+        assert overlay_fs.is_whiteout_file(Path("missing_file")) is False
+
+    @pytest.mark.parametrize(
+        "is_dir,is_symlink,attr,result",
+        [
+            (True, False, b"y", True),
+            (True, True, b"y", False),
+            (False, True, b"y", False),
+            (True, False, b"n", False),
+        ],
+    )
+    def test_is_opaque_dir(self, mocker, is_dir, is_symlink, attr, result):
+        if is_symlink:
+            if is_dir:
+                Path("target").mkdir()
+            else:
+                Path("target").touch()
+
+            Path("opaque_dir").symlink_to("target")
+        else:
+            if is_dir:
+                Path("opaque_dir").mkdir()
+            else:
+                Path("opaque_dir").touch()
+
+        mocker.patch("os.getxattr", new=lambda x, y: attr)
+
+        assert overlay_fs.is_opaque_dir(Path("opaque_dir")) == result
+
+    def test_opaque_dir_missing(self):
+        assert Path("missing").exists() is False
+        assert overlay_fs.is_opaque_dir(Path("missing")) is False

--- a/tests/unit/overlays/test_overlay_fs.py
+++ b/tests/unit/overlays/test_overlay_fs.py
@@ -17,7 +17,7 @@
 import os
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import List, Union
+from typing import List
 
 import pytest
 
@@ -28,9 +28,9 @@ class TestOverlayFS:
     """Mount and unmount an overlayfs."""
 
     @staticmethod
-    def _make_overlay_fs(lower: Union[Path, List[Path]]) -> overlay_fs.OverlayFS:
+    def _make_overlay_fs(lower: List[Path]) -> overlay_fs.OverlayFS:
         return overlay_fs.OverlayFS(
-            lower_dir=lower,
+            lower_dirs=lower,
             upper_dir=Path("/upper"),
             work_dir=Path("/work"),
         )
@@ -38,7 +38,7 @@ class TestOverlayFS:
     def test_mount_single_lower(self, mocker):
         mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
         mock_mount.assert_called_once_with(
             "overlay",
@@ -65,7 +65,7 @@ class TestOverlayFS:
             side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),
         )
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         with pytest.raises(errors.OverlayMountError) as err:
             ovfs.mount(Path("/mountpoint"))
         assert err.value.mountpoint == "/mountpoint"
@@ -78,7 +78,7 @@ class TestOverlayFS:
         mocker.patch("craft_parts.utils.os_utils.mount")
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
         ovfs.unmount()
         mock_umount.assert_called_once_with("/mountpoint")
@@ -86,7 +86,7 @@ class TestOverlayFS:
     def test_unmount_not_mounted(self, mocker):
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.unmount()
         mock_umount.assert_not_called()
 
@@ -94,7 +94,7 @@ class TestOverlayFS:
         mocker.patch("craft_parts.utils.os_utils.mount")
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
         ovfs.unmount()
         ovfs.unmount()
@@ -108,7 +108,7 @@ class TestOverlayFS:
             side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),
         )
 
-        ovfs = self._make_overlay_fs(Path("/lower"))
+        ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
 
         with pytest.raises(errors.OverlayMountError) as err:


### PR DESCRIPTION
Add helpers to mount and unmount overlayfs filesystems, and to
identify special files and directories used in filesystem layering.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
