### PR TITLE
overlay: add overlay hash to build and stage steps (CRAFT-489)

### DIFF
--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -16,6 +16,7 @@
 
 """Overlay filesystem management and helpers."""
 
+from .layers import LayerHash  # noqa: F401
 from .overlay_fs import is_opaque_dir  # noqa: F401
 from .overlay_fs import is_whiteout_file  # noqa: F401
 from .overlays import oci_opaque_dir  # noqa: F401

--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -38,7 +38,9 @@ class LayerHash:
         return self.hash_bytes == other.hash_bytes
 
     @classmethod
-    def for_part(cls, part: Part, *, previous_layer_hash: "LayerHash") -> "LayerHash":
+    def for_part(
+        cls, part: Part, *, previous_layer_hash: Optional["LayerHash"]
+    ) -> "LayerHash":
         """Obtain the validation hash for a part.
 
         :param part: The part being processed.
@@ -49,7 +51,8 @@ class LayerHash:
             to the given part.
         """
         hasher = hashlib.sha1()
-        hasher.update(previous_layer_hash.hash_bytes)
+        if previous_layer_hash:
+            hasher.update(previous_layer_hash.hash_bytes)
         for entry in part.spec.overlay_packages:
             hasher.update(entry.encode())
         digest = hasher.digest()

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -16,7 +16,9 @@
 
 """State definitions for the build step."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from pydantic import validator
 
 from .step_state import StepState
 
@@ -25,6 +27,14 @@ class BuildState(StepState):
     """Context information for the build step."""
 
     assets: Dict[str, Any] = {}
+    overlay_hash: Optional[str] = None
+
+    @validator("overlay_hash")
+    @classmethod
+    def _validate_hex_string(cls, value):
+        if value:
+            bytes.fromhex(value)
+        return value
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "BuildState":

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -16,13 +16,24 @@
 
 """State definitions for the stage step."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from pydantic import validator
 
 from .step_state import StepState
 
 
 class StageState(StepState):
     """Context information for the stage step."""
+
+    overlay_hash: Optional[str] = None
+
+    @validator("overlay_hash")
+    @classmethod
+    def _validate_hex_string(cls, value):
+        if value:
+            bytes.fromhex(value)
+        return value
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "StageState":

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -101,6 +101,7 @@ class TestPartHandling:
                 "installed-packages": ["hello=2.10"],
                 "installed-snaps": ["snapcraft=6466"],
             },
+            overlay_hash="6554e32fa718d54160d0511b36f81458e4cb2357",
         )
 
     def test_run_stage(self, mocker):
@@ -115,6 +116,7 @@ class TestPartHandling:
             project_options=self._part_info.project_options,
             files={"file"},
             directories={"dir"},
+            overlay_hash="6554e32fa718d54160d0511b36f81458e4cb2357",
         )
 
     def test_run_prime(self, mocker):
@@ -153,6 +155,26 @@ class TestPartHandling:
         out, err = capfd.readouterr()
         assert out == "hello\n"
         assert err == ""
+
+    def test_compute_layer_hash(self, new_dir):
+        p1 = Part("p1", {"plugin": "nil", "overlay-packages": ["pkg1"]})
+        p2 = Part("p1", {"plugin": "nil", "overlay-script": "ls"})
+        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        part_info = PartInfo(info, p1)
+        handler = PartHandler(p1, part_info=part_info, part_list=[p1, p2])
+
+        layer_hash = handler._compute_layer_hash()
+        assert layer_hash.hex() == "80ab51c6c76eb2b6fc01adc3143ebaf2b982ae56"
+
+    def test_compute_layer_hash_for_all_parts(self, new_dir):
+        p1 = Part("p1", {"plugin": "nil", "overlay-packages": ["pkg1"]})
+        p2 = Part("p1", {"plugin": "nil", "overlay-script": "ls"})
+        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        part_info = PartInfo(info, p1)
+        handler = PartHandler(p1, part_info=part_info, part_list=[p1, p2])
+
+        layer_hash = handler._compute_layer_hash(for_all_parts=True)
+        assert layer_hash.hex() == "f4ae5a2ed1b4fd8a7e03f9264ab0f98ed6fd991b"
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -33,6 +33,7 @@ class TestBuildState:
             "project-options": {},
             "files": set(),
             "directories": set(),
+            "overlay-hash": None,
         }
 
     def test_marshal_unmarshal(self):
@@ -42,6 +43,7 @@ class TestBuildState:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "overlay-hash": "6f7665726c61792d68617368",
         }
 
         state = BuildState.unmarshal(state_data)

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -32,6 +32,7 @@ class TestStageState:
             "project-options": {},
             "files": set(),
             "directories": set(),
+            "overlay-hash": None,
         }
 
     def test_marshal_unmarshal(self):
@@ -40,6 +41,7 @@ class TestStageState:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "overlay-hash": "6f7665726c61792d68617368",
         }
 
         state = StageState.unmarshal(state_data)

--- a/tests/unit/state_manager/test_states.py
+++ b/tests/unit/state_manager/test_states.py
@@ -57,6 +57,7 @@ class TestStepStates:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "overlay-hash": "6f7665726c61792d68617368",
         }
         state_file = Path("parts/foo/state/build")
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -73,6 +74,7 @@ class TestStepStates:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "overlay-hash": "6f7665726c61792d68617368",
         }
         state_file = Path("parts/foo/state/stage")
         state_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
List the overlay verification hash in the build and stage steps to
ensure proper invalidation of steps depending on overlay data. This
hash will be verified in the build step of parts that can see overlay
contents, and in the stage step of parts declaring overlay parameters.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
