### PR TITLE
packages: load a stub AptCache on ImportError (CRAFT-574)

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -35,9 +35,16 @@ from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
 from .deb_package import DebPackage
 from .normalize import normalize
 
-if sys.platform == "linux":
-    # Ensure importing works on non-Linux.
+# Ensure importing works on non-Linux or linux without apt.
+# If the import fails provide a stub that appropriately fails
+# at runtime.
+try:
     from .apt_cache import AptCache
+
+    _apt_cache_available = True
+except ImportError:
+    _apt_cache_available = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +209,18 @@ IGNORE_FILTERS: Dict[str, Set[str]] = {
 }
 
 
+def _apt_cache_wrapper(method):
+    """Decorate a method to handle apt availability."""
+
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        if not _apt_cache_available:
+            raise errors.PackageBackendNotSupported("apt")
+        return method(self, *args, **kwargs)
+
+    return wrapped
+
+
 @functools.lru_cache(maxsize=256)
 def _run_dpkg_query_search(file_path: str) -> str:
     try:
@@ -280,6 +299,7 @@ class Ubuntu(BaseRepository):
     """Repository management for Ubuntu packages."""
 
     @classmethod
+    @_apt_cache_wrapper
     def configure(cls, application_package_name: str) -> None:
         """Set up apt options and directories."""
         AptCache.configure_apt(application_package_name)
@@ -290,6 +310,7 @@ class Ubuntu(BaseRepository):
         return _run_dpkg_query_list_files(package_name)
 
     @classmethod
+    @_apt_cache_wrapper
     def get_packages_for_source_type(cls, source_type):
         """Return a list of packages required to to work with source_type."""
         if source_type == "bzr":
@@ -324,6 +345,7 @@ class Ubuntu(BaseRepository):
             ) from call_error
 
     @classmethod
+    @_apt_cache_wrapper
     def _check_if_all_packages_installed(cls, package_names: List[str]) -> bool:
         """Check if all given packages are installed.
 
@@ -348,6 +370,7 @@ class Ubuntu(BaseRepository):
         return True
 
     @classmethod
+    @_apt_cache_wrapper
     def _get_packages_marked_for_installation(
         cls, package_names: List[str]
     ) -> List[Tuple[str, str]]:
@@ -452,6 +475,7 @@ class Ubuntu(BaseRepository):
             logger.warning("Impossible to mark packages as auto-installed: %s", err)
 
     @classmethod
+    @_apt_cache_wrapper
     def fetch_stage_packages(
         cls,
         *,
@@ -527,12 +551,14 @@ class Ubuntu(BaseRepository):
             normalize(install_path, repository=cls)
 
     @classmethod
+    @_apt_cache_wrapper
     def is_package_installed(cls, package_name) -> bool:
         """Inform if a package is installed on the host system."""
         with AptCache() as apt_cache:
             return apt_cache.get_installed_version(package_name) is not None
 
     @classmethod
+    @_apt_cache_wrapper
     def get_installed_packages(cls) -> List[str]:
         """Obtain a list of the installed packages and their versions."""
         with AptCache() as apt_cache:

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -26,6 +26,16 @@ class PackagesError(PartsError):
     """Base class for package handler errors."""
 
 
+class PackageBackendNotSupported(PartsError):
+    """Requested package resolved not supported on this host."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        super().__init__(
+            brief=f"Package backed {backend!r} is not supported on this environment.",
+        )
+
+
 class PackageNotFound(PackagesError):
     """Requested package doesn't exist in the remote repository.
 

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -85,6 +85,34 @@ def cache_dirs(mocker, tmpdir):
     )
 
 
+class _FakeUbuntu:
+    def __init__(self) -> None:
+        self.apt_called = False
+
+    @deb._apt_cache_wrapper
+    def call_apt(self) -> None:
+        self.apt_called = True
+
+
+def test_fake_wrapper_apt_available(monkeypatch):
+    monkeypatch.setattr(deb, "_apt_cache_available", True)
+
+    fake_ubuntu = _FakeUbuntu()
+    fake_ubuntu.call_apt()
+
+    assert fake_ubuntu.apt_called is True
+
+
+def test_fake_wrapper_apt_unavailable(monkeypatch):
+    monkeypatch.setattr(deb, "_apt_cache_available", False)
+
+    fake_ubuntu = _FakeUbuntu()
+    with pytest.raises(errors.PackageBackendNotSupported):
+        fake_ubuntu.call_apt()
+
+    assert fake_ubuntu.apt_called is False
+
+
 class TestPackages:
     def test_fetch_stage_packages(self, mocker, tmpdir, fake_apt_cache):
         mocker.patch(

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -17,6 +17,14 @@
 from craft_parts.packages import errors
 
 
+def test_package_backend_not_supported():
+    err = errors.PackageBackendNotSupported("apt")
+    assert err.backend == "apt"
+    assert err.brief == ("Package backed 'apt' is not supported on this environment.")
+    assert err.details is None
+    assert err.resolution is None
+
+
 def test_package_not_found():
     err = errors.PackageNotFound("foobar")
     assert err.package_name == "foobar"


### PR DESCRIPTION
The goal is to support non at enabled environments from working with
LXD or Multpass when running from a non snap in applications (like
Homebrew Linux).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----