### PR TITLE
overlay: add overlay support to parts (CRAFT-470)

### DIFF
--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -25,6 +25,15 @@ class ProjectDirs:
 
     :param work_dir: The parent directory containing the parts, prime and stage
         subdirectories. If not specified, the current directory will be used.
+
+    :ivar work_dir: The root of the work directories used for project processing.
+    :ivar parts_dir: The directory containing work subdirectories for each part.
+    :ivar overlay_dir: The directory containing work subdirectories for overlays.
+    :ivar overlay_mount_dir: The mountpoint for the overlay filesystem.
+    :ivar overlay_packages_dir: The cache directory for overlay packages.
+    :ivar overlay_work_dir: The work directory for the overlay filesystem.
+    :ivar stage_dir: The staging area containing installed files from all parts.
+    :ivar prime_dir: The primed tree containing the final artifacts to deploy.
     """
 
     def __init__(self, *, work_dir: Union[Path, str] = "."):

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -41,6 +41,21 @@ class ProjectDirs:
         return self._work_dir / "overlay"
 
     @property
+    def overlay_mount_dir(self) -> Path:
+        """Return the overlay directory."""
+        return self.overlay_dir / "overlay"
+
+    @property
+    def overlay_packages_dir(self) -> Path:
+        """Return the overlay package cache directory."""
+        return self.overlay_dir / "packages"
+
+    @property
+    def overlay_work_dir(self) -> Path:
+        """Return the overlay work directory."""
+        return self.overlay_dir / "work"
+
+    @property
     def parts_dir(self) -> Path:
         """Return the directory containing work subdirectories for each part."""
         return self._work_dir / "parts"

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -36,6 +36,11 @@ class ProjectDirs:
         return self._work_dir
 
     @property
+    def overlay_dir(self) -> Path:
+        """Return the directory containing work subdirectories for overlays."""
+        return self._work_dir / "overlay"
+
+    @property
     def parts_dir(self) -> Path:
         """Return the directory containing work subdirectories for each part."""
         return self._work_dir / "parts"

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -28,44 +28,11 @@ class ProjectDirs:
     """
 
     def __init__(self, *, work_dir: Union[Path, str] = "."):
-        self._work_dir = Path(work_dir).expanduser().resolve()
-
-    @property
-    def work_dir(self) -> Path:
-        """Return the root of the work directories used for project processing."""
-        return self._work_dir
-
-    @property
-    def overlay_dir(self) -> Path:
-        """Return the directory containing work subdirectories for overlays."""
-        return self._work_dir / "overlay"
-
-    @property
-    def overlay_mount_dir(self) -> Path:
-        """Return the overlay directory."""
-        return self.overlay_dir / "overlay"
-
-    @property
-    def overlay_packages_dir(self) -> Path:
-        """Return the overlay package cache directory."""
-        return self.overlay_dir / "packages"
-
-    @property
-    def overlay_work_dir(self) -> Path:
-        """Return the overlay work directory."""
-        return self.overlay_dir / "work"
-
-    @property
-    def parts_dir(self) -> Path:
-        """Return the directory containing work subdirectories for each part."""
-        return self._work_dir / "parts"
-
-    @property
-    def stage_dir(self) -> Path:
-        """Return the staging area containing installed files from all parts."""
-        return self._work_dir / "stage"
-
-    @property
-    def prime_dir(self) -> Path:
-        """Return the primed tree containing the final artifacts to deploy."""
-        return self._work_dir / "prime"
+        self.work_dir = Path(work_dir).expanduser().resolve()
+        self.parts_dir = self.work_dir / "parts"
+        self.overlay_dir = self.work_dir / "overlay"
+        self.overlay_mount_dir = self.overlay_dir / "overlay"
+        self.overlay_packages_dir = self.overlay_dir / "packages"
+        self.overlay_work_dir = self.overlay_dir / "work"
+        self.stage_dir = self.work_dir / "stage"
+        self.prime_dir = self.work_dir / "prime"

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -239,21 +239,6 @@ class Part:
         return self._dirs.overlay_dir
 
     @property
-    def overlay_mount_dir(self) -> Path:
-        """Return the overlay directory."""
-        return self._dirs.overlay_dir / "overlay"
-
-    @property
-    def overlay_packages_dir(self) -> Path:
-        """Return the overlay package cache directory."""
-        return self._dirs.overlay_dir / "packages"
-
-    @property
-    def overlay_work_dir(self) -> Path:
-        """Return the overlay work directory."""
-        return self._dirs.overlay_dir / "work"
-
-    @property
     def stage_dir(self) -> Path:
         """Return the staging area containing the installed files from all parts."""
         return self._dirs.stage_dir

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -159,7 +159,7 @@ class Sequencer:
         if not prerequisite_step:
             return
 
-        all_deps = parts.part_dependencies(part.name, part_list=self._part_list)
+        all_deps = parts.part_dependencies(part, part_list=self._part_list)
         deps = {p for p in all_deps if self._sm.should_step_run(p, prerequisite_step)}
         for dep in deps:
             self._add_all_actions(

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -357,7 +357,7 @@ class StateManager:
         # The part is clean, check its dependencies
 
         dependencies = parts.part_dependencies(
-            part.name, part_list=self._part_list, recursive=True
+            part, part_list=self._part_list, recursive=True
         )
 
         changed_dependencies: List[Dependency] = []

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -23,6 +23,10 @@ def test_dirs(new_dir):
     dirs = ProjectDirs()
     assert dirs.work_dir == new_dir
     assert dirs.parts_dir == new_dir / "parts"
+    assert dirs.overlay_dir == new_dir / "overlay"
+    assert dirs.overlay_mount_dir == new_dir / "overlay/overlay"
+    assert dirs.overlay_packages_dir == new_dir / "overlay/packages"
+    assert dirs.overlay_work_dir == new_dir / "overlay/work"
     assert dirs.stage_dir == new_dir / "stage"
     assert dirs.prime_dir == new_dir / "prime"
 
@@ -31,6 +35,10 @@ def test_dirs_work_dir(new_dir):
     dirs = ProjectDirs(work_dir="foobar")
     assert dirs.work_dir == new_dir / "foobar"
     assert dirs.parts_dir == new_dir / "foobar/parts"
+    assert dirs.overlay_dir == new_dir / "foobar/overlay"
+    assert dirs.overlay_mount_dir == new_dir / "foobar/overlay/overlay"
+    assert dirs.overlay_packages_dir == new_dir / "foobar/overlay/packages"
+    assert dirs.overlay_work_dir == new_dir / "foobar/overlay/work"
     assert dirs.stage_dir == new_dir / "foobar/stage"
     assert dirs.prime_dir == new_dir / "foobar/prime"
 

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -92,9 +92,6 @@ class TestPartData:
         assert p.part_run_dir == new_dir / "parts/foo/run"
         assert p.part_layer_dir == new_dir / "parts/foo/layer"
         assert p.overlay_dir == new_dir / "overlay"
-        assert p.overlay_mount_dir == new_dir / "overlay/overlay"
-        assert p.overlay_packages_dir == new_dir / "overlay/packages"
-        assert p.overlay_work_dir == new_dir / "overlay/work"
         assert p.stage_dir == new_dir / "stage"
         assert p.prime_dir == new_dir / "prime"
 
@@ -112,9 +109,6 @@ class TestPartData:
         assert p.part_run_dir == new_dir / "foobar/parts/foo/run"
         assert p.part_layer_dir == new_dir / "foobar/parts/foo/layer"
         assert p.overlay_dir == new_dir / "foobar/overlay"
-        assert p.overlay_mount_dir == new_dir / "foobar/overlay/overlay"
-        assert p.overlay_packages_dir == new_dir / "foobar/overlay/packages"
-        assert p.overlay_work_dir == new_dir / "foobar/overlay/work"
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 


### PR DESCRIPTION
Define the overlay work directory. Add part properties to retrieve
overlay-related subdirectories and identify if a part has overlay
parameters or overlay visibility.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
