### PR TITLE
executor: add overlay step handling (CRAFT-86)

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -477,6 +477,21 @@ class StagePackageNotFound(PartsError):
         super().__init__(brief=brief)
 
 
+class OverlayPackageNotFound(PartsError):
+    """Failed to install an overlay package.
+
+    :param part_name: The name of the part being processed.
+    :param message: the error message.
+    """
+
+    def __init__(self, *, part_name: str, package_name: str):
+        self.part_name = part_name
+        self.package_name = package_name
+        brief = f"Overlay package not found in part {part_name!r}: {package_name}."
+
+        super().__init__(brief=brief)
+
+
 class InvalidAction(PartsError):
     """An attempt was made to execute an action with invalid parameters.
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -727,7 +727,7 @@ class PartHandler:
 def _remove(filename: Path) -> None:
     if filename.is_symlink() or filename.is_file():
         logger.debug("remove file %s", filename)
-        os.unlink(filename)
+        filename.unlink()
     elif filename.is_dir():
         logger.debug("remove directory %s", filename)
         shutil.rmtree(filename)
@@ -756,10 +756,7 @@ def _apply_file_filter(
                 # Don't descend into this directory-- we'll just delete it
                 # entirely.
                 directories.remove(directory)
-                if path.is_dir():
-                    shutil.rmtree(str(path))
-                else:
-                    path.unlink()
+                shutil.rmtree(str(path))
 
 
 def _get_build_packages(*, part: Part, plugin: Plugin) -> List[str]:

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -118,6 +118,12 @@ class PartHandler:
         callbacks.run_post_step(step_info)
 
     def _run_pull(self, step_info: StepInfo) -> StepState:
+        """Execute the pull step for this part.
+
+        :param step_info: Information about the step to execute.
+
+        :return: The pull step state.
+        """
         _remove(self._part.part_src_dir)
         self._make_dirs()
 
@@ -144,6 +150,12 @@ class PartHandler:
         return state
 
     def _run_overlay(self, step_info: StepInfo) -> StepState:
+        """Execute the overlay step for this part.
+
+        :param step_info: Information about the step to execute.
+
+        :return: The overlay step state.
+        """
         self._make_dirs()
 
         if self._part.has_overlay:
@@ -183,6 +195,12 @@ class PartHandler:
         )
 
     def _run_build(self, step_info: StepInfo, *, update=False) -> StepState:
+        """Execute the build step for this part.
+
+        :param step_info: Information about the step to execute.
+
+        :return: The build step state.
+        """
         self._make_dirs()
         _remove(self._part.part_build_dir)
         self._unpack_stage_packages()
@@ -247,6 +265,12 @@ class PartHandler:
         return state
 
     def _run_stage(self, step_info: StepInfo) -> StepState:
+        """Execute the stage step for this part.
+
+        :param step_info: Information about the step to execute.
+
+        :return: The stage step state.
+        """
         self._make_dirs()
 
         contents = self._run_step(
@@ -273,6 +297,12 @@ class PartHandler:
         return state
 
     def _run_prime(self, step_info: StepInfo) -> StepState:
+        """Execute the prime step for this part.
+
+        :param step_info: Information about the step to execute.
+
+        :return: The prime step state.
+        """
         self._make_dirs()
 
         contents = self._run_step(
@@ -644,6 +674,10 @@ class PartHandler:
         )
 
     def _fetch_stage_packages(self, *, step_info: StepInfo) -> Optional[List[str]]:
+        """Download stage packages to the part's package directory.
+
+        :raises StagePackageNotFound: If a package is not available for download.
+        """
         stage_packages = self._part.spec.stage_packages
         if not stage_packages:
             return None
@@ -664,6 +698,7 @@ class PartHandler:
         return fetched_packages
 
     def _fetch_stage_snaps(self):
+        """Download snap packages to the part's snap directory."""
         stage_snaps = self._part.spec.stage_snaps
         if not stage_snaps:
             return None
@@ -675,6 +710,10 @@ class PartHandler:
         return stage_snaps
 
     def _fetch_overlay_packages(self) -> None:
+        """Download overlay packages to the local package cache.
+
+        :raises OverlayPackageNotFound: If a package is not available for download.
+        """
         overlay_packages = self._part.spec.overlay_packages
         if not overlay_packages:
             return
@@ -688,12 +727,14 @@ class PartHandler:
             )
 
     def _unpack_stage_packages(self):
+        """Extract stage packages contents to the part's install directory."""
         packages.Repository.unpack_stage_packages(
             stage_packages_path=self._part.part_packages_dir,
             install_path=Path(self._part.part_install_dir),
         )
 
     def _unpack_stage_snaps(self):
+        """Extract stage snap contents to the part's install directory."""
         stage_snaps = self._part.spec.stage_snaps
         if not stage_snaps:
             return
@@ -715,6 +756,7 @@ class PartHandler:
             snap_source.provision(str(install_dir), clean_target=False, keep=True)
 
     def _overlay_state_file(self, step: Step) -> Path:
+        """Return the path to the overlay migration state file for the given step."""
         if step == Step.STAGE:
             return Path(self._part.overlay_dir / "stage_overlay")
 
@@ -725,6 +767,10 @@ class PartHandler:
 
 
 def _remove(filename: Path) -> None:
+    """Remove the given directory entry.
+
+    :param filename: The path to the file or directory to remove.
+    """
     if filename.is_symlink() or filename.is_file():
         logger.debug("remove file %s", filename)
         filename.unlink()
@@ -736,6 +782,14 @@ def _remove(filename: Path) -> None:
 def _apply_file_filter(
     *, filter_files: Set[str], filter_dirs: Set[str], destdir: Path
 ) -> None:
+    """Remove files and directories from the filesystem.
+
+    Files and directories that are not part of the given file and directory
+    sets will be removed from the filesystem.
+
+    :param filter_files: The set of files to keep.
+    :param filter_dirs: The set of directories to keep.
+    """
     for (root, directories, files) in os.walk(destdir, topdown=True):
         for file_name in files:
             path = Path(root, file_name)

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -755,16 +755,6 @@ class PartHandler:
         for snap_source in snap_sources:
             snap_source.provision(str(install_dir), clean_target=False, keep=True)
 
-    def _overlay_state_file(self, step: Step) -> Path:
-        """Return the path to the overlay migration state file for the given step."""
-        if step == Step.STAGE:
-            return Path(self._part.overlay_dir / "stage_overlay")
-
-        if step == Step.PRIME:
-            return Path(self._part.overlay_dir / "prime_overlay")
-
-        raise RuntimeError(f"no overlay migration state in step {step!r}")
-
 
 def _remove(filename: Path) -> None:
     """Remove the given directory entry.

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2021 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,21 +14,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""State definitions for the pull step."""
+"""State definitions for the overlay step."""
 
 from typing import Any, Dict
 
 from .step_state import StepState
 
 
-class PullState(StepState):
-    """Context information for the pull step."""
-
-    assets: Dict[str, Any] = {}
+class OverlayState(StepState):
+    """Context information for the overlay step."""
 
     @classmethod
-    def unmarshal(cls, data: Dict[str, Any]) -> "PullState":
-        """Create and populate a new ``PullState`` object from dictionary data.
+    def unmarshal(cls, data: Dict[str, Any]) -> "OverlayState":
+        """Create and populate a new ``OverlayState`` object from dictionary data.
 
         The unmarshal method validates entries in the input dictionary, populating
         the corresponding fields in the state object.
@@ -51,25 +49,11 @@ class PullState(StepState):
 
         :return: A dictionary containing properties of interest.
         """
-        relevant_properties = [
-            "plugin",
-            "source",
-            "source-commit",
-            "source-depth",
-            "source-tag",
-            "source-type",
-            "source-branch",
-            "source-subdir",
-            "override-pull",
-            "stage-packages",
-            "overlay-packages",
-        ]
-
-        properties: Dict[str, Any] = {}
-        for name in relevant_properties:
-            properties[name] = part_properties.get(name)
-
-        return properties
+        return {
+            "filesets": part_properties.get("filesets", {}) or {},
+            "overlay-script": part_properties.get("overlay-script"),
+            "overlay": part_properties.get("overlay", ["*"]) or ["*"],
+        }
 
     def project_options_of_interest(
         self, project_options: Dict[str, Any]

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -27,6 +27,7 @@ from craft_parts.parts import Part
 from craft_parts.steps import Step
 
 from .build_state import BuildState
+from .overlay_state import OverlayState  # noqa: F401, pylint: disable=W0611
 from .prime_state import PrimeState
 from .pull_state import PullState
 from .stage_state import StageState

--- a/tests/integration/sequencer/test_sequencer.py
+++ b/tests/integration/sequencer/test_sequencer.py
@@ -37,6 +37,7 @@ _pull_state_foo = textwrap.dedent(
       source-tag: ''
       source-commit: ''
       stage-packages: []
+      overlay-packages: []
     project_options:
       target_arch: amd64
     assets:
@@ -72,6 +73,7 @@ _pull_state_bar = textwrap.dedent(
       source-tag: ''
       source-commit: ''
       stage-packages: []
+      overlay-packages: []
     project_options:
       target_arch: amd64
     assets:

--- a/tests/unit/executor/test_migration.py
+++ b/tests/unit/executor/test_migration.py
@@ -24,6 +24,7 @@ from craft_parts.actions import Action
 from craft_parts.executor import filesets, migration, part_handler
 from craft_parts.executor.filesets import Fileset
 from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.overlays import OverlayManager
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
@@ -351,12 +352,21 @@ class TestHelpers:
         Path("subdir2/baz.txt").write_text("yet another content")
 
         info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1, p2], base_layer_dir=None
+        )
 
         handler1 = part_handler.PartHandler(
-            p1, part_info=PartInfo(info, part=p1), part_list=[p1, p2]
+            p1,
+            part_info=PartInfo(info, part=p1),
+            part_list=[p1, p2],
+            overlay_manager=ovmgr,
         )
         handler2 = part_handler.PartHandler(
-            p2, part_info=PartInfo(info, part=p2), part_list=[p1, p2]
+            p2,
+            part_info=PartInfo(info, part=p2),
+            part_list=[p1, p2],
+            overlay_manager=ovmgr,
         )
 
         for step in [Step.PULL, Step.BUILD, Step.STAGE]:
@@ -398,7 +408,10 @@ class TestHelpers:
         p1 = Part("p1", {"plugin": "dump", "source": "subdir"})
         info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(info, part=p1)
-        handler = part_handler.PartHandler(p1, part_info=part_info, part_list=[p1])
+        ovmgr = OverlayManager(project_info=info, part_list=[p1], base_layer_dir=None)
+        handler = part_handler.PartHandler(
+            p1, part_info=part_info, part_list=[p1], overlay_manager=ovmgr
+        )
 
         handler.run_action(Action("p1", Step.PULL))
         handler.run_action(Action("p1", Step.BUILD))
@@ -418,7 +431,10 @@ class TestHelpers:
         p1 = Part("p1", {"plugin": "dump", "source": "subdir"})
         info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(info, part=p1)
-        handler = part_handler.PartHandler(p1, part_info=part_info, part_list=[p1])
+        ovmgr = OverlayManager(project_info=info, part_list=[p1], base_layer_dir=None)
+        handler = part_handler.PartHandler(
+            p1, part_info=part_info, part_list=[p1], overlay_manager=ovmgr
+        )
 
         handler.run_action(Action("p1", Step.PULL))
         handler.run_action(Action("p1", Step.BUILD))

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -320,6 +320,15 @@ def test_stage_package_not_found():
     assert err.resolution is None
 
 
+def test_overlay_package_not_found():
+    err = errors.OverlayPackageNotFound(part_name="foo", package_name="figlet")
+    assert err.part_name == "foo"
+    assert err.package_name == "figlet"
+    assert err.brief == "Overlay package not found in part 'foo': figlet."
+    assert err.details is None
+    assert err.resolution is None
+
+
 def test_invalid_action():
     err = errors.InvalidAction("cannot update step 'stage'")
     assert err.message == "cannot update step 'stage'"


### PR DESCRIPTION
The overlay step execution handler mounts the overlay stack to install
packages and execute user scripts.  During the build step, parts with
overlay visibility should be able to see the overlay filesystem mounted.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
