### PR TITLE
executor: use bash as script interpreter instead of /bin/sh (CRAFT-567)

### DIFF
--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -58,8 +58,8 @@ def generate_part_environment(
 
     # Create the script.
     with io.StringIO() as run_environment:
-        print("#!/bin/sh", file=run_environment)
-        print("set -e", file=run_environment)
+        print("#!/bin/bash", file=run_environment)
+        print("set -euo pipefail", file=run_environment)
 
         print("# Environment", file=run_environment)
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -219,7 +219,7 @@ class StepHandler:
                 script_file.flush()
                 script_file.seek(0)
                 process = subprocess.Popen(  # pylint: disable=consider-using-with
-                    ["/bin/sh"], stdin=script_file, cwd=work_dir
+                    ["/bin/bash"], stdin=script_file, cwd=work_dir
                 )
 
             status = None

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -87,8 +87,8 @@ def test_generate_part_environment_build(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"
@@ -132,8 +132,8 @@ def test_generate_part_environment_no_build(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"
@@ -176,8 +176,8 @@ def test_generate_part_environment_no_user_env(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"


### PR DESCRIPTION
Snapcraft uses /bin/sh as the script interpreter when using plugins
V1 and /bin/bash when using plugins V2. To maintain compatibility,
change craft-parts to use /bin/bash as the script interpreter.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
