### PR TITLE
sources: fix removed file updates (CRAFT-532)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -346,6 +346,7 @@ class PartHandler:
         state_file = states.get_step_state_path(self._part, step_info.step)
         self._source_handler.check_if_outdated(str(state_file))
         self._source_handler.update()
+        self._source_handler.source_cleanup()
 
     def _update_build(self, step_info: StepInfo) -> None:
         """Handle update action for the build step.

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -138,7 +138,7 @@ class Sequencer:
 
         # 3. If the step is outdated, run it again (without cleaning if possible).
         #    A step is considered outdated if an earlier step in the lifecycle
-        #    has been re-executed.
+        #    has been re-executed, or if the source code changed on disk.
 
         outdated_report = self._sm.check_if_outdated(part, current_step)
         if outdated_report:

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -57,6 +57,7 @@ class SourceHandler(abc.ABC):
         command: Optional[str] = None,
         project_dirs: Optional[ProjectDirs] = None,
         ignore_patterns: Optional[List[str]] = None,
+        part_build_dir: Optional[Path] = None,
     ):
         if not project_dirs:
             project_dirs = ProjectDirs()
@@ -66,6 +67,7 @@ class SourceHandler(abc.ABC):
 
         self.source = str(source)
         self.part_src_dir = str(part_src_dir)
+        self.part_build_dir = part_build_dir
         self._cache_dir = cache_dir
         self.source_tag = source_tag
         self.source_commit = source_commit
@@ -106,6 +108,13 @@ class SourceHandler(abc.ABC):
         """
         raise errors.SourceUpdateUnsupported(self.__class__.__name__)
 
+    def source_cleanup(self):
+        """Remove pulled entries not present in the actual part source.
+
+        :raise errors.SourceUpdateUnsupported: If the source can't update its files.
+        """
+        raise errors.SourceUpdateUnsupported(self.__class__.__name__)
+
     @classmethod
     def _run_output(cls, command: List[str]) -> str:
         try:
@@ -132,6 +141,7 @@ class FileSourceHandler(SourceHandler):
         command: Optional[str] = None,
         project_dirs: Optional[ProjectDirs] = None,
         ignore_patterns: Optional[List[str]] = None,
+        part_build_dir: Optional[Path] = None,
     ):
         super().__init__(
             source,
@@ -145,6 +155,7 @@ class FileSourceHandler(SourceHandler):
             command=command,
             project_dirs=project_dirs,
             ignore_patterns=ignore_patterns,
+            part_build_dir=part_build_dir,
         )
         self._file = Path()
 

--- a/craft_parts/sources/snap_source.py
+++ b/craft_parts/sources/snap_source.py
@@ -51,6 +51,7 @@ class SnapSource(FileSourceHandler):
         source_depth: Optional[int] = None,
         source_checksum: str = None,
         project_dirs: ProjectDirs = None,
+        part_build_dir: Optional[Path] = None
     ) -> None:
         super().__init__(
             source,
@@ -62,6 +63,7 @@ class SnapSource(FileSourceHandler):
             source_depth=source_depth,
             source_checksum=source_checksum,
             project_dirs=project_dirs,
+            part_build_dir=part_build_dir,
             command="unsquashfs",
         )
 

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -119,6 +119,7 @@ def get_source_handler(
             cache_dir=cache_dir,
             source=part.spec.source,
             part_src_dir=part.part_src_dir,
+            part_build_dir=part.part_build_dir,
             source_checksum=part.spec.source_checksum,
             source_branch=part.spec.source_branch,
             source_tag=part.spec.source_tag,

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -47,6 +47,7 @@ class TarSource(FileSourceHandler):
         source_checksum: Optional[str] = None,
         project_dirs: Optional[ProjectDirs] = None,
         ignore_patterns: Optional[List[str]] = None,
+        part_build_dir: Optional[Path] = None,
     ):
         super().__init__(
             source,
@@ -59,6 +60,7 @@ class TarSource(FileSourceHandler):
             source_checksum=source_checksum,
             project_dirs=project_dirs,
             ignore_patterns=ignore_patterns,
+            part_build_dir=part_build_dir,
         )
         if source_tag:
             raise errors.InvalidSourceOption(source_type="tar", option="source-tag")

--- a/tests/integration/sources/test_local.py
+++ b/tests/integration/sources/test_local.py
@@ -1,0 +1,147 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Action, Step
+from craft_parts.sources import errors
+
+
+def test_source_local_simple(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: dump
+            source: dir1
+        """
+    )
+
+    Path("dir1").mkdir()
+    Path("dir1/foobar.txt").write_text("content")
+
+    parts = yaml.safe_load(_parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_local", cache_dir=new_dir
+    )
+
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    foo_src_dir = Path("parts", "foo", "src")
+    assert list(foo_src_dir.rglob("*")) == [foo_src_dir / "foobar.txt"]
+    assert Path(foo_src_dir, "foobar.txt").read_text() == "content"
+
+
+def test_source_local_missing(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: make
+            source: not_here
+        """
+    )
+
+    parts = yaml.safe_load(_parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_local", cache_dir=new_dir
+    )
+
+    with pytest.raises(errors.InvalidSourceType) as raised, lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    assert raised.value.source == "not_here"
+
+
+def test_source_local_update(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: dump
+            source: dir1
+        """
+    )
+
+    Path("dir1").mkdir()
+    Path("dir1/foobar.txt").write_text("content")
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    # execute the lifecycle
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_local", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # add extra content to source dir
+    Path("dir1/new_file").write_text("new content")
+    Path("dir1/dir2").mkdir()
+    Path("dir1/dir2/another_new_file").write_text("more content")
+
+    # and add a build artifact to the part build dir
+    Path("parts/foo/build/build_artifact").write_text("created during build")
+
+    # execute the lifecycle
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_local", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # after updating the files should be in the part src and build dirs
+    assert Path("parts/foo/src/new_file").is_file()
+    assert Path("parts/foo/src/dir2/another_new_file").is_file()
+
+    assert Path("parts/foo/build/new_file").is_file()
+    assert Path("parts/foo/build/dir2/another_new_file").is_file()
+
+    # the build artifact must remain in the part build dir
+    assert Path("parts/foo/build/build_artifact").is_file()
+
+    # now remove the extra content from source dir
+    Path("dir1/new_file").unlink()
+    Path("dir1/dir2/another_new_file").unlink()
+    Path("dir1/dir2").rmdir()
+
+    # execute the lifecycle
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_local", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # the files should have been removed from the part src and build dirs
+    assert Path("parts/foo/src/new_file").is_file() is False
+    assert Path("parts/foo/src/dir2/another_new_file").is_file() is False
+    assert Path("parts/foo/src/dir2").is_dir() is False
+
+    assert Path("parts/foo/build/new_file").is_file() is False
+    assert Path("parts/foo/build/dir2/another_new_file").is_file() is False
+    assert Path("parts/foo/build/dir2").is_dir() is False
+
+    # we can't remove build artifacts
+    assert Path("parts/foo/build/build_artifact").is_file()

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -441,6 +441,9 @@ class TestLocalUpdate:
         assert local.check_if_outdated("reference")
 
         local.update()
+        assert destination_file.is_file()
+
+        local.source_cleanup()
         assert destination_file.is_file() is False
 
     def test_directory_removed(self, new_dir):
@@ -479,4 +482,7 @@ class TestLocalUpdate:
         assert local.check_if_outdated("reference")
 
         local.update()
+        assert destination_directory.is_dir()
+
+        local.source_cleanup()
         assert destination_directory.is_dir() is False


### PR DESCRIPTION
Source handlers are used to pull sources from the location specified
in the part definition into the part source work directory. They may
provide a method to update specific files that have been modified
without re-pulling the entire source tree.

Changes were introduced in 5d56713 to allow removal of pulled files
that have been deleted in the part source.

The local source handler, however, is not used only for the primary
source handler purpose, it's also used to migrate contents from the
source work directory to the build work directory, regardless of the
type of the part's source. (We should investigate how to refactor this
to use the migration mechanisms directly without reusing the source
handler.)

As a consequence of the way deleted file removal was implemented and
the reuse of the local source handler for build migration, artifacts
created during the build process were removed in a source update.
Deleted file updates should cover only files removed from the original
source without affecting build artifacts.

Refactor source handlers to preserve build artifacts by removing
only entries present in the source work directory that are not
in the original source from the build work directory. In the long
term part handling should be refactored to be decoupled from the
local source handler.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
