### PR TITLE
packages/apt: use host state for apt cache (CRAFT-487)

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -144,22 +144,14 @@ class LifecycleManager:
         """
         self._executor.clean(initial_step=step, part_names=part_names)
 
-    def refresh_packages_list(self, *, system=False) -> None:
+    def refresh_packages_list(self) -> None:
         """Update the available packages list.
 
         The list of available packages should be updated before planning the
         sequence of actions to take. To ensure consistency between the scenarios,
         it shouldn't be updated between planning and execution.
-
-        :param system: Also refresh the list of available build packages to
-            install on the host system.
         """
-        packages.Repository.refresh_stage_packages_list(
-            cache_dir=self._project_info.cache_dir, target_arch=self._target_arch
-        )
-
-        if system:
-            packages.Repository.refresh_build_packages_list()
+        packages.Repository.refresh_build_packages_list()
 
     def plan(self, target_step: Step, part_names: Sequence[str] = None) -> List[Action]:
         """Obtain the list of actions to be executed given the target step and parts.

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -133,6 +133,7 @@ class AptCache(ContextDecorator):
 
         apt.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg")
         apt.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/")
+        apt.apt_pkg.config.set("Dir::State", "/var/lib/apt")
 
         # Clear up apt's Post-Invoke-Success as we are not running
         # on the system.
@@ -358,18 +359,6 @@ class AptCache(ContextDecorator):
 
         # Unmark dependencies that are no longer required.
         self._autokeep_packages()
-
-    # pylint: disable=attribute-defined-outside-init
-    def update(self) -> None:
-        """Update the package manager cache."""
-        try:
-            self.cache.update(fetch_progress=self.progress, sources_list=None)
-            self.cache.close()
-            self.cache = apt.cache.Cache(rootdir=str(self.stage_cache), memonly=True)
-        except apt.cache.FetchFailedException as err:
-            raise errors.PackageListRefreshError(str(err))
-
-    # pylint: enable=attribute-defined-outside-init
 
 
 def _verify_marked_install(package: apt.package.Package):

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -112,18 +112,6 @@ class BaseRepository(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def refresh_stage_packages_list(cls, *, cache_dir: Path, target_arch: str) -> None:
-        """Update the list of packages available in the repository.
-
-        :param application_name: A unique identifier for the application
-            using Craft Parts.
-        :param target_arch: The architecture of the packages to fetch.
-
-        :raise PackageListRefreshError: If the update process is not successful.
-        """
-
-    @classmethod
-    @abc.abstractmethod
     def fetch_stage_packages(
         cls,
         *,
@@ -201,10 +189,6 @@ class DummyRepository(BaseRepository):
     def get_installed_packages(cls) -> List[str]:
         """Obtain a list of the installed packages and their versions."""
         return []
-
-    @classmethod
-    def refresh_stage_packages_list(cls, *, cache_dir: Path, target_arch: str) -> None:
-        """Update the list of packages available in the repository."""
 
     @classmethod
     def fetch_stage_packages(

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -481,10 +481,8 @@ class Ubuntu(BaseRepository):
         stage_cache_dir, _ = get_cache_dirs(cache_dir)
         stage_cache_dir.mkdir(parents=True, exist_ok=True)
 
-        with AptCache(
-            stage_cache=stage_cache_dir, stage_cache_arch=target_arch
-        ) as apt_cache:
-            apt_cache.update()
+        with AptCache(stage_cache=stage_cache_dir, stage_cache_arch=target_arch) as _:
+            pass
 
     @classmethod
     def unpack_stage_packages(

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -476,15 +476,6 @@ class Ubuntu(BaseRepository):
         return sorted(installed)
 
     @classmethod
-    def refresh_stage_packages_list(cls, *, cache_dir: Path, target_arch: str):
-        """Refresh the list of packages available in the repository."""
-        stage_cache_dir, _ = get_cache_dirs(cache_dir)
-        stage_cache_dir.mkdir(parents=True, exist_ok=True)
-
-        with AptCache(stage_cache=stage_cache_dir, stage_cache_arch=target_arch) as _:
-            pass
-
-    @classmethod
     def unpack_stage_packages(
         cls, *, stage_packages_path: pathlib.Path, install_path: pathlib.Path
     ) -> None:

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -314,35 +314,7 @@ class TestCleaning:
 
 
 class TestUpdating:
-    def test_refresh_stage_packages_list(self, new_dir, mocker):
-        refresh_stage = mocker.patch(
-            "craft_parts.packages.Repository.refresh_stage_packages_list"
-        )
-        refresh_build = mocker.patch(
-            "craft_parts.packages.Repository.refresh_build_packages_list"
-        )
-
-        parts_yaml = textwrap.dedent(
-            """
-            parts:
-              foo:
-                plugin: nil
-            """
-        )
-        parts = yaml.safe_load(parts_yaml)
-
-        lf = craft_parts.LifecycleManager(
-            parts, application_name="test_update", arch="aarch64", cache_dir=new_dir
-        )
-        lf.refresh_packages_list()
-
-        refresh_stage.assert_called_once_with(cache_dir=new_dir, target_arch="arm64")
-        refresh_build.assert_not_called()
-
     def test_refresh_system_packages_list(self, new_dir, mocker):
-        refresh_stage = mocker.patch(
-            "craft_parts.packages.Repository.refresh_stage_packages_list"
-        )
         refresh_build = mocker.patch(
             "craft_parts.packages.Repository.refresh_build_packages_list"
         )
@@ -359,7 +331,6 @@ class TestUpdating:
         lf = craft_parts.LifecycleManager(
             parts, application_name="test_update", cache_dir=new_dir, arch="aarch64"
         )
-        lf.refresh_packages_list(system=True)
+        lf.refresh_packages_list()
 
-        refresh_stage.assert_called_once_with(cache_dir=new_dir, target_arch="arm64")
         refresh_build.assert_called_once_with()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -177,8 +177,6 @@ def test_main_application_name(new_dir, mocker, capfd):
     )
     Path("parts.yaml").write_text(my_parts_yaml)
 
-    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
-
     mocker.patch.object(
         sys, "argv", ["cmd", "--application-name", "znapcraft", "--refresh", "pull"]
     )
@@ -206,8 +204,6 @@ def test_main_application_name(new_dir, mocker, capfd):
     # check cache location
     assert Path(".cache/craft-parts/stage-packages").is_dir()
 
-    mock_update.assert_called_with()
-
 
 def test_main_invalid_application_name(mocker):
     Path("parts.yaml").write_text(parts_yaml)
@@ -224,8 +220,6 @@ def test_main_invalid_application_name(mocker):
 def test_main_cache_dir(new_dir, mocker):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
-
     mocker.patch.object(
         sys, "argv", ["cmd", "--dry-run", "--cache-dir", "cache_dir", "--refresh"]
     )
@@ -235,8 +229,6 @@ def test_main_cache_dir(new_dir, mocker):
 
     # check cache location
     assert Path("cache_dir/stage-packages").is_dir()
-
-    mock_update.assert_called_with()
 
 
 def test_main_alternative_work_dir(mocker, capfd):
@@ -289,8 +281,6 @@ def test_main_alternative_parts_invalid_file(mocker, capfd):
 def test_main_refresh(new_dir, mocker, capfd):
     Path("parts.yaml").write_text(parts_yaml)
 
-    mock_update = mocker.patch("craft_parts.packages.apt_cache.AptCache.update")
-
     mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "--refresh"])
     with pytest.raises(SystemExit) as raised:
         main.main()
@@ -302,8 +292,6 @@ def test_main_refresh(new_dir, mocker, capfd):
 
     # check cache location
     assert Path(".cache/craft-parts/stage-packages").is_dir()
-
-    mock_update.assert_called_with()
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -177,9 +177,7 @@ def test_main_application_name(new_dir, mocker, capfd):
     )
     Path("parts.yaml").write_text(my_parts_yaml)
 
-    mocker.patch.object(
-        sys, "argv", ["cmd", "--application-name", "znapcraft", "--refresh", "pull"]
-    )
+    mocker.patch.object(sys, "argv", ["cmd", "--application-name", "znapcraft", "pull"])
     main.main()
 
     # check environment variables
@@ -201,9 +199,6 @@ def test_main_application_name(new_dir, mocker, capfd):
         """
     )
 
-    # check cache location
-    assert Path(".cache/craft-parts/stage-packages").is_dir()
-
 
 def test_main_invalid_application_name(mocker):
     Path("parts.yaml").write_text(parts_yaml)
@@ -215,20 +210,6 @@ def test_main_invalid_application_name(mocker):
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code == 3
-
-
-def test_main_cache_dir(new_dir, mocker):
-    Path("parts.yaml").write_text(parts_yaml)
-
-    mocker.patch.object(
-        sys, "argv", ["cmd", "--dry-run", "--cache-dir", "cache_dir", "--refresh"]
-    )
-    with pytest.raises(SystemExit) as raised:
-        main.main()
-    assert raised.value.code is None
-
-    # check cache location
-    assert Path("cache_dir/stage-packages").is_dir()
 
 
 def test_main_alternative_work_dir(mocker, capfd):
@@ -276,22 +257,6 @@ def test_main_alternative_parts_invalid_file(mocker, capfd):
     out, err = capfd.readouterr()
     assert err == "Error: missing.yaml: No such file or directory.\n"
     assert out == ""
-
-
-def test_main_refresh(new_dir, mocker, capfd):
-    Path("parts.yaml").write_text(parts_yaml)
-
-    mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "--refresh"])
-    with pytest.raises(SystemExit) as raised:
-        main.main()
-    assert raised.value.code is None
-
-    out, err = capfd.readouterr()
-    assert err == ""
-    assert out == plan_result[3]
-
-    # check cache location
-    assert Path(".cache/craft-parts/stage-packages").is_dir()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -44,8 +44,6 @@ class TestAptStageCache:
 
         AptCache.configure_apt("test_stage_packages")
         with AptCache(stage_cache=stage_cache) as apt_cache:
-            apt_cache.update()
-
             package_names = {"pciutils"}
             filtered_names = {
                 "base-files",
@@ -152,6 +150,7 @@ class TestMockedApt:
             call.apt_pkg.config.set("Acquire::AllowInsecureRepositories", "False"),
             call.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg"),
             call.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"),
+            call.apt_pkg.config.set("Dir::State", "/var/lib/apt"),
             call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
         ]
         # fmt: on
@@ -175,6 +174,7 @@ class TestMockedApt:
             call.apt_pkg.config.set("Apt::Key::gpgvcommand", snap_dir + "/usr/bin/gpgv"),
             call.apt_pkg.config.set("Dir::Etc::Trusted", "/etc/apt/trusted.gpg"),
             call.apt_pkg.config.set("Dir::Etc::TrustedParts", "/etc/apt/trusted.gpg.d/"),
+            call.apt_pkg.config.set("Dir::State", "/var/lib/apt"),
             call.apt_pkg.config.clear("APT::Update::Post-Invoke-Success"),
         ]
         # fmt: on
@@ -184,13 +184,10 @@ class TestMockedApt:
         stage_cache.mkdir(exist_ok=True, parents=True)
         fake_apt = mocker.patch("craft_parts.packages.apt_cache.apt")
 
-        with AptCache(stage_cache=stage_cache) as apt_cache:
-            apt_cache.update()
+        with AptCache(stage_cache=stage_cache) as _:
+            pass
 
         assert fake_apt.mock_calls == [
-            call.cache.Cache(rootdir=str(stage_cache), memonly=True),
-            call.cache.Cache().update(fetch_progress=mocker.ANY, sources_list=None),
-            call.cache.Cache().close(),
             call.cache.Cache(rootdir=str(stage_cache), memonly=True),
             call.cache.Cache().close(),
         ]

--- a/tests/unit/packages/test_base.py
+++ b/tests/unit/packages/test_base.py
@@ -31,7 +31,6 @@ class TestBaseRepository:
             "install_build_packages",
             "fetch_stage_packages",
             "refresh_build_packages_list",
-            "refresh_stage_packages_list",
             "unpack_stage_packages",
         }
 


### PR DESCRIPTION
Instead of having a split state for stage cache, rely on the
host's cache by setting the state directory to /var/lib/apt.

With this, we can remove the update() interface which is no
longer required.

This effectively causes the refresh_stage_packages_list()
to noop.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
