### PR TITLE
overlay: compute layer validation hash (CRAFT-478)

### DIFF
--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -18,6 +18,7 @@
 
 import hashlib
 import logging
+from typing import Optional
 
 from craft_parts.parts import Part
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 class LayerHash:
     """The layer validation hash for a part."""
 
-    def __init__(self, layer_hash: bytes = b""):
+    def __init__(self, layer_hash: bytes):
         self.hash_bytes = layer_hash
 
     def __repr__(self):
@@ -66,17 +67,17 @@ class LayerHash:
         return cls(hasher.digest())
 
     @classmethod
-    def load(cls, part: Part) -> "LayerHash":
+    def load(cls, part: Part) -> Optional["LayerHash"]:
         """Read the part layer validation hash from persistent state.
 
         :param part: The part whose layer hash will be loaded.
 
-        :return: A layer hash object containing the loaded validaton hash.
-            An empty hash value will be used if the file doesn't exist.
+        :return: A layer hash object containing the loaded validaton hash,
+            or None if the file doesn't exist.
         """
         hash_file = part.part_state_dir / "layer_hash"
         if not hash_file.exists():
-            return cls()
+            return None
 
         with open(hash_file) as file:
             hex_string = file.readline()

--- a/tests/unit/overlays/test_layers.py
+++ b/tests/unit/overlays/test_layers.py
@@ -60,7 +60,7 @@ class TestLayerHash:
         p1 = Part(
             "p1", {"overlay-packages": pkgs, "overlay": files, "overlay-script": script}
         )
-        h1 = LayerHash.for_part(p1, previous_layer_hash=LayerHash())
+        h1 = LayerHash.for_part(p1, previous_layer_hash=LayerHash(b""))
         assert h1.hex() == result
 
         h2 = LayerHash.for_part(p1, previous_layer_hash=h1)
@@ -68,7 +68,7 @@ class TestLayerHash:
 
     def test_previous_hash(self):
         p1 = Part("p1", {"overlay-packages": [], "overlay": [], "overlay-script": None})
-        h1 = LayerHash.for_part(p1, previous_layer_hash=LayerHash())
+        h1 = LayerHash.for_part(p1, previous_layer_hash=LayerHash(b""))
         assert h1.hex() == "80324ed2458e5d51e851972d092a0996dc038e8b"
 
         h2 = LayerHash.for_part(p1, previous_layer_hash=h1)
@@ -81,12 +81,13 @@ class TestLayerHash:
 
         p1 = Part("p1", {})
         h = LayerHash.load(part=p1)
+        assert h is not None
         assert h.hex() == "736f6d652076616c7565"
 
     def test_load_missing_file(self, new_dir):
         p1 = Part("p1", {})
         h = LayerHash.load(p1)
-        assert h.hex() == ""
+        assert h is None
 
     def test_save(self, new_dir):
         Path("parts/p1/state").mkdir(parents=True)


### PR DESCRIPTION
Obtain a layer hash based on layer parameters and the previous layer's
validation hash. `LayerHash` also provides helper methods to persist and
recover the hash value.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
