### PR TITLE
lifecycle_manager: check if overlay is supported (CRAFT-562)

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -503,3 +503,21 @@ class InvalidAction(PartsError):
         brief = f"Action is invalid: {message}."
 
         super().__init__(brief=brief)
+
+
+class OverlayPlatformError(PartsError):
+    """A project using overlays was processed on a non-Linux platform."""
+
+    def __init__(self) -> None:
+        brief = "The overlay step is only supported on Linux."
+
+        super().__init__(brief=brief)
+
+
+class OverlayPermissionError(PartsError):
+    """A project using overlays was processed by a non-privileged user."""
+
+    def __init__(self) -> None:
+        brief = "Using the overlay step requires superuser privileges."
+
+        super().__init__(brief=brief)

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -47,6 +47,11 @@ def mock_mount_unmount(mocker):
     mocker.patch("craft_parts.utils.os_utils.umount")
 
 
+@pytest.fixture(autouse=True)
+def mock_prerequisites_for_overlay(mocker):
+    mocker.patch("craft_parts.lifecycle_manager._ensure_overlay_supported")
+
+
 def _step_callback(info: StepInfo) -> bool:
     print(f"step = {info.step!r}")
     print(f"part_src_dir = {info.part_src_dir}")

--- a/tests/integration/lifecycle/test_overlay.py
+++ b/tests/integration/lifecycle/test_overlay.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
 import textwrap
 from pathlib import Path
 from typing import List
@@ -28,6 +29,12 @@ from craft_parts import Action, ActionType, Step
 @pytest.fixture
 def fake_call(mocker):
     return mocker.patch("subprocess.check_call")
+
+
+@pytest.fixture(autouse=True)
+def mock_overlay_support_prerequisites(mocker):
+    mocker.patch.object(sys, "platform", "linux")
+    mocker.patch("os.geteuid", return_value=0)
 
 
 class TestOverlayLayerOrder:

--- a/tests/integration/lifecycle/test_partsctl.py
+++ b/tests/integration/lifecycle/test_partsctl.py
@@ -46,6 +46,8 @@ def setup_fixture(new_dir, mocker):
 
 
 def test_ctl_client_steps(new_dir, capfd, mocker):
+    mocker.patch("craft_parts.lifecycle_manager._ensure_overlay_supported")
+
     parts_yaml = textwrap.dedent(
         """\
         parts:

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -335,3 +335,17 @@ def test_invalid_action():
     assert err.brief == "Action is invalid: cannot update step 'stage'."
     assert err.details is None
     assert err.resolution is None
+
+
+def test_overlay_platform_error():
+    err = errors.OverlayPlatformError()
+    assert err.brief == "The overlay step is only supported on Linux."
+    assert err.details is None
+    assert err.resolution is None
+
+
+def test_overlay_permission_error():
+    err = errors.OverlayPermissionError()
+    assert err.brief == "Using the overlay step requires superuser privileges."
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
The overlay step is only supported on Linux and must be executed as
the superuser. Add a verification to lifecycle manager creation to
make sure these prerequisites are satisfied if the project uses
overlay.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
