### PR TITLE
overlay: add layer visibility helpers (CRAFT-477)

### DIFF
--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -18,3 +18,6 @@
 
 from .overlay_fs import is_opaque_dir  # noqa: F401
 from .overlay_fs import is_whiteout_file  # noqa: F401
+from .overlays import oci_opaque_dir  # noqa: F401
+from .overlays import oci_whiteout  # noqa: F401
+from .overlays import visible_in_layer  # noqa: F401

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -72,7 +72,7 @@ def visible_in_layer(lower_dir: Path, upper_dir: Path) -> Tuple[Set[str], Set[st
                 # Don't descend into this directory, overridden by opaque
                 directories.remove(directory)
 
-    logger.debug("files=%r, dirs=%r", visible_files, visible_dirs)
+    logger.debug("layer visibility files=%r, dirs=%r", visible_files, visible_dirs)
     return visible_files, visible_dirs
 
 

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -1,0 +1,125 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Overlay handling helpers."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def visible_in_layer(srcdir: Path, destdir: Path) -> Tuple[Set[str], Set[str]]:
+    """Determine the files and directories that are visible in a layer.
+
+    Given a source and destination directories, list the files and directories that
+    would be visible in an overlay stack if the destination directory is the upper
+    layer and the source directory is the lower layer.
+
+    :param srcdir: The source directory.
+    :param destdir: The destination directory.
+
+    :returns: A tuple containing the sets of files and directories that are visible.
+    """
+    visible_files: Set[str] = set()
+    visible_dirs: Set[str] = set()
+
+    logger.debug("check layer visibility in %s", srcdir)
+    for (root, directories, files) in os.walk(srcdir, topdown=True):
+        for file_name in files:
+            path = Path(root, file_name)
+            relpath = path.relative_to(srcdir)
+            if not _is_path_visible(destdir, relpath):
+                continue
+
+            destpath = destdir / relpath
+            if not destpath.exists() and not oci_whiteout(destpath).exists():
+                visible_files.add(str(relpath))
+
+        for directory in directories:
+            path = Path(root, directory)
+            relpath = path.relative_to(srcdir)
+            if not _is_path_visible(destdir, relpath):
+                continue
+
+            destpath = destdir / relpath
+            if not destpath.exists():
+                if path.is_symlink():
+                    visible_files.add(str(relpath))
+                else:
+                    visible_dirs.add(str(relpath))
+            elif is_oci_opaque_dir(destpath):
+                logger.debug("is opaque dir: %s", relpath)
+                # Don't descend into this directory, overridden by opaque
+                directories.remove(directory)
+
+    logger.debug("files=%r, dirs=%r", visible_files, visible_dirs)
+    return visible_files, visible_dirs
+
+
+def _is_path_visible(root: Path, relpath: Path) -> bool:
+    """Verify if any element of the given path is not whited out.
+
+    :var root: The root directory, not included in the verification.
+    :var relpath: The relative path to verify.
+
+    :returns: Whether the final element of the path is visible.
+    """
+    logger.debug("check if path is visible: root=%s, relpath=%s", root, relpath)
+    levels = len(relpath.parts)
+
+    for level in range(levels):
+        path = Path(root, os.path.join(*relpath.parts[: level + 1]))
+        if oci_whiteout(path).exists() or is_oci_opaque_dir(path):
+            logger.debug("is whiteout or opaque: %s", path)
+            return False
+
+    return True
+
+
+def is_oci_opaque_dir(path: Path) -> bool:
+    """Verify if the given path corresponds to an opaque directory.
+
+    :param path: The path of the file to verify.
+
+    :returns: Whether the given path is an overlayfs opaque directory.
+    """
+    if not path.is_dir() or path.is_symlink():
+        return False
+
+    return oci_opaque_dir(path).exists()
+
+
+def oci_whiteout(path: Path) -> Path:
+    """Convert the given path to an OCI whiteout file name.
+
+    :param path: The file path to white out.
+
+    :returns: The corresponding OCI whiteout file name.
+    """
+    return path.parent / (".wh." + path.name)
+
+
+def oci_opaque_dir(path: Path) -> Path:
+    """Return the OCI opaque directory marker.
+
+    :param path: The directory to mark as opaque.
+
+    :returns: The corresponding OCI opaque directory marker path.
+    """
+    return path / ".wh..wh..opq"

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -75,8 +75,8 @@ def visible_in_layer(srcdir: Path, destdir: Path) -> Tuple[Set[str], Set[str]]:
 def _is_path_visible(root: Path, relpath: Path) -> bool:
     """Verify if any element of the given path is not whited out.
 
-    :var root: The root directory, not included in the verification.
-    :var relpath: The relative path to verify.
+    :param root: The root directory, not included in the verification.
+    :param relpath: The relative path to verify.
 
     :returns: Whether the final element of the path is visible.
     """

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -31,9 +31,11 @@ logger = logging.getLogger(__name__)
 def visible_in_layer(lower_dir: Path, upper_dir: Path) -> Tuple[Set[str], Set[str]]:
     """Determine the files and directories that are visible in a layer.
 
-    Given a pair of directories containing lower and upper layer contents, list the
-    files and subdirectories that would be visible if they're layered. The upper
-    directory may contain OCI whiteout files and opaque dirs.
+    Given a pair of directories containing lower and upper layer entries, list the
+    files and subdirectories in the lower layer that would be directly visible when
+    the layers are stacked (i.e. the visibility is not "blocked" by an entry with
+    the same name that exists in the upper directory). The upper directory may contain
+    OCI whiteout files and opaque dirs.
 
     :param lower_dir: The lower directory.
     :param upper_dir: The upper directory.

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -14,7 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Overlay handling helpers."""
+"""Overlay handling helpers.
+
+Relevant OCI documentation available at:
+https://github.com/opencontainers/image-spec/blob/main/layer.md
+"""
 
 import logging
 import os

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -1,0 +1,173 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+from craft_parts.overlays import overlays
+
+
+class TestHelpers:
+    """OCI special files translation and verification."""
+
+    def test_is_oci_opaque_dir(self, new_dir):
+        dir1 = Path("dir1")
+        dir1.mkdir()
+        Path("dir1/.wh..wh..opq").touch()
+
+        assert overlays.is_oci_opaque_dir(dir1)
+
+    def test_is_oci_opaque_dir_nomarker(self, new_dir):
+        dir1 = Path("dir1")
+        dir1.mkdir()
+
+        assert overlays.is_oci_opaque_dir(dir1) is False
+
+    def test_is_oci_opaque_dir_symlink(self, new_dir):
+        dir1 = Path("dir1")
+        dir1.mkdir()
+        Path("dir1/.wh..wh..opq").touch()
+
+        dir2 = Path("dir2")
+        dir2.symlink_to(dir1)
+
+        assert overlays.is_oci_opaque_dir(dir1)
+        assert overlays.is_oci_opaque_dir(dir2) is False
+
+    @pytest.mark.parametrize(
+        "name,oci_name", [("foo", ".wh.foo"), ("/path/foo", "/path/.wh.foo")]
+    )
+    def test_oci_whiteout(self, name, oci_name):
+        assert overlays.oci_whiteout(Path(name)) == Path(oci_name)
+
+    @pytest.mark.parametrize(
+        "name,oci_name",
+        [("foo", "foo/.wh..wh..opq"), ("/path/foo", "/path/foo/.wh..wh..opq")],
+    )
+    def test_oci_opaque_dir(self, name, oci_name):
+        assert overlays.oci_opaque_dir(Path(name)) == Path(oci_name)
+
+    def test_is_path_visible(self, new_dir):
+        deepfile = Path("dir1/dir2/dir3/dir4/foo")
+        deepfile.parent.mkdir(parents=True)
+        deepfile.touch()
+        assert overlays._is_path_visible(new_dir, deepfile)
+
+    def test_is_path_visible_first_whited_out(self, new_dir):
+        deepfile = Path("dir1/dir2/dir3/dir4/foo")
+        Path(".wh.dir1").touch()
+        assert overlays._is_path_visible(new_dir, deepfile) is False
+
+    def test_is_path_visible_last_whited_out(self, new_dir):
+        deepfile = Path("dir1/dir2/dir3/dir4/foo")
+        Path("dir1/dir2/dir3").mkdir(parents=True)
+        Path("dir1/dir2/dir3/.wh.dir4").touch()
+        assert overlays._is_path_visible(new_dir, deepfile) is False
+
+    def test_is_path_visible_first_opaque(self, new_dir):
+        deepfile = Path("dir1/dir2/dir3/dir4/foo")
+        deepfile.parent.mkdir(parents=True)
+        Path("dir1/.wh..wh..opq").touch()
+        assert overlays._is_path_visible(new_dir, deepfile) is False
+
+    def test_is_path_visible_last_opaque(self, new_dir):
+        deepfile = Path("dir1/dir2/dir3/dir4/foo")
+        deepfile.parent.mkdir(parents=True)
+        Path("dir1/dir2/dir3/dir4/.wh..wh..opq").touch()
+        assert overlays._is_path_visible(new_dir, deepfile) is False
+
+
+class TestVisibility:
+    """File visibility in a directory layer."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, new_dir):
+        Path("srcdir").mkdir()
+        Path("srcdir/a").touch()
+        Path("srcdir/dir1").mkdir()
+        Path("srcdir/dir1/b").touch()
+        Path("srcdir/dir1/c").touch()
+        Path("destdir").mkdir()
+
+    def test_visible_in_layer(self, new_dir):
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c"}
+        assert dirs == {"dir1"}
+
+    def test_visible_in_layer_whited_out_file(self, new_dir):
+        Path("destdir/dir1").mkdir()
+        Path("destdir/dir1/.wh.b").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/c"}
+        assert dirs == set()
+
+    def test_visible_in_layer_opaque_dir(self, new_dir):
+        Path("destdir/dir1").mkdir()
+        Path("destdir/dir1/.wh..wh..opq").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a"}
+        assert dirs == set()
+
+    def test_visible_in_layer_whiteout_in_opaque_dir(self, new_dir):
+        Path("destdir/dir1").mkdir()
+        Path("destdir/dir1/.wh..wh..opq").touch()
+        Path("destdir/dir1/.wh.b").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a"}
+        assert dirs == set()
+
+    def test_visible_in_layer_symlink(self, new_dir):
+        Path("srcdir/dir2").symlink_to("dir1")
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c", "dir2"}
+        assert dirs == {"dir1"}
+
+    def test_visible_in_layer_deep_file(self, new_dir):
+        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile.parent.mkdir(parents=True)
+        deepfile.touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c", "dir2/dir3/dir4/d"}
+        assert dirs == {"dir1", "dir2", "dir2/dir3", "dir2/dir3/dir4"}
+
+    def test_visible_in_layer_deep_file_whiteout_dir(self, new_dir):
+        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile.parent.mkdir(parents=True)
+        deepfile.touch()
+
+        Path("destdir/.wh.dir2").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c"}
+        assert dirs == {"dir1"}
+
+    def test_visible_in_layer_deep_file_opaque_dir(self, new_dir):
+        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile.parent.mkdir(parents=True)
+        deepfile.touch()
+
+        Path("destdir/dir2/dir3").mkdir(parents=True)
+        Path("destdir/dir2/dir3/.wh..wh..opq").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c"}
+        assert dirs == {"dir1"}

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -96,86 +96,86 @@ class TestVisibility:
 
     @pytest.fixture(autouse=True)
     def setup_method_fixture(self, new_dir):
-        Path("srcdir").mkdir()
-        Path("srcdir/a").touch()
-        Path("srcdir/dir1").mkdir()
-        Path("srcdir/dir1/b").touch()
-        Path("srcdir/dir1/c").touch()
-        Path("destdir").mkdir()
+        Path("lower_dir").mkdir()
+        Path("lower_dir/a").touch()
+        Path("lower_dir/dir1").mkdir()
+        Path("lower_dir/dir1/b").touch()
+        Path("lower_dir/dir1/c").touch()
+        Path("upper_dir").mkdir()
 
     def test_visible_in_layer(self, new_dir):
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c"}
         assert dirs == {"dir1"}
 
     def test_visible_in_layer_merge_dir_contents(self, new_dir):
-        Path("destdir/dir1").mkdir()
-        Path("destdir/dir1/d").touch()
+        Path("upper_dir/dir1").mkdir()
+        Path("upper_dir/dir1/d").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c"}
         assert dirs == set()
 
     def test_visible_in_layer_whited_out_file(self, new_dir):
-        Path("destdir/dir1").mkdir()
-        Path("destdir/dir1/.wh.b").touch()
+        Path("upper_dir/dir1").mkdir()
+        Path("upper_dir/dir1/.wh.b").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/c"}
         assert dirs == set()
 
     def test_visible_in_layer_opaque_dir(self, new_dir):
-        Path("destdir/dir1").mkdir()
-        Path("destdir/dir1/.wh..wh..opq").touch()
+        Path("upper_dir/dir1").mkdir()
+        Path("upper_dir/dir1/.wh..wh..opq").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a"}
         assert dirs == set()
 
     def test_visible_in_layer_whiteout_in_opaque_dir(self, new_dir):
-        Path("destdir/dir1").mkdir()
-        Path("destdir/dir1/.wh..wh..opq").touch()
-        Path("destdir/dir1/.wh.b").touch()
+        Path("upper_dir/dir1").mkdir()
+        Path("upper_dir/dir1/.wh..wh..opq").touch()
+        Path("upper_dir/dir1/.wh.b").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a"}
         assert dirs == set()
 
     def test_visible_in_layer_symlink(self, new_dir):
-        Path("srcdir/dir2").symlink_to("dir1")
+        Path("lower_dir/dir2").symlink_to("dir1")
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c", "dir2"}
         assert dirs == {"dir1"}
 
     def test_visible_in_layer_deep_file(self, new_dir):
-        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile = Path("lower_dir/dir2/dir3/dir4/d")
         deepfile.parent.mkdir(parents=True)
         deepfile.touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c", "dir2/dir3/dir4/d"}
         assert dirs == {"dir1", "dir2", "dir2/dir3", "dir2/dir3/dir4"}
 
     def test_visible_in_layer_deep_file_whiteout_dir(self, new_dir):
-        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile = Path("lower_dir/dir2/dir3/dir4/d")
         deepfile.parent.mkdir(parents=True)
         deepfile.touch()
 
-        Path("destdir/.wh.dir2").touch()
+        Path("upper_dir/.wh.dir2").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c"}
         assert dirs == {"dir1"}
 
     def test_visible_in_layer_deep_file_opaque_dir(self, new_dir):
-        deepfile = Path("srcdir/dir2/dir3/dir4/d")
+        deepfile = Path("lower_dir/dir2/dir3/dir4/d")
         deepfile.parent.mkdir(parents=True)
         deepfile.touch()
 
-        Path("destdir/dir2/dir3").mkdir(parents=True)
-        Path("destdir/dir2/dir3/.wh..wh..opq").touch()
+        Path("upper_dir/dir2/dir3").mkdir(parents=True)
+        Path("upper_dir/dir2/dir3/.wh..wh..opq").touch()
 
-        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        files, dirs = overlays.visible_in_layer(Path("lower_dir"), Path("upper_dir"))
         assert files == {"a", "dir1/b", "dir1/c"}
         assert dirs == {"dir1"}

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -29,7 +29,7 @@ class TestHelpers:
         dir1.mkdir()
         Path("dir1/.wh..wh..opq").touch()
 
-        assert overlays.is_oci_opaque_dir(dir1)
+        assert overlays.is_oci_opaque_dir(dir1) is True
 
     def test_is_oci_opaque_dir_nomarker(self, new_dir):
         dir1 = Path("dir1")
@@ -45,7 +45,7 @@ class TestHelpers:
         dir2 = Path("dir2")
         dir2.symlink_to(dir1)
 
-        assert overlays.is_oci_opaque_dir(dir1)
+        assert overlays.is_oci_opaque_dir(dir1) is True
         assert overlays.is_oci_opaque_dir(dir2) is False
 
     @pytest.mark.parametrize(
@@ -65,7 +65,7 @@ class TestHelpers:
         deepfile = Path("dir1/dir2/dir3/dir4/foo")
         deepfile.parent.mkdir(parents=True)
         deepfile.touch()
-        assert overlays._is_path_visible(new_dir, deepfile)
+        assert overlays._is_path_visible(new_dir, deepfile) is True
 
     def test_is_path_visible_first_whited_out(self, new_dir):
         deepfile = Path("dir1/dir2/dir3/dir4/foo")

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -31,7 +31,7 @@ class TestHelpers:
 
         assert overlays.is_oci_opaque_dir(dir1) is True
 
-    def test_is_oci_opaque_dir_nomarker(self, new_dir):
+    def test_is_not_oci_opaque_dir(self, new_dir):
         dir1 = Path("dir1")
         dir1.mkdir()
 

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -108,6 +108,14 @@ class TestVisibility:
         assert files == {"a", "dir1/b", "dir1/c"}
         assert dirs == {"dir1"}
 
+    def test_visible_in_layer_merge_dir_contents(self, new_dir):
+        Path("destdir/dir1").mkdir()
+        Path("destdir/dir1/d").touch()
+
+        files, dirs = overlays.visible_in_layer(Path("srcdir"), Path("destdir"))
+        assert files == {"a", "dir1/b", "dir1/c"}
+        assert dirs == set()
+
     def test_visible_in_layer_whited_out_file(self, new_dir):
         Path("destdir/dir1").mkdir()
         Path("destdir/dir1/.wh.b").touch()


### PR DESCRIPTION
Add helper functions to obtain the sets of migratable files and
directories from each overlay layer considering whited out entries and
opaque directories.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
