### PR TITLE
packages: add package download helper (CRAFT-511)

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -171,7 +171,7 @@ class Executor:
         if self._extra_build_packages:
             build_packages.update(self._extra_build_packages)
 
-        packages.Repository.install_build_packages(sorted(build_packages))
+        packages.Repository.install_packages(sorted(build_packages))
 
     def _install_build_snaps(self) -> None:
         build_snaps = set()

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -144,7 +144,7 @@ class LifecycleManager:
         """
         self._executor.clean(initial_step=step, part_names=part_names)
 
-    def refresh_packages_list(self) -> None:
+    def refresh_packages_list(self) -> None:  # pylint: disable=no-self-use
         """Update the available packages list.
 
         The list of available packages should be updated before planning the

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -67,11 +67,19 @@ class BaseRepository(abc.ABC):
         should be raised.
         """
 
+    @classmethod
+    @abc.abstractmethod
+    def download_packages(cls, package_names: List[str]) -> None:
+        """Download the specified packages to the local package cache.
+
+        :param package_names: A list with the names of the packages to download.
+        """
+
     # XXX: list-only functionality can be a method called by install_build_packages
 
     @classmethod
     @abc.abstractmethod
-    def install_build_packages(
+    def install_packages(
         cls, package_names: List[str], list_only: bool = False
     ) -> List[str]:
         """Install packages on the host system.
@@ -174,7 +182,11 @@ class DummyRepository(BaseRepository):
         """Refresh the build packages cache."""
 
     @classmethod
-    def install_build_packages(
+    def download_packages(cls, package_names: List[str]) -> None:
+        """Download the specified packages to the local package cache."""
+
+    @classmethod
+    def install_packages(
         cls, package_names: List[str], list_only: bool = False
     ) -> List[str]:
         """Install packages on the host system."""

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -136,6 +136,22 @@ class BuildPackagesNotInstalled(PackagesError):
         super().__init__(brief=brief)
 
 
+class PackagesDownloadError(PackagesError):
+    """Failed to download packages from remote repository.
+
+    :param packages: The packages to download.
+    """
+
+    def __init__(self, *, packages: Sequence[str]) -> None:
+        self.packages = packages
+        brief = f"Failed to download all requested packages: {', '.join(packages)}"
+        resolution = (
+            "Make sure the network configuration and package names are correct."
+        )
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
 class UnpackError(PackagesError):
     """Error unpacking stage package.
 

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -96,19 +96,19 @@ def test_application_plugin_happy(caplog, new_dir, mocker):
         Action("foo", Step.BUILD, action_type=ActionType.RUN),
     ]
 
-    mock_install_build_packages = mocker.patch(
-        "craft_parts.packages.Repository.install_build_packages"
+    mock_install_packages = mocker.patch(
+        "craft_parts.packages.Repository.install_packages"
     )
 
-    mock_install_build_snaps = mocker.patch("craft_parts.packages.snaps.install_snaps")
+    mock_install_snaps = mocker.patch("craft_parts.packages.snaps.install_snaps")
 
     with lf.action_executor() as exe, caplog.at_level(logging.DEBUG):
         exe.execute(actions[1])
 
     assert "hello application plugin" in caplog.text
 
-    mock_install_build_packages.assert_called_once_with(["build_package"])
-    mock_install_build_snaps.assert_called_once_with({"build_snap"})
+    mock_install_packages.assert_called_once_with(["build_package"])
+    mock_install_snaps.assert_called_once_with({"build_snap"})
 
     # make sure parts data was not changed
     assert parts == old_parts

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -81,8 +81,8 @@ class TestExecutor:
 class TestPackages:
     """Verify package installation during the execution phase."""
 
-    def test_install_build_packages(self, mocker, new_dir):
-        install = mocker.patch("craft_parts.packages.Repository.install_build_packages")
+    def test_install_packages(self, mocker, new_dir):
+        install = mocker.patch("craft_parts.packages.Repository.install_packages")
 
         p1 = Part("foo", {"plugin": "nil", "build-packages": ["pkg1"]})
         p2 = Part("bar", {"plugin": "nil", "build-packages": ["pkg2"]})
@@ -94,7 +94,7 @@ class TestPackages:
         install.assert_called_once_with(["pkg1", "pkg2"])
 
     def test_install_extra_build_packages(self, mocker, new_dir):
-        install = mocker.patch("craft_parts.packages.Repository.install_build_packages")
+        install = mocker.patch("craft_parts.packages.Repository.install_packages")
 
         p1 = Part("foo", {"plugin": "nil", "build-packages": ["pkg1"]})
         p2 = Part("bar", {"plugin": "nil", "build-packages": ["pkg2"]})

--- a/tests/unit/packages/test_base.py
+++ b/tests/unit/packages/test_base.py
@@ -28,7 +28,8 @@ class TestBaseRepository:
             "get_package_libraries",
             "is_package_installed",
             "get_packages_for_source_type",
-            "install_build_packages",
+            "download_packages",
+            "install_packages",
             "fetch_stage_packages",
             "refresh_build_packages_list",
             "unpack_stage_packages",
@@ -44,7 +45,7 @@ class TestDummyRepository:
     def test_methods(self):
         assert DummyRepository.get_package_libraries("foo") == set()
         assert DummyRepository.get_packages_for_source_type("bar") == set()
-        assert DummyRepository.install_build_packages([]) == []
+        assert DummyRepository.install_packages([]) == []
         assert DummyRepository.is_package_installed("baz") is False
         assert DummyRepository.get_installed_packages() == []
         assert DummyRepository.fetch_stage_packages() == []

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -207,6 +207,34 @@ class TestPackages:
 
         mock_normalize.assert_not_called()
 
+    def test_download_packages(self, fake_apt_cache, fake_run):
+        deb.Ubuntu.refresh_build_packages_list()
+        deb.Ubuntu.download_packages(["package", "versioned-package=2.0"])
+
+        fake_run.assert_has_calls(
+            [
+                call(["apt-get", "update"]),
+                call(
+                    [
+                        "apt-get",
+                        "--no-install-recommends",
+                        "-y",
+                        "-oDpkg::Use-Pty=0",
+                        "--allow-downgrades",
+                        "--download-only",
+                        "install",
+                        "package",
+                        "versioned-package=2.0",
+                    ],
+                    env={
+                        "DEBIAN_FRONTEND": "noninteractive",
+                        "DEBCONF_NONINTERACTIVE_SEEN": "true",
+                        "DEBIAN_PRIORITY": "critical",
+                    },
+                ),
+            ]
+        )
+
 
 class TestBuildPackages:
     def test_install_build_packages(self, fake_apt_cache, fake_run):

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -86,6 +86,16 @@ def test_build_packages_not_installed():
     assert err.resolution is None
 
 
+def test_packages_download_error():
+    err = errors.PackagesDownloadError(packages=["foo", "bar"])
+    assert err.packages == ["foo", "bar"]
+    assert err.brief == "Failed to download all requested packages: foo, bar"
+    assert err.details is None
+    assert err.resolution == (
+        "Make sure the network configuration and package names are correct."
+    )
+
+
 def test_unpack_error():
     err = errors.UnpackError("foobar")
     assert err.package == "foobar"


### PR DESCRIPTION
Add a helper to download packages from a repository to a cache area
so that they can be installed later on the overlay step chroot.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
