### PR TITLE
overlay: add layer state management helper (CRAFT-506)

### DIFF
--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -17,6 +17,7 @@
 """Overlay filesystem management and helpers."""
 
 from .layers import LayerHash  # noqa: F401
+from .layers import LayerStateManager  # noqa: F401
 from .overlay_fs import is_opaque_dir  # noqa: F401
 from .overlay_fs import is_whiteout_file  # noqa: F401
 from .overlays import oci_opaque_dir  # noqa: F401

--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -114,7 +114,7 @@ class LayerStateManager:
         self._part_list = part_list
         self._base_layer_hash = base_layer_hash
 
-        self._layer_hash: Dict[str, Optional[LayerHash]] = dict()
+        self._layer_hash: Dict[str, Optional[LayerHash]] = {}
         for part in part_list:
             self.set_layer_hash(part, LayerHash.load(part))
 

--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -107,6 +107,7 @@ class LayerStateManager:
     """An in-memory layer state management helper for action planning.
 
     :param part_list: The list of parts in the project.
+    :param base_layer_hash: The verification hash of the overlay base layer.
     """
 
     def __init__(self, part_list: List[Part], base_layer_hash: Optional[LayerHash]):

--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -18,7 +18,7 @@
 
 import hashlib
 import logging
-from typing import Optional
+from typing import Dict, List, Optional
 
 from craft_parts.parts import Part
 
@@ -35,6 +35,9 @@ class LayerHash:
         return self.hex()
 
     def __eq__(self, other):
+        if not isinstance(other, LayerHash):
+            return False
+
         return self.digest == other.digest
 
     @classmethod
@@ -98,3 +101,51 @@ class LayerHash:
     def hex(self) -> str:
         """Return the current hash value as a hexadecimal string."""
         return self.digest.hex()
+
+
+class LayerStateManager:
+    """An in-memory layer state management helper for action planning.
+
+    :param part_list: The list of parts in the project.
+    """
+
+    def __init__(self, part_list: List[Part], base_layer_hash: Optional[LayerHash]):
+        self._part_list = part_list
+        self._base_layer_hash = base_layer_hash
+
+        self._layer_hash: Dict[str, Optional[LayerHash]] = dict()
+        for part in part_list:
+            self.set_layer_hash(part, LayerHash.load(part))
+
+    def get_layer_hash(self, part: Part) -> Optional[LayerHash]:
+        """Obtain the layer hash for the given part."""
+        return self._layer_hash.get(part.name)
+
+    def set_layer_hash(self, part: Part, layer_hash: Optional[LayerHash]) -> None:
+        """Store the value of the layer hash for the given part."""
+        self._layer_hash[part.name] = layer_hash
+
+    def compute_layer_hash(self, part: Part) -> LayerHash:
+        """Calculate the layer validation hash for the given part.
+
+        :param part: The part being processed.
+
+        :return: The validation hash of the layer corresponding to the
+            given part.
+        """
+        index = self._part_list.index(part)
+
+        if index > 0:
+            previous_layer_hash = self.get_layer_hash(self._part_list[index - 1])
+        else:
+            previous_layer_hash = self._base_layer_hash
+
+        return LayerHash.for_part(part, previous_layer_hash=previous_layer_hash)
+
+    def get_overlay_hash(self) -> bytes:
+        """Obtain the overlay validation hash."""
+        last_part = self._part_list[-1]
+        overlay_hash = self.get_layer_hash(last_part)
+        if not overlay_hash:
+            return b""
+        return overlay_hash.digest

--- a/tests/unit/overlays/test_layers.py
+++ b/tests/unit/overlays/test_layers.py
@@ -107,16 +107,18 @@ class TestLayerStateManager:
         base_layer_hash = LayerHash(b"base hash value")
 
         Path("parts/p1/state").mkdir(parents=True)
-        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
-        lh.save(p1)
+        layer_hash = LayerHash(
+            bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f")
+        )
+        layer_hash.save(p1)
 
         lsm = LayerStateManager([p1, p2], base_layer_hash)
-        p1_lh = lsm.get_layer_hash(p1)
-        assert p1_lh is not None
-        assert p1_lh.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
+        p1_layer_hash = lsm.get_layer_hash(p1)
+        assert p1_layer_hash is not None
+        assert p1_layer_hash.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
 
-        p2_lh = lsm.get_layer_hash(p2)
-        assert p2_lh is None
+        p2_layer_hash = lsm.get_layer_hash(p2)
+        assert p2_layer_hash is None
 
     def test_set_layer_hash(self):
         p1 = Part("p1", {})
@@ -125,12 +127,14 @@ class TestLayerStateManager:
         lsm = LayerStateManager([p1], base_layer_hash)
         assert lsm.get_layer_hash(p1) is None
 
-        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
-        lsm.set_layer_hash(p1, lh)
+        layer_hash = LayerHash(
+            bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f")
+        )
+        lsm.set_layer_hash(p1, layer_hash)
 
-        p1_lh = lsm.get_layer_hash(p1)
-        assert p1_lh is not None
-        assert p1_lh.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
+        p1_layer_hash = lsm.get_layer_hash(p1)
+        assert p1_layer_hash is not None
+        assert p1_layer_hash.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
 
     @pytest.mark.parametrize(
         "params,digest",
@@ -169,37 +173,45 @@ class TestLayerStateManager:
         p2 = Part("p2", {})
         base_layer_hash = LayerHash(b"base hash value")
 
-        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
+        layer_hash = LayerHash(
+            bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f")
+        )
 
         lsm = LayerStateManager([p1, p2], base_layer_hash)
-        lsm.set_layer_hash(p1, lh)
+        lsm.set_layer_hash(p1, layer_hash)
 
-        p2_lh = lsm.compute_layer_hash(p2)
-        assert p2_lh.hex() == "c6e659c5a430c093a120bb17868ade39e91e00b8"
+        p2_layer_hash = lsm.compute_layer_hash(p2)
+        assert p2_layer_hash.hex() == "c6e659c5a430c093a120bb17868ade39e91e00b8"
 
     def test_compute_layer_hash_multiple_parts_new_base(self):
         p1 = Part("p1", {})
         p2 = Part("p2", {})
         base_layer_hash = LayerHash(b"other base hash value")
 
-        lh = LayerHash(bytes.fromhex("a15e326327c3456bc5547a69fe2996bcf8088cba"))
+        layer_hash = LayerHash(
+            bytes.fromhex("a15e326327c3456bc5547a69fe2996bcf8088cba")
+        )
 
         lsm = LayerStateManager([p1, p2], base_layer_hash)
-        lsm.set_layer_hash(p1, lh)
+        lsm.set_layer_hash(p1, layer_hash)
 
-        p2_lh = lsm.compute_layer_hash(p2)
-        assert p2_lh.hex() == "c522dd71ef33a7eee9b8122ff8f4482152a99a12"
+        p2_layer_hash = lsm.compute_layer_hash(p2)
+        assert p2_layer_hash.hex() == "c522dd71ef33a7eee9b8122ff8f4482152a99a12"
 
     def test_get_overlay_hash(self):
         p1 = Part("p1", {})
         p2 = Part("p2", {})
         base_layer_hash = LayerHash(b"base hash value")
 
-        p1_lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
-        p2_lh = LayerHash(bytes.fromhex("c6e659c5a430c093a120bb17868ade39e91e00b8"))
+        p1_layer_hash = LayerHash(
+            bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f")
+        )
+        p2_layer_hash = LayerHash(
+            bytes.fromhex("c6e659c5a430c093a120bb17868ade39e91e00b8")
+        )
 
         lsm = LayerStateManager([p1, p2], base_layer_hash)
-        lsm.set_layer_hash(p1, p1_lh)
-        lsm.set_layer_hash(p2, p2_lh)
+        lsm.set_layer_hash(p1, p1_layer_hash)
+        lsm.set_layer_hash(p2, p2_layer_hash)
 
-        assert lsm.get_overlay_hash() == p2_lh.digest
+        assert lsm.get_overlay_hash() == p2_layer_hash.digest

--- a/tests/unit/overlays/test_layers.py
+++ b/tests/unit/overlays/test_layers.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from craft_parts.overlays.layers import LayerHash
+from craft_parts.overlays.layers import LayerHash, LayerStateManager
 from craft_parts.parts import Part
 
 
@@ -95,3 +95,111 @@ class TestLayerHash:
         h = LayerHash(b"some value")
         h.save(part=p1)
         assert Path("parts/p1/state/layer_hash").read_text() == "736f6d652076616c7565"
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestLayerStateManager:
+    """Verify in-memory layer state management operations."""
+
+    def test_get_layer_hash(self):
+        p1 = Part("p1", {})
+        p2 = Part("p2", {})
+        base_layer_hash = LayerHash(b"base hash value")
+
+        Path("parts/p1/state").mkdir(parents=True)
+        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
+        lh.save(p1)
+
+        lsm = LayerStateManager([p1, p2], base_layer_hash)
+        p1_lh = lsm.get_layer_hash(p1)
+        assert p1_lh is not None
+        assert p1_lh.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
+
+        p2_lh = lsm.get_layer_hash(p2)
+        assert p2_lh is None
+
+    def test_set_layer_hash(self):
+        p1 = Part("p1", {})
+        base_layer_hash = LayerHash(b"base hash value")
+
+        lsm = LayerStateManager([p1], base_layer_hash)
+        assert lsm.get_layer_hash(p1) is None
+
+        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
+        lsm.set_layer_hash(p1, lh)
+
+        p1_lh = lsm.get_layer_hash(p1)
+        assert p1_lh is not None
+        assert p1_lh.hex() == "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"
+
+    @pytest.mark.parametrize(
+        "params,digest",
+        [
+            ({}, "a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"),
+            ({"overlay-script": "true"}, "fa8a0be828daebe4fd503d14fa9d6307ae0b01ae"),
+            ({"overlay-packages": ["pkg"]}, "1d1f4f14a6809e389bdb6c6d0fb58fa5491c7981"),
+            ({"overlay": ["/etc"]}, "b4d14ee52c4ba9c5d5c7610c5e2bce06f2f34b2b"),
+        ],
+    )
+    def test_compute_layer_hash(self, params, digest):
+        p1 = Part("p1", params)
+        base_layer_hash = LayerHash(b"base hash value")
+
+        lsm = LayerStateManager([p1], base_layer_hash)
+        assert lsm.compute_layer_hash(p1).hex() == digest
+
+    @pytest.mark.parametrize(
+        "params,digest",
+        [
+            ({}, "a15e326327c3456bc5547a69fe2996bcf8088cba"),
+            ({"overlay-script": "true"}, "a992882dc823bde22d93b0fe4ea6282926b5cfa9"),
+            ({"overlay-packages": ["pkg"]}, "c890ac631a1cde929edefb1b27b10d9ba848d548"),
+            ({"overlay": ["/etc"]}, "c1b0caeabdfc607110dbcbb1c58a320127b61622"),
+        ],
+    )
+    def test_compute_layer_hash_new_base(self, params, digest):
+        p1 = Part("p1", params)
+        base_layer_hash = LayerHash(b"other base hash value")
+
+        lsm = LayerStateManager([p1], base_layer_hash)
+        assert lsm.compute_layer_hash(p1).hex() == digest
+
+    def test_compute_layer_hash_multiple_parts(self):
+        p1 = Part("p1", {})
+        p2 = Part("p2", {})
+        base_layer_hash = LayerHash(b"base hash value")
+
+        lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
+
+        lsm = LayerStateManager([p1, p2], base_layer_hash)
+        lsm.set_layer_hash(p1, lh)
+
+        p2_lh = lsm.compute_layer_hash(p2)
+        assert p2_lh.hex() == "c6e659c5a430c093a120bb17868ade39e91e00b8"
+
+    def test_compute_layer_hash_multiple_parts_new_base(self):
+        p1 = Part("p1", {})
+        p2 = Part("p2", {})
+        base_layer_hash = LayerHash(b"other base hash value")
+
+        lh = LayerHash(bytes.fromhex("a15e326327c3456bc5547a69fe2996bcf8088cba"))
+
+        lsm = LayerStateManager([p1, p2], base_layer_hash)
+        lsm.set_layer_hash(p1, lh)
+
+        p2_lh = lsm.compute_layer_hash(p2)
+        assert p2_lh.hex() == "c522dd71ef33a7eee9b8122ff8f4482152a99a12"
+
+    def test_get_overlay_hash(self):
+        p1 = Part("p1", {})
+        p2 = Part("p2", {})
+        base_layer_hash = LayerHash(b"base hash value")
+
+        p1_lh = LayerHash(bytes.fromhex("a42a1d8ac7fdcfc4752e28aba0b0ee905e7cf96f"))
+        p2_lh = LayerHash(bytes.fromhex("c6e659c5a430c093a120bb17868ade39e91e00b8"))
+
+        lsm = LayerStateManager([p1, p2], base_layer_hash)
+        lsm.set_layer_hash(p1, p1_lh)
+        lsm.set_layer_hash(p2, p2_lh)
+
+        assert lsm.get_overlay_hash() == p2_lh.digest


### PR DESCRIPTION
The sequencer must keep track of layer state and changes in order to
emit actions related to the overlay step (such as layer reapplications
or re-execution of steps invalidated by changes in layers). Add a
layer state management helper to be used during the planning phase
to store the layer hash corresponding to each part and compute the
expected values to ensure overlay consistency.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
