### PR TITLE
sources: copy mutable ignore pattern for source handlers (CRAFT-494)

### DIFF
--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -76,7 +76,7 @@ class SourceHandler(abc.ABC):
         self.command = command
         self._dirs = project_dirs
         self._checked = False
-        self._ignore_patterns = ignore_patterns
+        self._ignore_patterns = ignore_patterns.copy()
 
     # pylint: enable=too-many-arguments
 

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -244,6 +244,28 @@ class TestLocal:
     def test_has_source_handler_entry(self):
         assert sources._source_handler["local"] is LocalSource
 
+    def test_ignore_patterns_workdir(self, new_dir):
+        ignore_patterns = ["hello"]
+        project_dirs = ProjectDirs(work_dir=Path("src/work"))
+
+        s1 = LocalSource(
+            "src",
+            "destination",
+            project_dirs=project_dirs,
+            cache_dir=new_dir,
+            ignore_patterns=ignore_patterns,
+        )
+        assert s1._ignore_patterns == ["hello", "work"]
+
+        s2 = LocalSource(
+            "src",
+            "destination",
+            project_dirs=project_dirs,
+            cache_dir=new_dir,
+            ignore_patterns=ignore_patterns,
+        )
+        assert s2._ignore_patterns == ["hello", "work"]
+
 
 class TestLocalUpdate:
     """Verify that the local source can detect changes and update."""


### PR DESCRIPTION
Source handlers may modify the list of ignore patterns, so make a new
copy for each source handler instance.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
