### PR TITLE
overlays: replace pychroot with non-magic chroot (CRAFT-558)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,3 +103,63 @@ jobs:
         run: |
           source ${HOME}/.venv/bin/activate
           make test-integrations
+      - name: Run overlay smoke test
+        run: |
+          source ${HOME}/.venv/bin/activate
+          wget -q https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.squashfs
+          mkdir base
+          sudo mount -t squashfs focal-server-cloudimg-amd64.squashfs base/
+          cat <<-EOF > parts.yaml
+          parts:
+            foo:
+              plugin: nil
+              overlay-packages: [hello]
+              overlay-script: |
+                chroot "\$CRAFT_PARTS_OVERLAY" /bin/bash -c "hello > hello.txt"
+                echo 1234 > "\$CRAFT_PARTS_OVERLAY/etc/issue"
+              overlay:
+                - "*.txt"
+                - etc
+                - usr/bin
+            bar:
+              plugin: nil
+              after: [foo]
+              overlay-packages: [bison]
+              overlay-script: |
+                chroot "\$CRAFT_PARTS_OVERLAY" /bin/bash -c "rm -Rf /etc/shells /etc/ssh && mkdir /etc/ssh"
+                echo 5678 > "\$CRAFT_PARTS_OVERLAY/etc/issue"
+              overlay:
+                - -usr/share
+              override-build: |
+                rev "\$CRAFT_PARTS_OVERLAY/hello.txt" > "\$CRAFT_PARTS_PART_INSTALL/olleh.txt"
+          EOF
+          cat <<-EOF > run.sh
+            source ${HOME}/.venv/bin/activate
+            echo "--- overlay foo"
+            python -mcraft_parts --work-dir=work --trace --overlay-base=base --refresh overlay foo
+            echo "--- next actions plan"
+            python -mcraft_parts --work-dir=work --overlay-base=base --dry-run --show-skipped
+            echo "--- next actions execution"
+            python -mcraft_parts --work-dir=work --trace --overlay-base=base
+          EOF
+          echo "--- parts.yaml:"
+          cat parts.yaml
+          sudo bash run.sh
+          echo "* Check if hello executables installed"
+          test -x work/prime/usr/bin/hello && echo "hello"
+          test -x work/prime/usr/bin/bison && echo "bison"
+          test -x work/prime/usr/bin/m4 && echo "m4"
+          echo "* Check if /usr/bin/yacc is a symbolic link"
+          test -L work/prime/usr/bin/yacc && ls -l work/prime/usr/bin/yacc
+          echo "* Check if docs excluded"
+          test ! -d work/usr/share/doc/hello && echo "hello"
+          test ! -d work/usr/share/doc/bison && echo "bison"
+          echo "* Check created files"
+          grep "!dlrow ,olleH" work/prime/olleh.txt
+          grep "Hello, world!" work/prime/hello.txt
+          grep 5678 work/prime/etc/issue
+          echo "* Check whiteout files"
+          test -f work/prime/etc/.wh.shells && echo "/etc/shells"
+          test -f work/prime/etc/ssh/.wh..wh.opq && echo "/etc/ssh"
+          echo "--- prime files:"
+          find work/prime

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -130,6 +130,7 @@ jobs:
                 echo 5678 > "\$CRAFT_PARTS_OVERLAY/etc/issue"
               overlay:
                 - -usr/share
+                - -var/cache
               override-build: |
                 rev "\$CRAFT_PARTS_OVERLAY/hello.txt" > "\$CRAFT_PARTS_PART_INSTALL/olleh.txt"
           EOF

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -165,19 +165,15 @@ class PartHandler:
         self._make_dirs()
 
         if self._part.has_overlay:
+            # install overlay packages
             overlay_packages = self._part.spec.overlay_packages
             if overlay_packages:
-                # must be in a separate context manager to avoid pychroot process leak
                 with overlays.LayerMount(
                     self._overlay_manager, top_part=self._part
                 ) as ctx:
                     ctx.install_packages(overlay_packages)
 
-            # remove temporary files and package cache from layer
-            shutil.rmtree(self._part.part_layer_dir / "var/cache", ignore_errors=True)
-            shutil.rmtree(self._part.part_layer_dir / "var/tmp", ignore_errors=True)
-            shutil.rmtree(self._part.part_layer_dir / "tmp", ignore_errors=True)
-
+            # execute overlay script
             with overlays.LayerMount(self._overlay_manager, top_part=self._part):
                 contents = self._run_step(
                     step_info=step_info,

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -173,6 +173,11 @@ class PartHandler:
                 ) as ctx:
                     ctx.install_packages(overlay_packages)
 
+            # remove temporary files and package cache from layer
+            shutil.rmtree(self._part.part_layer_dir / "var/cache", ignore_errors=True)
+            shutil.rmtree(self._part.part_layer_dir / "var/tmp", ignore_errors=True)
+            shutil.rmtree(self._part.part_layer_dir / "tmp", ignore_errors=True)
+
             with overlays.LayerMount(self._overlay_manager, top_part=self._part):
                 contents = self._run_step(
                     step_info=step_info,

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -109,6 +109,7 @@ _linux_mounts: List[_Mount] = [
 
 def _setup_chroot_linux(path: Path) -> None:
     """Linux-specific chroot environment preparation."""
+    pid = os.getpid()
     for entry in _linux_mounts:
         args = []
         if entry.option:
@@ -133,19 +134,18 @@ def _setup_chroot_linux(path: Path) -> None:
 
         # Only mount if mountpoint exists.
         if mountpoint.exists():
-            logger.debug("[pid=%d] mount %r on chroot", os.getpid(), str(mountpoint))
+            logger.debug("[pid=%d] mount %r on chroot", pid, str(mountpoint))
             os_utils.mount(entry.src, str(mountpoint), *args)
         else:
-            logger.debug(
-                "[pid=%d] mountpoint %r does not exist", os.getpid(), str(mountpoint)
-            )
+            logger.debug("[pid=%d] mountpoint %r does not exist", pid, str(mountpoint))
 
 
 def _cleanup_chroot_linux(path: Path) -> None:
     """Linux-specific chroot environment cleanup."""
+    pid = os.getpid()
     for entry in reversed(_linux_mounts):
         mountpoint = path / entry.mountpoint.lstrip("/")
 
         if mountpoint.exists():
-            logger.debug("[pid=%d] umount: %r", os.getpid(), str(mountpoint))
+            logger.debug("[pid=%d] umount: %r", pid, str(mountpoint))
             os_utils.umount(str(mountpoint))

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -78,7 +78,6 @@ def _runner(
         return
 
     conn.send((res, None))
-    sys.exit()
 
 
 def _setup_chroot(path: Path) -> None:

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -1,0 +1,126 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Execute a callable in a chroot environment."""
+
+import logging
+import multiprocessing
+import os
+import sys
+from collections import namedtuple
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple
+
+from craft_parts.utils import os_utils
+
+logger = logging.getLogger(__name__)
+
+
+def chroot(path: Path, target: Callable, *args, **kwargs) -> Any:
+    """Execute a callable in a chroot environment."""
+    logger.debug("[pid=%d] parent process", os.getpid())
+    parent_conn, child_conn = multiprocessing.Pipe()
+    child = multiprocessing.Process(
+        target=_runner, args=(Path(path), child_conn, target, args, kwargs)
+    )
+    _setup_chroot(path)
+    try:
+        child.start()
+        res, exc = parent_conn.recv()
+        child.join()
+    finally:
+        _cleanup_chroot(path)
+
+    if isinstance(exc, Exception):
+        raise exc
+
+    return res
+
+
+def _runner(
+    path: Path,
+    conn: Connection,
+    target: Callable,
+    args: Tuple,
+    kwargs: Dict,
+) -> None:
+    logger.debug("[pid=%d] child process: target=%r", os.getpid(), target)
+    try:
+        logger.debug("[pid=%d] chroot to %r", os.getpid(), path)
+        os.chdir(path)
+        os.chroot(path)
+        res = target(*args, **kwargs)
+    except Exception as exc:  # pylint: disable=broad-except
+        conn.send((None, exc))
+        return
+
+    conn.send((res, None))
+    sys.exit()
+
+
+def _setup_chroot(path: Path) -> None:
+    logger.debug("setup chroot: %r", path)
+    if sys.platform == "linux":
+        _setup_chroot_linux(path)
+
+
+def _cleanup_chroot(path: Path) -> None:
+    logger.debug("cleanup chroot: %r", path)
+    if sys.platform == "linux":
+        _cleanup_chroot_linux(path)
+
+
+_Mount = namedtuple("_Mount", ["fstype", "src", "mountpoint", "option"])
+
+_linux_mounts: List[_Mount] = [
+    _Mount(None, "/etc/resolv.conf", "/etc/resolv.conf", "--bind"),
+    _Mount("proc", "proc", "/proc", None),
+    _Mount("sysfs", "sysfs", "/sys", None),
+    _Mount(None, "/dev", "/dev", "--bind"),
+    # _Mount("tmpfs", "tmpfs", "/dev/shm", None),
+]
+
+
+def _setup_chroot_linux(path: Path) -> None:
+    for entry in _linux_mounts:
+        args = []
+        if entry.option:
+            args.append(entry.option)
+        if entry.fstype:
+            args.append(f"-t{entry.fstype}")
+
+        mountpoint = path / entry.mountpoint.lstrip("/")
+
+        # Some images (such as cloudimgs) symlink ``/etc/resolv.conf`` to
+        # ``/run/systemd/resolve/stub-resolv.conf``. We want resolv.conf to be
+        # a regular file to bind-mount the host resolver configuration on.
+        #
+        # There's no need to restore the file to its original conditions because
+        # this operation happens on a temporary filesystem layer.
+        if mountpoint.is_symlink():
+            mountpoint.unlink()
+            mountpoint.touch()
+
+        logger.debug("[pid=%d] mount %r on chroot", os.getpid(), str(mountpoint))
+        os_utils.mount(entry.src, str(mountpoint), *args)
+
+
+def _cleanup_chroot_linux(path: Path) -> None:
+    for entry in reversed(_linux_mounts):
+        mountpoint = path / entry.mountpoint.lstrip("/")
+        logger.debug("[pid=%d] umount: %r", os.getpid(), str(mountpoint))
+        os_utils.umount(str(mountpoint))

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -96,6 +96,8 @@ def _cleanup_chroot(path: Path) -> None:
 
 _Mount = namedtuple("_Mount", ["fstype", "src", "mountpoint", "option"])
 
+# Essential filesystems to mount in order to have basic utilities and
+# name resolution working inside the chroot environment.
 _linux_mounts: List[_Mount] = [
     _Mount(None, "/etc/resolv.conf", "/etc/resolv.conf", "--bind"),
     _Mount("proc", "proc", "/proc", None),
@@ -106,6 +108,7 @@ _linux_mounts: List[_Mount] = [
 
 
 def _setup_chroot_linux(path: Path) -> None:
+    """Linux-specific chroot environment preparation."""
     for entry in _linux_mounts:
         args = []
         if entry.option:
@@ -139,6 +142,7 @@ def _setup_chroot_linux(path: Path) -> None:
 
 
 def _cleanup_chroot_linux(path: Path) -> None:
+    """Linux-specific chroot environment cleanup."""
     for entry in reversed(_linux_mounts):
         mountpoint = path / entry.mountpoint.lstrip("/")
 

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -45,7 +45,7 @@ class OverlayFS:
 
         :raises OverlayMountError: on mount error.
         """
-        logger.debug("mount overlayfs on %s", self._mountpoint)
+        logger.debug("mount overlayfs on %s", mountpoint)
         lower_dir = ":".join([str(p) for p in self._lower_dirs])
 
         try:

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -239,6 +239,9 @@ def mount(device: str, mountpoint: str, *args) -> None:
     subprocess.check_call(["/bin/mount", *args, device, mountpoint])
 
 
+_UMOUNT_RETRIES = 5
+
+
 def umount(mountpoint: str) -> None:
     """Unmount a filesystem.
 
@@ -247,7 +250,20 @@ def umount(mountpoint: str) -> None:
     :raises subprocess.CalledProcessError: on error.
     """
     logger.debug("umount mountpoint=%r", mountpoint)
-    subprocess.check_call(["/bin/umount", mountpoint])
+    attempt = 0
+    while True:  # unmount in Github CI fails randomly and needs a retry
+        try:
+            subprocess.check_call(["/bin/umount", mountpoint])
+            break
+        except subprocess.CalledProcessError as err:
+            attempt += 1
+            if attempt > _UMOUNT_RETRIES:
+                raise err
+
+            time.sleep(1)
+            logger.debug(
+                "retry umount %r (%d/%d)", mountpoint, attempt, _UMOUNT_RETRIES
+            )
 
 
 _ID_TO_UBUNTU_CODENAME = {

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -235,6 +235,7 @@ def mount(device: str, mountpoint: str, *args) -> None:
 
     :raises subprocess.CalledProcessError: on error.
     """
+    logger.debug("mount device=%r, mountpoint=%r, args=%r", device, mountpoint, args)
     subprocess.check_call(["/bin/mount", *args, device, mountpoint])
 
 
@@ -245,6 +246,7 @@ def umount(mountpoint: str) -> None:
 
     :raises subprocess.CalledProcessError: on error.
     """
+    logger.debug("umount mountpoint=%r", mountpoint)
     subprocess.check_call(["/bin/umount", mountpoint])
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,6 @@ pkginfo==1.7.1
 platformdirs==2.3.0
 pluggy==1.0.0
 py==1.10.0
-pychroot==0.10.3
 pycodestyle==2.7.0
 pycparser==2.20
 pydantic==1.8.2
@@ -65,7 +64,6 @@ rfc3986==1.5.0
 SecretStorage==3.3.1
 semver==2.13.0
 six==1.16.0
-snakeoil==0.8.9
 snowballstemmer==2.1.0
 Sphinx==4.2.0
 sphinx-autodoc-typehints==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 certifi==2021.5.30
 charset-normalizer==2.0.6
 idna==3.2
-pychroot==0.10.3
 pydantic==1.8.2
 pydantic-yaml==0.4.2
 pyxdg==0.27
@@ -9,6 +8,5 @@ PyYAML==5.4.1
 requests==2.26.0
 requests-unixsocket==0.2.0
 semver==2.13.0
-snakeoil==0.8.9
 typing-extensions==3.10.0.2
 urllib3==1.26.6

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ with open("README.md") as readme_file:
 
 install_requires = [
     "PyYAML",
-    "pychroot==0.10.3",  # 0.10.4 drops Python 3.7 support
     "pydantic",
     "pydantic-yaml",
     "pyxdg",

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -172,10 +172,7 @@ class TestChroot:
         mock_chdir = mocker.patch("os.chdir")
         mock_chroot = mocker.patch("os.chroot")
 
-        with pytest.raises(SystemExit):
-            chroot._runner(
-                Path("/some/path"), fake_conn, target_func, ("func arg",), {}
-            )
+        chroot._runner(Path("/some/path"), fake_conn, target_func, ("func arg",), {})
 
         assert Path("foo.txt").read_text() == "func arg"
         assert mock_chdir.mock_calls == [call(Path("/some/path"))]

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -1,0 +1,112 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import multiprocessing
+from pathlib import Path
+from unittest.mock import ANY, call
+
+import pytest
+
+from craft_parts.overlays import chroot
+
+
+def target_func(content: str) -> int:
+    Path("foo.txt").write_text(content)
+    return 1337
+
+
+def target_func_error(content: str) -> int:
+    raise RuntimeError("bummer")
+
+
+class FakeConn:
+    """Fake connection."""
+
+    def __init__(self):
+        self.sent = None
+
+    def send(self, data):
+        self.sent = data
+
+
+@pytest.fixture
+def fake_conn():
+    return FakeConn()
+
+
+class TestChroot:
+    """Fork process and execute in chroot."""
+
+    def test_chroot(self, mocker, new_dir):
+        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
+
+        spy_process = mocker.spy(multiprocessing, "Process")
+        new_root = Path(new_dir, "dir1")
+
+        # this runs in the child process
+        mocker.patch("os.chroot")
+
+        Path("dir1").mkdir()
+        chroot.chroot(new_root, target_func, "content")
+
+        assert Path("dir1/foo.txt").read_text() == "content"
+        assert spy_process.mock_calls == [
+            call(
+                target=chroot._runner,
+                args=(new_root, ANY, target_func, ("content",), {}),
+            )
+        ]
+        assert mock_mount.mock_calls == [
+            call("/etc/resolv.conf", f"{new_root}/etc/resolv.conf", "--bind"),
+            call("proc", f"{new_root}/proc", "-tproc"),
+            call("sysfs", f"{new_root}/sys", "-tsysfs"),
+            call("/dev", f"{new_root}/dev", "--bind"),
+        ]
+        assert mock_umount.mock_calls == [
+            call(f"{new_root}/dev"),
+            call(f"{new_root}/sys"),
+            call(f"{new_root}/proc"),
+            call(f"{new_root}/etc/resolv.conf"),
+        ]
+
+    def test_runner(self, mocker, new_dir, fake_conn):
+        mock_chdir = mocker.patch("os.chdir")
+        mock_chroot = mocker.patch("os.chroot")
+
+        with pytest.raises(SystemExit):
+            chroot._runner(
+                Path("/some/path"), fake_conn, target_func, ("func arg",), {}
+            )
+
+        assert Path("foo.txt").read_text() == "func arg"
+        assert mock_chdir.mock_calls == [call(Path("/some/path"))]
+        assert mock_chroot.mock_calls == [call(Path("/some/path"))]
+        assert fake_conn.sent == (1337, None)
+
+    def test_runner_error(self, mocker, new_dir, fake_conn):
+        mock_chdir = mocker.patch("os.chdir")
+        mock_chroot = mocker.patch("os.chroot")
+
+        chroot._runner(
+            Path("/some/path"), fake_conn, target_func_error, ("func arg",), {}
+        )
+
+        assert mock_chdir.mock_calls == [call(Path("/some/path"))]
+        assert mock_chroot.mock_calls == [call(Path("/some/path"))]
+        assert fake_conn.sent[0] is None
+        assert isinstance(fake_conn.sent[1], RuntimeError)
+        assert str(fake_conn.sent[1]) == "bummer"


### PR DESCRIPTION
Add a simple, non-magic replacement for pychroot. Pychroot has numerous
issues such as being too hackish, being restricted to certain interpreter
versions and platforms, and not working in the CI environment. This
implementation is much simpler and we can actually understand it.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
