### PR TITLE
release: craft-parts 1.0.3 (CRAFT-576)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = True
 tag = True
 

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -25,3 +25,16 @@ from .infos import PartInfo, ProjectInfo, StepInfo  # noqa: F401
 from .lifecycle_manager import LifecycleManager  # noqa: F401
 from .parts import Part  # noqa: F401
 from .steps import Step  # noqa: F401
+
+__all__ = [
+    "Action",
+    "ActionType",
+    "ProjectDirs",
+    "PartsError",
+    "ProjectInfo",
+    "PartInfo",
+    "StepInfo",
+    "LifecycleManager",
+    "Part",
+    "Step",
+]

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft a project from several parts."""
 
-__version__ = "1.0.2"  # noqa: F401
+__version__ = "1.0.3"  # noqa: F401
 
 from .actions import Action, ActionType  # noqa: F401
 from .dirs import ProjectDirs  # noqa: F401

--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -58,8 +58,8 @@ def generate_part_environment(
 
     # Create the script.
     with io.StringIO() as run_environment:
-        print("#!/bin/sh", file=run_environment)
-        print("set -e", file=run_environment)
+        print("#!/bin/bash", file=run_environment)
+        print("set -euo pipefail", file=run_environment)
 
         print("# Environment", file=run_environment)
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -213,7 +213,7 @@ class StepHandler:
                 script_file.flush()
                 script_file.seek(0)
                 process = subprocess.Popen(  # pylint: disable=consider-using-with
-                    ["/bin/sh"], stdin=script_file, cwd=work_dir
+                    ["/bin/bash"], stdin=script_file, cwd=work_dir
                 )
 
             status = None

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -41,9 +41,9 @@ from .normalize import normalize
 try:
     from .apt_cache import AptCache
 
-    _apt_cache_available = True
+    _APT_CACHE_AVAILABLE = True
 except ImportError:
-    _apt_cache_available = False
+    _APT_CACHE_AVAILABLE = False
 
 
 logger = logging.getLogger(__name__)
@@ -214,7 +214,7 @@ def _apt_cache_wrapper(method):
 
     @functools.wraps(method)
     def wrapped(*args, **kwargs):
-        if not _apt_cache_available:
+        if not _APT_CACHE_AVAILABLE:
             raise errors.PackageBackendNotSupported("apt")
         return method(*args, **kwargs)
 

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -35,9 +35,16 @@ from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
 from .deb_package import DebPackage
 from .normalize import normalize
 
-if sys.platform == "linux":
-    # Ensure importing works on non-Linux.
+# Ensure importing works on non-Linux or linux without apt.
+# If the import fails provide a stub that appropriately fails
+# at runtime.
+try:
     from .apt_cache import AptCache
+
+    _apt_cache_available = True
+except ImportError:
+    _apt_cache_available = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +209,18 @@ IGNORE_FILTERS: Dict[str, Set[str]] = {
 }
 
 
+def _apt_cache_wrapper(method):
+    """Decorate a method to handle apt availability."""
+
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        if not _apt_cache_available:
+            raise errors.PackageBackendNotSupported("apt")
+        return method(self, *args, **kwargs)
+
+    return wrapped
+
+
 @functools.lru_cache(maxsize=256)
 def _run_dpkg_query_search(file_path: str) -> str:
     try:
@@ -280,6 +299,7 @@ class Ubuntu(BaseRepository):
     """Repository management for Ubuntu packages."""
 
     @classmethod
+    @_apt_cache_wrapper
     def configure(cls, application_package_name: str) -> None:
         """Set up apt options and directories."""
         AptCache.configure_apt(application_package_name)
@@ -290,6 +310,7 @@ class Ubuntu(BaseRepository):
         return _run_dpkg_query_list_files(package_name)
 
     @classmethod
+    @_apt_cache_wrapper
     def get_packages_for_source_type(cls, source_type):
         """Return a list of packages required to to work with source_type."""
         if source_type == "bzr":
@@ -324,6 +345,7 @@ class Ubuntu(BaseRepository):
             ) from call_error
 
     @classmethod
+    @_apt_cache_wrapper
     def _check_if_all_packages_installed(cls, package_names: List[str]) -> bool:
         """Check if all given packages are installed.
 
@@ -348,6 +370,7 @@ class Ubuntu(BaseRepository):
         return True
 
     @classmethod
+    @_apt_cache_wrapper
     def _get_packages_marked_for_installation(
         cls, package_names: List[str]
     ) -> List[Tuple[str, str]]:
@@ -423,6 +446,7 @@ class Ubuntu(BaseRepository):
             logger.warning("Impossible to mark packages as auto-installed: %s", err)
 
     @classmethod
+    @_apt_cache_wrapper
     def fetch_stage_packages(
         cls,
         *,
@@ -498,12 +522,14 @@ class Ubuntu(BaseRepository):
             normalize(install_path, repository=cls)
 
     @classmethod
+    @_apt_cache_wrapper
     def is_package_installed(cls, package_name) -> bool:
         """Inform if a package is installed on the host system."""
         with AptCache() as apt_cache:
             return apt_cache.get_installed_version(package_name) is not None
 
     @classmethod
+    @_apt_cache_wrapper
     def get_installed_packages(cls) -> List[str]:
         """Obtain a list of the installed packages and their versions."""
         with AptCache() as apt_cache:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -35,9 +35,9 @@ from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
 from .deb_package import DebPackage
 from .normalize import normalize
 
-# Ensure importing works on non-Linux or linux without apt.
-# If the import fails provide a stub that appropriately fails
-# at runtime.
+# Catch the ImportError to set availability of apt on this system
+# to fail appropriately on use instead. This implementation is
+# independent of the underlying host OS.
 try:
     from .apt_cache import AptCache
 

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -213,10 +213,10 @@ def _apt_cache_wrapper(method):
     """Decorate a method to handle apt availability."""
 
     @functools.wraps(method)
-    def wrapped(self, *args, **kwargs):
+    def wrapped(*args, **kwargs):
         if not _apt_cache_available:
             raise errors.PackageBackendNotSupported("apt")
-        return method(self, *args, **kwargs)
+        return method(*args, **kwargs)
 
     return wrapped
 

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -32,7 +32,7 @@ class PackageBackendNotSupported(PartsError):
     def __init__(self, backend: str) -> None:
         self.backend = backend
         super().__init__(
-            brief=f"Package backed {backend!r} is not supported on this environment.",
+            brief=f"Package backend {backend!r} is not supported on this environment.",
         )
 
 

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -26,6 +26,16 @@ class PackagesError(PartsError):
     """Base class for package handler errors."""
 
 
+class PackageBackendNotSupported(PartsError):
+    """Requested package resolved not supported on this host."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        super().__init__(
+            brief=f"Package backed {backend!r} is not supported on this environment.",
+        )
+
+
 class PackageNotFound(PackagesError):
     """Requested package doesn't exist in the remote repository.
 

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -26,3 +26,10 @@ from .plugins import (  # noqa: F401
     register,
     unregister_all,
 )
+
+__all__ = [
+    "Plugin",
+    "PluginProperties",
+    "register",
+    "unregister_all",
+]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+1.0.3 (2021-10-19)
+------------------
+
+- Properly declare public API names
+- Allow non-snap applications running on non-apt systems to invoke parts
+  processing on build providers
+- Use Bash as script interpreter instead of /bin/sh to stay compatible
+  with Snapcraft V2 plugins
+
 1.0.2 (2021-09-16)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ copyright = "2021, Canonical Ltd."
 author = "Canonical Ltd."
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.2"
+release = "1.0.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ extras_requires = {
 
 setup(
     name="craft-parts",
-    version="1.0.2",
+    version="1.0.3",
     description="Craft parts tooling",
     long_description=readme,
     author="Canonical Ltd.",

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -87,8 +87,8 @@ def test_generate_part_environment_build(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"
@@ -131,8 +131,8 @@ def test_generate_part_environment_no_build(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"
@@ -174,8 +174,8 @@ def test_generate_part_environment_no_user_env(new_dir):
 
     assert env == textwrap.dedent(
         """\
-        #!/bin/sh
-        set -e
+        #!/bin/bash
+        set -euo pipefail
         # Environment
         ## Part Environment
         export XYZ_ARCH_TRIPLET="aarch64-linux-gnu"

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -94,7 +94,7 @@ class _FakeUbuntu:
 
 
 def test_fake_wrapper_apt_available(monkeypatch):
-    monkeypatch.setattr(deb, "_apt_cache_available", True)
+    monkeypatch.setattr(deb, "_APT_CACHE_AVAILABLE", True)
 
     fake_ubuntu = _FakeUbuntu()
     fake_ubuntu.call_apt()
@@ -103,7 +103,7 @@ def test_fake_wrapper_apt_available(monkeypatch):
 
 
 def test_fake_wrapper_apt_unavailable(monkeypatch):
-    monkeypatch.setattr(deb, "_apt_cache_available", False)
+    monkeypatch.setattr(deb, "_APT_CACHE_AVAILABLE", False)
 
     fake_ubuntu = _FakeUbuntu()
     with pytest.raises(errors.PackageBackendNotSupported):

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -84,6 +84,34 @@ def cache_dirs(mocker, tmpdir):
     )
 
 
+class _FakeUbuntu:
+    def __init__(self) -> None:
+        self.apt_called = False
+
+    @deb._apt_cache_wrapper
+    def call_apt(self) -> None:
+        self.apt_called = True
+
+
+def test_fake_wrapper_apt_available(monkeypatch):
+    monkeypatch.setattr(deb, "_apt_cache_available", True)
+
+    fake_ubuntu = _FakeUbuntu()
+    fake_ubuntu.call_apt()
+
+    assert fake_ubuntu.apt_called is True
+
+
+def test_fake_wrapper_apt_unavailable(monkeypatch):
+    monkeypatch.setattr(deb, "_apt_cache_available", False)
+
+    fake_ubuntu = _FakeUbuntu()
+    with pytest.raises(errors.PackageBackendNotSupported):
+        fake_ubuntu.call_apt()
+
+    assert fake_ubuntu.apt_called is False
+
+
 class TestPackages:
     def test_fetch_stage_packages(self, mocker, tmpdir, fake_apt_cache):
         mocker.patch(

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -20,7 +20,7 @@ from craft_parts.packages import errors
 def test_package_backend_not_supported():
     err = errors.PackageBackendNotSupported("apt")
     assert err.backend == "apt"
-    assert err.brief == ("Package backed 'apt' is not supported on this environment.")
+    assert err.brief == "Package backend 'apt' is not supported on this environment."
     assert err.details is None
     assert err.resolution is None
 

--- a/tests/unit/packages/test_errors.py
+++ b/tests/unit/packages/test_errors.py
@@ -17,6 +17,14 @@
 from craft_parts.packages import errors
 
 
+def test_package_backend_not_supported():
+    err = errors.PackageBackendNotSupported("apt")
+    assert err.backend == "apt"
+    assert err.brief == ("Package backed 'apt' is not supported on this environment.")
+    assert err.details is None
+    assert err.resolution is None
+
+
 def test_package_not_found():
     err = errors.PackageNotFound("foobar")
     assert err.package_name == "foobar"


### PR DESCRIPTION
Changelog
========

* Properly declare public API names
* Allow non-snap applications running on non-apt systems to invoke parts processing on build providers
* Use Bash as script interpreter instead of /bin/sh to stay compatible with Snapcraft V2 plugins

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
