### PR TITLE
many: add overlay step (CRAFT-84)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -102,6 +102,8 @@ class PartHandler:
 
         if action.step == Step.PULL:
             handler = self._run_pull
+        elif action.step == Step.OVERLAY:
+            handler = self._run_overlay
         elif action.step == Step.BUILD:
             handler = self._run_build
         elif action.step == Step.STAGE:
@@ -576,6 +578,8 @@ class PartHandler:
 
         if step == Step.PULL:
             handler = self._clean_pull
+        elif step == Step.OVERLAY:
+            handler = self._clean_overlay
         elif step == Step.BUILD:
             handler = self._clean_build
         elif step == Step.STAGE:

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -86,6 +86,8 @@ class StepHandler:
 
         if step == Step.PULL:
             handler = self._builtin_pull
+        elif step == Step.OVERLAY:
+            handler = self._builtin_overlay
         elif step == Step.BUILD:
             handler = self._builtin_build
         elif step == Step.STAGE:
@@ -102,6 +104,10 @@ class StepHandler:
     def _builtin_pull(self) -> StepContents:
         if self._source_handler:
             self._source_handler.pull()
+        return StepContents()
+
+    @staticmethod
+    def _builtin_overlay() -> StepContents:
         return StepContents()
 
     def _builtin_build(self) -> StepContents:

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -124,9 +124,9 @@ class LifecycleManager:
         # a base layer is mandatory if overlays are in use
         if self._has_overlay:
             if not base_layer_dir:
-                raise ValueError("using overlays and base_layer_dir not specified")
+                raise ValueError("base_layer_dir must be specified if using overlays")
             if not base_layer_hash:
-                raise ValueError("using overlays and base_layer hash not specified")
+                raise ValueError("base_layer_hash must be specified if using overlays")
         else:
             base_layer_dir = None
 

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -26,6 +26,7 @@ from craft_parts import errors, executor, packages, plugins, sequencer
 from craft_parts.actions import Action
 from craft_parts.dirs import ProjectDirs
 from craft_parts.infos import ProjectInfo
+from craft_parts.overlays import LayerHash
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
@@ -59,6 +60,10 @@ class LifecycleManager:
         by the package manager used by the platform. Defaults to the application name.
     :param ignore_local_sources: A list of local source patterns to ignore.
     :param extra_build_packages: A list of additional build packages to install.
+    :param base_layer_dir: The path to the overlay base layer, if using overlays.
+    :param base_layer_hash: The validation hash of the overlay base image, if using
+        overlays. The validation hash should be constant for a given image, and should
+        change if a different base image is used.
     :param custom_args: Any additional arguments that will be passed directly
         to :ref:`callbacks<callbacks>`.
     """
@@ -76,8 +81,12 @@ class LifecycleManager:
         application_package_name: Optional[str] = None,
         ignore_local_sources: Optional[List[str]] = None,
         extra_build_packages: Optional[List[str]] = None,
+        base_layer_dir: Optional[Path] = None,
+        base_layer_hash: Optional[bytes] = None,
         **custom_args,  # custom passthrough args
     ):
+        # pylint: disable=too-many-locals
+
         if not re.match("^[A-Za-z][0-9A-Za-z_]*$", application_name):
             raise errors.InvalidApplicationName(application_name)
 
@@ -110,6 +119,22 @@ class LifecycleManager:
         for name, spec in parts_data.items():
             part_list.append(_build_part(name, spec, project_dirs))
 
+        self._has_overlay = any(p.has_overlay for p in part_list)
+
+        # a base layer is mandatory if overlays are in use
+        if self._has_overlay:
+            if not base_layer_dir:
+                raise ValueError("using overlays and base_layer_dir not specified")
+            if not base_layer_hash:
+                raise ValueError("using overlays and base_layer hash not specified")
+        else:
+            base_layer_dir = None
+
+        if base_layer_hash:
+            layer_hash: Optional[LayerHash] = LayerHash(base_layer_hash)
+        else:
+            layer_hash = None
+
         self._part_list = part_list
         self._application_name = application_name
         self._target_arch = project_info.target_arch
@@ -117,14 +142,18 @@ class LifecycleManager:
             part_list=self._part_list,
             project_info=project_info,
             ignore_outdated=ignore_local_sources,
+            base_layer_hash=layer_hash,
         )
         self._executor = executor.Executor(
             part_list=self._part_list,
             project_info=project_info,
             ignore_patterns=ignore_local_sources,
             extra_build_packages=extra_build_packages,
+            base_layer_dir=base_layer_dir,
+            base_layer_hash=layer_hash,
         )
         self._project_info = project_info
+        # pylint: enable=too-many-locals
 
     @property
     def project_info(self) -> ProjectInfo:

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -81,6 +81,10 @@ def _process_parts(options: argparse.Namespace) -> None:
         cache_dir = BaseDirectory.save_cache_path("craft-parts")
 
     if options.overlay_base:
+        # The base layer hash algorithm is not specified and could be anything
+        # that remains constant for a given base. The CLI tool just uses the path
+        # to the base for simplicity, but applications can (and probably should)
+        # use a real digest.
         base_layer_hash = options.overlay_base.encode()
     else:
         base_layer_hash = b""

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -113,12 +113,18 @@ class PartSpec(BaseModel):
 
         :return: The scriptlet for the given step, if any.
         """
-        return {
-            Step.PULL: self.override_pull,
-            Step.BUILD: self.override_build,
-            Step.STAGE: self.override_stage,
-            Step.PRIME: self.override_prime,
-        }[step]
+        if step == Step.PULL:
+            return self.override_pull
+        if step == Step.OVERLAY:
+            return self.overlay_script
+        if step == Step.BUILD:
+            return self.override_build
+        if step == Step.STAGE:
+            return self.override_stage
+        if step == step.PRIME:
+            return self.override_prime
+
+        raise RuntimeError(f"cannot get scriptlet for invalid step {step!r}")
 
 
 class Part:

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -17,7 +17,7 @@
 """Determine the sequence of lifecycle actions to be executed."""
 
 import logging
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Set
 
 from craft_parts import parts, steps
 from craft_parts.actions import Action, ActionType
@@ -62,6 +62,13 @@ class Sequencer:
         self._layer_state = LayerStateManager(self._part_list, base_layer_hash)
         self._actions: List[Action] = []
 
+        self._overlay_viewers: Set[Part] = set()
+        for part in part_list:
+            if parts.has_overlay_visibility(
+                part, viewers=self._overlay_viewers, part_list=part_list
+            ):
+                self._overlay_viewers.add(part)
+
     def plan(self, target_step: Step, part_names: Sequence[str] = None) -> List[Action]:
         """Determine the list of steps to execute for each part.
 
@@ -87,6 +94,8 @@ class Sequencer:
         reason: Optional[str] = None,
     ) -> None:
         selected_parts = part_list_by_name(part_names, self._part_list)
+        if not selected_parts:
+            return
 
         for current_step in target_step.previous_steps() + [target_step]:
             for part in selected_parts:
@@ -132,9 +141,10 @@ class Sequencer:
         dirty_report = self._sm.check_if_dirty(part, current_step)
         if dirty_report:
             logger.debug("%s:%s is dirty", part.name, current_step)
-
             self._rerun_step(part, current_step, reason=dirty_report.reason())
             return
+
+        # TODO: 2.5 If the step depends on overlay, check if it must be reapplied.
 
         # 3. If the step is outdated, run it again (without cleaning if possible).
         #    A step is considered outdated if an earlier step in the lifecycle
@@ -144,7 +154,7 @@ class Sequencer:
         if outdated_report:
             logger.debug("%s:%s is outdated", part.name, current_step)
 
-            if current_step in (Step.PULL, Step.BUILD):
+            if current_step in (Step.PULL, Step.OVERLAY, Step.BUILD):
                 self._update_step(part, current_step, reason=outdated_report.reason())
             else:
                 self._rerun_step(part, current_step, reason=outdated_report.reason())
@@ -181,6 +191,29 @@ class Sequencer:
     ) -> None:
         self._process_dependencies(part, step)
 
+        if step == Step.OVERLAY:
+            # Make sure all previous layers are in place before we add a new
+            # layer to the overlay stack,
+            layer_hash = self._ensure_overlay_consistency(
+                part,
+                reason=f"required to overlay {part.name!r}",
+                skip_last=True,
+            )
+            self._layer_state.set_layer_hash(part, layer_hash)
+
+        elif (step == Step.BUILD and part in self._overlay_viewers) or (
+            step == Step.STAGE and part.has_overlay
+        ):
+            # The overlay step for all parts should run before we build a part
+            # with overlay visibility or before we stage a part that declares
+            # overlay parameters.
+            last_part = self._part_list[-1]
+            verb = _step_verb[step]
+            self._ensure_overlay_consistency(
+                last_part,
+                reason=f"required to {verb} {part.name!r}",
+            )
+
         if rerun:
             self._add_action(part, step, action_type=ActionType.RERUN, reason=reason)
         else:
@@ -189,8 +222,16 @@ class Sequencer:
         state: states.StepState
         part_properties = part.spec.marshal()
 
+        # create step state
+
         if step == Step.PULL:
             state = states.PullState(
+                part_properties=part_properties,
+                project_options=self._project_info.project_options,
+            )
+
+        elif step == Step.OVERLAY:
+            state = states.OverlayState(
                 part_properties=part_properties,
                 project_options=self._project_info.project_options,
             )
@@ -225,8 +266,10 @@ class Sequencer:
     ) -> None:
         logger.debug("rerun step %s:%s", part.name, step)
 
-        # clean the step and later steps for this part, then run it again
-        self._sm.clean_part(part, step)
+        if step != Step.OVERLAY:
+            # clean the step and later steps for this part
+            self._sm.clean_part(part, step)
+
         self._run_step(part, step, reason=reason, rerun=True)
 
     def _update_step(self, part: Part, step: Step, *, reason: Optional[str] = None):
@@ -247,9 +290,56 @@ class Sequencer:
             Action(part.name, step, action_type=action_type, reason=reason)
         )
 
+    def _ensure_overlay_consistency(
+        self, top_part: Part, reason: Optional[str] = None, skip_last: bool = False
+    ) -> LayerHash:
+        """Make sure overlay step layers are consistent.
+
+        The overlay step layers are stacked according to the part order. Each part
+        is given an identificaton value based on its overlay parameters and the value
+        of the previous layer in the stack, which is used to make sure the overlay
+        parameters for all previous layers remain the same. If any previous part
+        has not run, or had its parameters changed, it must run again to ensure
+        overlay consistency.
+
+        :param top_part: The part currently the top of the layer stack and whose
+            consistency is to be verified.
+        :param skip_last: Don't verify the consistency of the last (topmost) layer.
+            This is used during the overlay stack creation.
+
+        :return: This part's identification value.
+
+        :raise ValueError: If part is not in the project's parts list.
+        """
+        if top_part.name not in [p.name for p in self._part_list]:
+            raise ValueError(f"part {top_part!r} not in parts list")
+
+        for part in self._part_list:
+            layer_hash = self._layer_state.compute_layer_hash(part)
+
+            if skip_last and part.name == top_part.name:
+                return layer_hash
+
+            state_layer_hash = self._layer_state.get_layer_hash(part)
+
+            if layer_hash != state_layer_hash:
+                self._add_all_actions(
+                    target_step=Step.OVERLAY,
+                    part_names=[part.name],
+                    reason=reason,
+                )
+                self._layer_state.set_layer_hash(part, layer_hash)
+
+            if part.name == top_part.name:
+                return layer_hash
+
+        # execution should never reach this line
+        raise RuntimeError(f"part {top_part!r} not in parts list")
+
 
 _step_verb: Dict[Step, str] = {
     Step.PULL: "pull",
+    Step.OVERLAY: "overlay",
     Step.BUILD: "build",
     Step.STAGE: "stage",
     Step.PRIME: "prime",

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -308,12 +308,7 @@ class Sequencer:
             This is used during the overlay stack creation.
 
         :return: This topmost layer's verification hash.
-
-        :raise ValueError: If part is not in the project's parts list.
         """
-        if top_part.name not in [p.name for p in self._part_list]:
-            raise ValueError(f"part {top_part!r} not in parts list")
-
         for part in self._part_list:
             layer_hash = self._layer_state.compute_layer_hash(part)
 

--- a/craft_parts/state_manager/states.py
+++ b/craft_parts/state_manager/states.py
@@ -58,6 +58,8 @@ def load_step_state(part: Part, step: Step) -> Optional[StepState]:
 
     if step == Step.PULL:
         state_class = PullState
+    elif step == Step.OVERLAY:
+        state_class = OverlayState
     elif step == Step.BUILD:
         state_class = BuildState
     elif step == Step.STAGE:

--- a/tests/integration/lifecycle/test_stage_snaps.py
+++ b/tests/integration/lifecycle/test_stage_snaps.py
@@ -47,6 +47,7 @@ def test_stage_snap(new_dir, fake_snap_command):
     actions = lf.plan(Step.BUILD)
     assert actions == [
         Action("foo", Step.PULL),
+        Action("foo", Step.OVERLAY),
         Action("foo", Step.BUILD),
     ]
 
@@ -59,7 +60,7 @@ def test_stage_snap(new_dir, fake_snap_command):
     assert len(snaps) == 1
     assert snaps[0].name == "basic.snap"
 
-    ctx.execute(actions[1])
+    ctx.execute(actions[2])
 
     foo_install_dir = Path(new_dir / "parts" / "foo" / "install")
     assert (foo_install_dir / "meta.basic" / "snap.yaml").is_file()
@@ -84,6 +85,7 @@ def test_stage_snap_download_error(new_dir, fake_snap_command):
     actions = lf.plan(Step.BUILD)
     assert actions == [
         Action("foo", Step.PULL),
+        Action("foo", Step.OVERLAY),
         Action("foo", Step.BUILD),
     ]
 
@@ -115,6 +117,7 @@ def test_stage_snap_unpack_error(new_dir, fake_snap_command):
     actions = lf.plan(Step.BUILD)
     assert actions == [
         Action("foo", Step.PULL),
+        Action("foo", Step.OVERLAY),
         Action("foo", Step.BUILD),
     ]
 
@@ -129,5 +132,5 @@ def test_stage_snap_unpack_error(new_dir, fake_snap_command):
     assert snaps[0].name == "bad-snap.snap"
 
     with pytest.raises(PullError) as raised:
-        ctx.execute(actions[1])
+        ctx.execute(actions[2])
     assert raised.value.exit_code == 1

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -93,6 +93,7 @@ def test_application_plugin_happy(caplog, new_dir, mocker):
     actions = lf.plan(Step.BUILD)
     assert actions == [
         Action("foo", Step.PULL, action_type=ActionType.RUN),
+        Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
         Action("foo", Step.BUILD, action_type=ActionType.RUN),
     ]
 
@@ -103,7 +104,7 @@ def test_application_plugin_happy(caplog, new_dir, mocker):
     mock_install_snaps = mocker.patch("craft_parts.packages.snaps.install_snaps")
 
     with lf.action_executor() as exe, caplog.at_level(logging.DEBUG):
-        exe.execute(actions[1])
+        exe.execute(actions[2])
 
     assert "hello application plugin" in caplog.text
 

--- a/tests/integration/sequencer/test_sequencer.py
+++ b/tests/integration/sequencer/test_sequencer.py
@@ -109,6 +109,8 @@ class TestSequencerPlan:
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.RUN),
             Action("foo", Step.PULL, action_type=ActionType.RUN),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
+            Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("foo", Step.BUILD, action_type=ActionType.RUN),
             Action("bar", Step.STAGE, action_type=ActionType.RUN),
@@ -132,8 +134,11 @@ class TestSequencerPlan:
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.RUN),
             Action("foo", Step.PULL, action_type=ActionType.RUN),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
+            Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+            Action("bar", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
             Action("bar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
             Action("bar", Step.STAGE, action_type=ActionType.RUN, reason="required to build 'foo'"),
             Action("foo", Step.BUILD, action_type=ActionType.RUN),
@@ -156,6 +161,7 @@ class TestSequencerPlan:
         actions = seq.plan(Step.PRIME, part_names=["bar"])
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.RUN),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("bar", Step.STAGE, action_type=ActionType.RUN),
             Action("bar", Step.PRIME, action_type=ActionType.RUN),
@@ -221,11 +227,13 @@ class TestSequencerPlan:
                 action_type=ActionType.SKIP,
                 reason="already ran",
             ),
+            Action(part_name="foo", step=Step.OVERLAY),
             Action(
                 part_name="foo",
                 step=Step.BUILD,
                 action_type=ActionType.UPDATE,
-                reason="'PULL' step changed",
+                # XXX: this should be PULL after outdated check for overlay is in place
+                reason="'OVERLAY' step changed",
             ),
         ]
 
@@ -247,6 +255,8 @@ class TestSequencerStates:
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
             Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
+            Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("foo", Step.BUILD, action_type=ActionType.RUN),
         ]
@@ -267,6 +277,8 @@ class TestSequencerStates:
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
             Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
+            Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("foo", Step.BUILD, action_type=ActionType.RUN),
         ]
@@ -277,6 +289,8 @@ class TestSequencerStates:
         assert actions == [
             Action("bar", Step.PULL, action_type=ActionType.RUN),
             Action("foo", Step.PULL, action_type=ActionType.RUN),
+            Action("bar", Step.OVERLAY, action_type=ActionType.RUN),
+            Action("foo", Step.OVERLAY, action_type=ActionType.RUN),
             Action("bar", Step.BUILD, action_type=ActionType.RUN),
             Action("foo", Step.BUILD, action_type=ActionType.RUN),
         ]

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -38,33 +38,36 @@ parts_yaml = textwrap.dedent(
 
 plan_steps = [
     "Pull foo\nPull bar\n",
+    "Overlay foo\nOverlay bar\n",
     "Build foo\nStage foo (required to build 'bar')\nBuild bar\n",
     "Stage bar\n",
     "Prime foo\nPrime bar\n",
 ]
 
-plan_result = ["".join(plan_steps[0:n]) for n in range(1, 5)]
+plan_result = ["".join(plan_steps[0:n]) for n in range(1, len(plan_steps) + 1)]
 
 
 # pylint: disable=line-too-long
 
 execute_steps = [
     "Execute: Pull foo\nExecute: Pull bar\n",
+    "Execute: Overlay foo\nExecute: Overlay bar\n",
     "Execute: Build foo\nExecute: Stage foo (required to build 'bar')\nExecute: Build bar\n",
     "Execute: Stage bar\n",
     "Execute: Prime foo\nExecute: Prime bar\n",
 ]
 
-execute_result = ["".join(execute_steps[0:n]) for n in range(1, 5)]
+execute_result = ["".join(execute_steps[0:n]) for n in range(1, len(execute_steps) + 1)]
 
 skip_steps = [
     "Skip pull foo (already ran)\nSkip pull bar (already ran)\n",
+    "Skip overlay foo (already ran)\nSkip overlay bar (already ran)\n",
     "Skip build foo (already ran)\nSkip build bar (already ran)\n",
     "Skip stage foo (already ran)\nSkip stage bar (already ran)\n",
     "Skip prime foo (already ran)\nSkip prime bar (already ran)\n",
 ]
 
-skip_result = ["".join(skip_steps[0:n]) for n in range(1, 5)]
+skip_result = ["".join(skip_steps[0:n]) for n in range(1, len(skip_steps) + 1)]
 
 
 @pytest.fixture(autouse=True)
@@ -80,7 +83,7 @@ def test_main_no_args(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == execute_result[3]
+    assert out == execute_result[4]
     assert Path("parts").is_dir()
     assert Path("parts/foo").is_dir()
     assert Path("parts/bar").is_dir()
@@ -160,7 +163,7 @@ def test_main_dry_run(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == plan_result[3]
+    assert out == plan_result[4]
     assert Path("parts").is_dir() is False
     assert Path("stage").is_dir() is False
     assert Path("prime").is_dir() is False
@@ -221,7 +224,7 @@ def test_main_alternative_work_dir(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == execute_result[3]
+    assert out == execute_result[4]
 
     # work dirs are in the new location
     assert Path("work_dir/parts").is_dir()
@@ -243,7 +246,7 @@ def test_main_alternative_parts_file(mocker, capfd, opt):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == plan_result[3]
+    assert out == plan_result[4]
 
 
 def test_main_alternative_parts_invalid_file(mocker, capfd):
@@ -263,9 +266,10 @@ def test_main_alternative_parts_invalid_file(mocker, capfd):
     "step,result",
     [
         ("pull", execute_result[0]),
-        ("build", execute_result[1]),
-        ("stage", execute_result[2]),
-        ("prime", execute_result[3]),
+        ("overlay", execute_result[1]),
+        ("build", execute_result[2]),
+        ("stage", execute_result[3]),
+        ("prime", execute_result[4]),
     ],
 )
 def test_main_step(mocker, capfd, step, result):
@@ -284,9 +288,10 @@ def test_main_step(mocker, capfd, step, result):
     "step,result",
     [
         ("pull", plan_result[0]),
-        ("build", plan_result[1]),
-        ("stage", plan_result[2]),
-        ("prime", plan_result[3]),
+        ("overlay", plan_result[1]),
+        ("build", plan_result[2]),
+        ("stage", plan_result[3]),
+        ("prime", plan_result[4]),
     ],
 )
 def test_main_step_dry_run(mocker, capfd, step, result):
@@ -342,7 +347,7 @@ def test_main_step_dry_run_show_skip(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == skip_result[3]
+    assert out == skip_result[4]
 
 
 def test_main_step_specify_part(mocker, capfd):
@@ -353,9 +358,9 @@ def test_main_step_specify_part(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert (
-        out
-        == "Execute: Pull foo\nExecute: Build foo\nExecute: Stage foo\nExecute: Prime foo\n"
+    assert out == (
+        "Execute: Pull foo\nExecute: Overlay foo\nExecute: Build foo\n"
+        "Execute: Stage foo\nExecute: Prime foo\n"
     )
 
 
@@ -369,7 +374,7 @@ def test_main_step_specify_part_dry_run(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert err == ""
-    assert out == "Pull foo\nBuild foo\nStage foo\nPrime foo\n"
+    assert out == "Pull foo\nOverlay foo\nBuild foo\nStage foo\nPrime foo\n"
 
     assert Path("parts").is_dir() is False
 
@@ -378,12 +383,15 @@ def test_main_step_specify_part_dry_run(mocker, capfd):
     "step,result",
     [
         ("pull", plan_result[0]),
-        ("build", plan_result[1]),
+        ("overlay", plan_result[1]),
+        ("build", plan_result[2]),
         (
             "stage",
             (
                 "Pull foo\n"
                 "Pull bar\n"
+                "Overlay foo\n"
+                "Overlay bar\n"
                 "Build foo\n"
                 "Stage foo (required to build 'bar')\n"
                 "Build bar\n"
@@ -391,7 +399,7 @@ def test_main_step_specify_part_dry_run(mocker, capfd):
                 "Stage bar\n"
             ),
         ),
-        ("prime", plan_result[3]),
+        ("prime", plan_result[4]),
     ],
 )
 def test_main_step_specify_multiple_parts(mocker, capfd, step, result):

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -91,8 +91,7 @@ class TestPartHandling:
         mocker.patch("craft_parts.overlays.OverlayManager.download_packages")
         mocker.patch("craft_parts.overlays.OverlayManager.install_packages")
 
-        # TODO: replace with Step.OVERLAY after we implement it
-        state = self._handler._run_overlay(StepInfo(self._part_info, Step.PULL))
+        state = self._handler._run_overlay(StepInfo(self._part_info, Step.OVERLAY))
         assert state == states.OverlayState(
             part_properties=self._part.spec.marshal(),
             project_options=self._part_info.project_options,
@@ -212,6 +211,7 @@ class TestPartHandling:
         "step,scriptlet",
         [
             (Step.PULL, "override-pull"),
+            (Step.OVERLAY, "overlay-script"),
             (Step.BUILD, "override-build"),
             (Step.STAGE, "override-stage"),
             (Step.PRIME, "override-prime"),
@@ -350,6 +350,7 @@ class TestPartUpdateHandler:
     def test_update_build(self):
         self._handler._make_dirs()
         self._handler.run_action(Action("foo", Step.PULL))
+        self._handler.run_action(Action("foo", Step.OVERLAY))
         self._handler.run_action(Action("foo", Step.BUILD))
 
         source_file = Path("subdir/foo.txt")

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -81,6 +81,11 @@ class TestStepHandlerBuiltins:
         mock_source_pull.assert_called_once_with()
         assert result == StepContents()
 
+    def test_run_builtin_overlay(self, new_dir, mocker):
+        sh = _step_handler_for_step(Step.OVERLAY, cache_dir=new_dir)
+        result = sh.run_builtin()
+        assert result == StepContents()
+
     def test_run_builtin_build(self, new_dir, mocker):
         mock_run = mocker.patch("craft_parts.executor.step_handler.process_run")
 

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -107,6 +107,7 @@ class TestLifecycleManager:
             part_list=lf._part_list,
             project_info=lf.project_info,
             ignore_outdated=["foo.*"],
+            base_layer_hash=None,
         )
 
 

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -206,6 +206,7 @@ class TestPartData:
         "tc_step,tc_content",
         [
             (Step.PULL, "pull"),
+            (Step.OVERLAY, "overlay"),
             (Step.BUILD, "build"),
             (Step.STAGE, "stage"),
             (Step.PRIME, "prime"),
@@ -219,14 +220,12 @@ class TestPartData:
                 "override-build": "build",
                 "override-stage": "stage",
                 "override-prime": "prime",
+                "overlay-script": "overlay",
             },
         )
         assert p.spec.get_scriptlet(tc_step) == tc_content
 
-    @pytest.mark.parametrize(
-        "step",
-        [Step.PULL, Step.BUILD, Step.STAGE, Step.PRIME],
-    )
+    @pytest.mark.parametrize("step", list(Step))
     def test_part_get_scriptlet_none(self, step):
         p = Part("foo", {})
         assert p.spec.get_scriptlet(step) is None

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -22,6 +22,7 @@ from craft_parts.steps import Step
 
 def test_step():
     assert f"{Step.PULL!r}" == "Step.PULL"
+    assert f"{Step.OVERLAY!r}" == "Step.OVERLAY"
     assert f"{Step.BUILD!r}" == "Step.BUILD"
     assert f"{Step.STAGE!r}" == "Step.STAGE"
     assert f"{Step.PRIME!r}" == "Step.PRIME"
@@ -29,16 +30,23 @@ def test_step():
 
 def test_ordering():
     slist = list(Step)
-    assert sorted(slist) == [Step.PULL, Step.BUILD, Step.STAGE, Step.PRIME]
+    assert sorted(slist) == [
+        Step.PULL,
+        Step.OVERLAY,
+        Step.BUILD,
+        Step.STAGE,
+        Step.PRIME,
+    ]
 
 
 @pytest.mark.parametrize(
     "tc_step,tc_result",
     [
         (Step.PULL, []),
-        (Step.BUILD, [Step.PULL]),
-        (Step.STAGE, [Step.PULL, Step.BUILD]),
-        (Step.PRIME, [Step.PULL, Step.BUILD, Step.STAGE]),
+        (Step.OVERLAY, [Step.PULL]),
+        (Step.BUILD, [Step.PULL, Step.OVERLAY]),
+        (Step.STAGE, [Step.PULL, Step.OVERLAY, Step.BUILD]),
+        (Step.PRIME, [Step.PULL, Step.OVERLAY, Step.BUILD, Step.STAGE]),
     ],
 )
 def test_previous_steps(tc_step, tc_result):
@@ -48,7 +56,8 @@ def test_previous_steps(tc_step, tc_result):
 @pytest.mark.parametrize(
     "tc_step,tc_result",
     [
-        (Step.PULL, [Step.BUILD, Step.STAGE, Step.PRIME]),
+        (Step.PULL, [Step.OVERLAY, Step.BUILD, Step.STAGE, Step.PRIME]),
+        (Step.OVERLAY, [Step.BUILD, Step.STAGE, Step.PRIME]),
         (Step.BUILD, [Step.STAGE, Step.PRIME]),
         (Step.STAGE, [Step.PRIME]),
         (Step.PRIME, []),
@@ -62,6 +71,7 @@ def test_next_steps(tc_step, tc_result):
     "tc_step,tc_result",
     [
         (Step.PULL, None),
+        (Step.OVERLAY, None),
         (Step.BUILD, Step.STAGE),
         (Step.STAGE, Step.STAGE),
         (Step.PRIME, Step.PRIME),


### PR DESCRIPTION
The overlay step is used to process filesystem mutations defined for
each part. It can include package installation, modification of existing
file data or metadata, file renaming or removal, etc.

**Note to reviewers:** this change is rather large because many subsystems
need to be updated to handle the new step, and tests need to be updated to
account for the actions corresponding to step changes. Additional integration
tests will be added after the outdated overlay verification tests land, covering
the usage scenarios described in the feature specification.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>