### PR TITLE
main: rename debug option to trace for consistency (CRAFT-513)

### DIFF
--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -43,7 +43,7 @@ def main():
         print(f"craft-parts {craft_parts.__version__}")
         sys.exit()
 
-    if options.debug:
+    if options.trace:
         log_level = logging.DEBUG
     else:
         log_level = logging.INFO
@@ -239,7 +239,7 @@ def _parse_arguments() -> argparse.Namespace:
         help="Set an alternate cache directory location.",
     )
     parser.add_argument(
-        "--debug",
+        "--trace",
         action="store_true",
         help="Enable debug messages.",
     )


### PR DESCRIPTION
Future craft tools will adopt `--trace` as the standard CLI option to
display debug messages, and Snapcraft uses `--debug` for a different
purpose. Rename the craft-parts CLI option to be consistent with tools.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
