### PR TITLE
main: add details to the parts specification error message (CRAFT-512)

### DIFF
--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -58,8 +58,8 @@ def main():
             msg = f"{err.filename}: {msg}"
         print(f"Error: {msg}.", file=sys.stderr)
         sys.exit(1)
-    except craft_parts.errors.PartSpecificationError:
-        print("Error: invalid parts specification.", file=sys.stderr)
+    except craft_parts.errors.PartSpecificationError as err:
+        print(f"Error: invalid parts specification: {err}", file=sys.stderr)
         sys.exit(2)
     except craft_parts.errors.PartsError as err:
         print(f"Error: {err}", file=sys.stderr)


### PR DESCRIPTION
The parts specification error when running craft-parts from the CLI
tool entry point lacks information, add details on what cause the
reported error.

With this fix, parts errors will look like:
```
$  python -mcraft_parts
Error: invalid parts specification: Part 'p1' validation failed.                                                                                                                                
'source' is required by the dump plugin                                                         
Review part 'p1' and make sure it's correct.
```

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
