### PR TITLE
overlay: migrate overlay data to stage and prime (CRAFT-468, CRAFT-82)

### DIFF
--- a/craft_parts/executor/migration.py
+++ b/craft_parts/executor/migration.py
@@ -102,7 +102,7 @@ def migrate_files(
         if dst.exists():
             dst.unlink()
 
-        # If source is an whiteout file (overlayfs or OCI), create an OCI whiteout file
+        # If source is a whiteout file (overlayfs or OCI), create an OCI whiteout file
         # in destination and add it to the list of migrated files so it can be removed
         # when cleaning.
         if oci_translation and _is_whiteout_file(src):

--- a/craft_parts/executor/migration.py
+++ b/craft_parts/executor/migration.py
@@ -19,9 +19,10 @@
 import logging
 import os
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Optional, Set, Tuple
 
-from craft_parts.state_manager.states import StepState
+from craft_parts import overlays
+from craft_parts.state_manager.states import MigrationState, StepState
 from craft_parts.utils import file_utils
 
 logger = logging.getLogger(__name__)
@@ -31,12 +32,13 @@ def migrate_files(
     *,
     files: Set[str],
     dirs: Set[str],
-    srcdir: str,
-    destdir: str,
+    srcdir: Path,
+    destdir: Path,
     missing_ok: bool = False,
     follow_symlinks: bool = False,
+    oci_translation: bool = False,
     fixup_func=lambda *args: None,
-) -> None:
+) -> Tuple[Set[str], Set[str]]:
     """Copy or link files from a directory to another.
 
     Files and directories are migrated from one step to the next during
@@ -49,43 +51,95 @@ def migrate_files(
     :param destdir: The directory to migrate entries to.
     :param missing_ok: Ignore entries that don't exist.
     :param follow_symlinks: Migrate symlink targets.
+    :param oci_translation: Convert to OCI whiteout files and opaque dirs.
     :param fixup_func: A function to run on each migrated file.
-    """
-    for dirname in sorted(dirs):
-        src = os.path.join(srcdir, dirname)
-        dst = os.path.join(destdir, dirname)
 
-        file_utils.create_similar_directory(src, dst)
+    :returns: A tuple containing sets of migrated files and directories.
+    """
+    migrated_files: Set[str] = set()
+    migrated_dirs: Set[str] = set()
+
+    for dirname in sorted(dirs):
+        src = srcdir / dirname
+        dst = destdir / dirname
+
+        # If migrating a whited out directory from stage (OCI) using layer (overlayfs)
+        # as reference, use the OCI whiteout file names.
+        if not src.exists() and overlays.oci_whiteout(src).exists():
+            src = overlays.oci_whiteout(src)
+            dst = overlays.oci_whiteout(dst)
+
+        file_utils.create_similar_directory(str(src), str(dst))
+        migrated_dirs.add(dirname)
+
+        # If source is an opaque dir (overlayfs or OCI), create an OCI opaque
+        # directory marker file in destination and add it to the list of migrated
+        # files so it can be removed when cleaning.
+        if oci_translation and _is_opaque_dir(src):
+            oci_opaque_marker = overlays.oci_opaque_dir(Path(dirname))
+            oci_dst = Path(destdir, oci_opaque_marker)
+            oci_dst.touch()
+            migrated_files.add(str(oci_opaque_marker))
 
     for filename in sorted(files):
-        src = os.path.join(srcdir, filename)
-        dst = os.path.join(destdir, filename)
+        src = srcdir / filename
+        dst = destdir / filename
 
-        if missing_ok and not os.path.exists(src):
-            continue
+        if not src.exists():
+            # If migrating a whited out file from stage (OCI) using layer (overlayfs)
+            # as reference, use the OCI whiteout file names.
+            if overlays.oci_whiteout(src).exists():
+                src = overlays.oci_whiteout(src)
+                dst = overlays.oci_whiteout(dst)
+            elif missing_ok:
+                continue
 
         # If the file is already here and it's a symlink, leave it alone.
-        if os.path.islink(dst):
+        if dst.is_symlink():
             continue
 
         # Otherwise, remove and re-link it.
-        if os.path.exists(dst):
-            os.remove(dst)
+        if dst.exists():
+            dst.unlink()
 
-        file_utils.link_or_copy(src, dst, follow_symlinks=follow_symlinks)
+        # If source is an whiteout file (overlayfs or OCI), create an OCI whiteout file
+        # in destination and add it to the list of migrated files so it can be removed
+        # when cleaning.
+        if oci_translation and _is_whiteout_file(src):
+            oci_whiteout = overlays.oci_whiteout(Path(filename))
+            oci_dst = Path(destdir, oci_whiteout)
+            oci_dst.touch()
+            migrated_files.add(str(oci_whiteout))
+        else:
+            file_utils.link_or_copy(str(src), str(dst), follow_symlinks=follow_symlinks)
+            fixup_func(str(dst))
+            migrated_files.add(str(filename))
 
-        fixup_func(dst)
+    return migrated_files, migrated_dirs
+
+
+def _is_whiteout_file(path: Path) -> bool:
+    return overlays.is_whiteout_file(path) or overlays.is_oci_whiteout_file(path)
+
+
+def _is_opaque_dir(path: Path) -> bool:
+    return overlays.is_opaque_dir(path) or overlays.is_oci_opaque_dir(path)
 
 
 def clean_shared_area(
-    *, part_name: str, shared_dir: Path, part_states: Dict[str, StepState]
+    *,
+    part_name: str,
+    shared_dir: Path,
+    part_states: Dict[str, StepState],
+    overlay_migration_state: Optional[MigrationState],
 ) -> None:
     """Clean files added by a part to a shared directory.
 
     :param part_name: The name of the part that added the files.
     :param shared_dir: The shared directory to remove files from.
-    :param part_states: A dictionary containing the each part's state for the
-        step being processed.
+    :param part_states: A dictionary mapping each part to the part's state for
+        the step corresponding to the area being cleaned.
+    :param overlay_migration_state: The state of the overlay migration to step.
     """
     # no state defined for this part, we won't remove files
     if part_name not in part_states:
@@ -104,8 +158,42 @@ def clean_shared_area(
             files -= other_state.files
             directories -= other_state.directories
 
+    # If overlay has been migrated, also take overlay files into account
+    if overlay_migration_state:
+        files -= overlay_migration_state.files
+        directories -= overlay_migration_state.directories
+
     # Finally, clean the files and directories that are specific to this
     # part.
+    _clean_migrated_files(files, directories, shared_dir)
+
+
+def clean_shared_overlay(
+    *,
+    shared_dir: Path,
+    part_states: Dict[str, StepState],
+    overlay_migration_state: Optional[MigrationState],
+) -> None:
+    """Remove migrated overlay files from a shared directory.
+
+    :param state_file: The migration state file.
+    :param shared_dir: The shared directory to remove files from.
+    :param part_states: A dictionary mapping each part to the part's state for
+        the step corresponding to the area being cleaned.
+    """
+    # no overlay staging state defined, we won't remove files
+    if not overlay_migration_state:
+        return
+
+    files = overlay_migration_state.files
+    directories = overlay_migration_state.directories
+
+    # Don't remove entries that also belong to a part.
+    for other_state in part_states.values():
+        if other_state:
+            files -= other_state.files
+            directories -= other_state.directories
+
     _clean_migrated_files(files, directories, shared_dir)
 
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -393,6 +393,9 @@ class PartHandler:
         stage_overlay_state_path = states.get_overlay_migration_state_path(
             self._part.overlay_dir, Step.STAGE
         )
+
+        # Overlay data is migrated to stage only when the first part declaring overlay
+        # parameters is migrated.
         if stage_overlay_state_path.exists():
             logger.debug(
                 "stage overlay migration state exists, not migrating overlay data"
@@ -436,6 +439,9 @@ class PartHandler:
         prime_overlay_state_path = states.get_overlay_migration_state_path(
             self._part.overlay_dir, Step.PRIME
         )
+
+        # Overlay data is migrated to prime only when the first part declaring overlay
+        # parameters is migrated.
         if prime_overlay_state_path.exists():
             logger.debug(
                 "prime overlay migration state exists, not migrating overlay data"

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -394,7 +394,9 @@ class PartHandler:
             self._part.overlay_dir, Step.STAGE
         )
         if stage_overlay_state_path.exists():
-            logger.debug("stage overlay migration state exists")
+            logger.debug(
+                "stage overlay migration state exists, not migrating overlay data"
+            )
             return
 
         if self._part not in parts_with_overlay(part_list=self._part_list):
@@ -437,7 +439,9 @@ class PartHandler:
             self._part.overlay_dir, Step.PRIME
         )
         if prime_overlay_state_path.exists():
-            logger.debug("prime overlay migration state exists")
+            logger.debug(
+                "prime overlay migration state exists, not migrating overlay data"
+            )
             return
 
         if self._part not in parts_with_overlay(part_list=self._part_list):

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -534,22 +534,20 @@ class PartHandler:
             overlay_migration_state=overlay_migration_state,
         )
 
-        # remove overlay data if this is the last primed part with overlay
-        if not self._part.has_overlay:
-            return
-
-        if len(_parts_with_overlay_in_step(step, part_list=self._part_list)) != 1:
-            return
-
-        migration.clean_shared_overlay(
-            shared_dir=shared_dir,
-            part_states=part_states,
-            overlay_migration_state=overlay_migration_state,
-        )
-        overlay_migration_state_path = states.get_overlay_migration_state_path(
-            self._part.overlay_dir, step
-        )
-        overlay_migration_state_path.unlink()
+        # remove overlay data if this is the last part with overlay
+        if (
+            self._part.has_overlay
+            and len(_parts_with_overlay_in_step(step, part_list=self._part_list)) == 1
+        ):
+            migration.clean_shared_overlay(
+                shared_dir=shared_dir,
+                part_states=part_states,
+                overlay_migration_state=overlay_migration_state,
+            )
+            overlay_migration_state_path = states.get_overlay_migration_state_path(
+                self._part.overlay_dir, step
+            )
+            overlay_migration_state_path.unlink()
 
     def _make_dirs(self):
         dirs = [

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -22,21 +22,20 @@ import os.path
 import shutil
 from glob import iglob
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
-from craft_parts import callbacks, errors, packages, plugins, sources
+from craft_parts import callbacks, errors, overlays, packages, plugins, sources
 from craft_parts.actions import Action, ActionType
 from craft_parts.infos import PartInfo, StepInfo
 from craft_parts.overlays import LayerHash
 from craft_parts.packages import errors as packages_errors
-from craft_parts.parts import Part
+from craft_parts.parts import Part, parts_with_overlay
 from craft_parts.plugins import Plugin
-from craft_parts.state_manager import states
-from craft_parts.state_manager.states import StepState
+from craft_parts.state_manager import MigrationState, StepState, states
 from craft_parts.steps import Step
 from craft_parts.utils import file_utils, os_utils
 
-from .migration import clean_shared_area
+from . import migration
 from .organize import organize_files
 from .step_handler import StepContents, StepHandler
 
@@ -206,6 +205,8 @@ class PartHandler:
             work_dir=self._part.stage_dir,
         )
 
+        self._migrate_overlay_files_to_stage()
+
         # Overlay integrity is checked based by the hash of its last (topmost) layer,
         # so we compute it for all parts. The overlay hash is added to the stage state
         # to ensure proper stage step invalidation of parts that declare overlay
@@ -229,6 +230,8 @@ class PartHandler:
             scriptlet_name="override-prime",
             work_dir=self._part.prime_dir,
         )
+
+        self._migrate_overlay_files_to_prime()
 
         state = states.PrimeState(
             part_properties=self._part_properties,
@@ -380,6 +383,92 @@ class PartHandler:
 
         self._organize(overwrite=True)
 
+    def _migrate_overlay_files_to_stage(self) -> None:
+        """Stage overlay files create state.
+
+        Files and directories are migrated from overlay to stage based on a
+        list of visible overlay entries, converting overlayfs whiteout files
+        and opaque dirs to OCI.
+        """
+        stage_overlay_state_path = states.get_overlay_migration_state_path(
+            self._part.overlay_dir, Step.STAGE
+        )
+        if stage_overlay_state_path.exists():
+            logger.debug("stage overlay migration state exists")
+            return
+
+        if self._part not in parts_with_overlay(part_list=self._part_list):
+            return
+
+        logger.debug("staging overlay files")
+        migrated_files: Set[str] = set()
+        migrated_dirs: Set[str] = set()
+
+        # process layers from top to bottom
+        for part in reversed(self._part_list):
+            if not part.has_overlay:
+                continue
+
+            logger.debug("migrate part %r layer to stage", part.name)
+            visible_files, visible_dirs = overlays.visible_in_layer(
+                part.part_layer_dir, part.stage_dir
+            )
+            layer_files, layer_dirs = migration.migrate_files(
+                files=visible_files,
+                dirs=visible_dirs,
+                srcdir=part.part_layer_dir,
+                destdir=part.stage_dir,
+                oci_translation=True,
+            )
+            migrated_files |= layer_files
+            migrated_dirs |= layer_dirs
+
+        state = MigrationState(files=migrated_files, directories=migrated_dirs)
+        state.write(stage_overlay_state_path)
+
+    def _migrate_overlay_files_to_prime(self) -> None:
+        """Prime overlay files and create state.
+
+        Files and directories are migrated from stage to prime based on a list
+        of visible overlay entries, including OCI-compatible whiteout files and
+        opaque directories.
+        """
+        prime_overlay_state_path = states.get_overlay_migration_state_path(
+            self._part.overlay_dir, Step.PRIME
+        )
+        if prime_overlay_state_path.exists():
+            logger.debug("prime overlay migration state exists")
+            return
+
+        if self._part not in parts_with_overlay(part_list=self._part_list):
+            return
+
+        logger.debug("priming overlay files")
+        migrated_files: Set[str] = set()
+        migrated_dirs: Set[str] = set()
+
+        # process layers from top to bottom
+        for part in reversed(self._part_list):
+            if not part.has_overlay:
+                continue
+
+            logger.debug("migrate part %r layer to prime", part.name)
+            visible_files, visible_dirs = overlays.visible_in_layer(
+                part.part_layer_dir, part.prime_dir
+            )
+            layer_files, layer_dirs = migration.migrate_files(
+                files=visible_files,
+                dirs=visible_dirs,
+                srcdir=part.stage_dir,
+                destdir=part.prime_dir,
+                oci_translation=True,
+            )
+            migrated_files |= layer_files
+            migrated_dirs |= layer_dirs
+
+        state = MigrationState(files=migrated_files, directories=migrated_dirs)
+        state.write(prime_overlay_state_path)
+
     def clean_step(self, step: Step) -> None:
         """Remove the work files and the state of the given step.
 
@@ -421,27 +510,53 @@ class PartHandler:
 
     def _clean_stage(self) -> None:
         """Remove the current part's stage step files and state."""
-        part_states = _load_part_states(Step.STAGE, self._part_list)
-        clean_shared_area(
-            part_name=self._part.name,
-            shared_dir=self._part.stage_dir,
-            part_states=part_states,
-        )
+        self._clean_shared(Step.STAGE, shared_dir=self._part.stage_dir)
 
     def _clean_prime(self) -> None:
         """Remove the current part's prime step files and state."""
-        part_states = _load_part_states(Step.PRIME, self._part_list)
-        clean_shared_area(
-            part_name=self._part.name,
-            shared_dir=self._part.prime_dir,
-            part_states=part_states,
+        self._clean_shared(Step.PRIME, shared_dir=self._part.prime_dir)
+
+    def _clean_shared(self, step: Step, *, shared_dir: Path) -> None:
+        """Remove the current part's shared files from the given directory.
+
+        :param step: The step corresponding to the shared directory.
+        :param shared_dir: The shared directory to clean.
+        """
+        part_states = _load_part_states(step, self._part_list)
+        overlay_migration_state = states.load_overlay_migration_state(
+            self._part.overlay_dir, step
         )
+
+        migration.clean_shared_area(
+            part_name=self._part.name,
+            shared_dir=shared_dir,
+            part_states=part_states,
+            overlay_migration_state=overlay_migration_state,
+        )
+
+        # remove overlay data if this is the last primed part with overlay
+        if not self._part.has_overlay:
+            return
+
+        if len(_parts_with_overlay_in_step(step, part_list=self._part_list)) != 1:
+            return
+
+        migration.clean_shared_overlay(
+            shared_dir=shared_dir,
+            part_states=part_states,
+            overlay_migration_state=overlay_migration_state,
+        )
+        overlay_migration_state_path = states.get_overlay_migration_state_path(
+            self._part.overlay_dir, step
+        )
+        overlay_migration_state_path.unlink()
 
     def _make_dirs(self):
         dirs = [
             self._part.part_src_dir,
             self._part.part_build_dir,
             self._part.part_install_dir,
+            self._part.part_layer_dir,
             self._part.part_state_dir,
             self._part.part_run_dir,
             self._part.stage_dir,
@@ -516,6 +631,15 @@ class PartHandler:
 
         for snap_source in snap_sources:
             snap_source.provision(str(install_dir), clean_target=False, keep=True)
+
+    def _overlay_state_file(self, step: Step) -> Path:
+        if step == Step.STAGE:
+            return Path(self._part.overlay_dir / "stage_overlay")
+
+        if step == Step.PRIME:
+            return Path(self._part.overlay_dir / "prime_overlay")
+
+        raise RuntimeError(f"no overlay migration state in step {step!r}")
 
 
 def _remove(filename: Path) -> None:
@@ -612,3 +736,15 @@ def _load_part_states(step: Step, part_list: List[Part]) -> Dict[str, StepState]
         if state:
             part_states[part.name] = state
     return part_states
+
+
+def _parts_with_overlay_in_step(step: Step, *, part_list: List[Part]) -> List[Part]:
+    """Obtain a list of parts with overlay that reached the given step.
+
+    :param step: The step to test for parts with overlay.
+    :param part_list: A list containing all parts.
+
+    :returns: The list of parts with overlay in step.
+    """
+    oparts = parts_with_overlay(part_list=part_list)
+    return [p for p in oparts if states.get_step_state_path(p, step).exists()]

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -143,11 +143,11 @@ class StepHandler:
                 prefix_trim=self._part.part_install_dir,
             )
 
-        migrate_files(
+        files, dirs = migrate_files(
             files=files,
             dirs=dirs,
-            srcdir=str(self._part.part_install_dir),
-            destdir=str(self._part.stage_dir),
+            srcdir=self._part.part_install_dir,
+            destdir=self._part.stage_dir,
             fixup_func=pkgconfig_fixup,
         )
         return StepContents(files, dirs)
@@ -163,11 +163,11 @@ class StepHandler:
 
         srcdir = str(self._part.part_install_dir)
         files, dirs = filesets.migratable_filesets(prime_fileset, srcdir)
-        migrate_files(
+        files, dirs = migrate_files(
             files=files,
             dirs=dirs,
-            srcdir=str(self._part.stage_dir),
-            destdir=str(self._part.prime_dir),
+            srcdir=self._part.stage_dir,
+            destdir=self._part.prime_dir,
         )
         # TODO: handle elf dependencies
 

--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -19,6 +19,8 @@
 from .layers import LayerHash  # noqa: F401
 from .overlay_fs import is_opaque_dir  # noqa: F401
 from .overlay_fs import is_whiteout_file  # noqa: F401
+from .overlays import is_oci_opaque_dir  # noqa: F401
+from .overlays import is_oci_whiteout_file  # noqa: F401
 from .overlays import oci_opaque_dir  # noqa: F401
 from .overlays import oci_whiteout  # noqa: F401
 from .overlays import visible_in_layer  # noqa: F401

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -111,6 +111,16 @@ def is_oci_opaque_dir(path: Path) -> bool:
     return oci_opaque_dir(path).exists()
 
 
+def is_oci_whiteout_file(path: Path) -> bool:
+    """Verify if the given path corresponds to an OCI whiteout file.
+
+    :param path: The path of the file to verify.
+
+    :returns: Whether the given path is an OCI whiteout file.
+    """
+    return path.name.startswith(".wh.") and path.name != ".wh..wh..opq"
+
+
 def oci_whiteout(path: Path) -> Path:
     """Convert the given path to an OCI whiteout file name.
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -395,7 +395,7 @@ def has_overlay_visibility(
     return False
 
 
-def parts_with_overlay(*, part_list: List[Part]) -> List[Part]:
+def get_parts_with_overlay(*, part_list: List[Part]) -> List[Part]:
     """Obtain a list of parts that declare overlay parameters.
 
     :param part_list: A list of all parts in the project.

--- a/craft_parts/state_manager/__init__.py
+++ b/craft_parts/state_manager/__init__.py
@@ -17,3 +17,5 @@
 """Part state management."""
 
 from .state_manager import StateManager  # noqa: F401
+from .step_state import MigrationState  # noqa: F401
+from .step_state import StepState  # noqa: F401

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -401,12 +401,12 @@ class TestPartHelpers:
         assert has_overlay_visibility(p4) is True
         assert has_overlay_visibility(p5) is False
 
-    def test_parts_with_overlay(self):
+    def test_get_parts_with_overlay(self):
         p1 = Part("foo", {})
         p2 = Part("bar", {"overlay-packages": ["pkg1"]})
         p3 = Part("baz", {"overlay-script": "echo"})
         p4 = Part("qux", {"overlay": ["*"]})
         p5 = Part("quux", {"overlay": ["-etc/passwd"]})
 
-        p = parts.parts_with_overlay(part_list=[p1, p2, p3, p4, p5])
+        p = parts.get_parts_with_overlay(part_list=[p1, p2, p3, p4, p5])
         assert p == [p2, p3, p5]


### PR DESCRIPTION
Migrate overlay tree entries to stage and prime areas, handling
whiteouts and translating overlayfs whiteout files and opaque
directories to OCI. Cleanup of overlay files in shared areas is
done when the last part with overlay parameters is cleaned.

Note: collision detection in overlay staging will be implemented
in a forthcoming PR.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
