### PR TITLE
overlay: pass error message from chrooted process (CRAFT-580)

### DIFF
--- a/craft_parts/overlays/errors.py
+++ b/craft_parts/overlays/errors.py
@@ -51,3 +51,13 @@ class OverlayUnmountError(OverlayError):
         brief = f"Failed to unmount {mountpoint}: {message}"
 
         super().__init__(brief=brief)
+
+
+class OverlayChrootExecutionError(OverlayError):
+    """Failed to execute in a chroot environment."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        brief = f"Overlay environment execution error: {message}"
+
+        super().__init__(brief=brief)

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -190,5 +190,5 @@ class TestChroot:
         assert mock_chdir.mock_calls == [call(Path("/some/path"))]
         assert mock_chroot.mock_calls == [call(Path("/some/path"))]
         assert fake_conn.sent[0] is None
-        assert isinstance(fake_conn.sent[1], RuntimeError)
+        assert isinstance(fake_conn.sent[1], str)
         assert str(fake_conn.sent[1]) == "bummer"

--- a/tests/unit/overlays/test_errors.py
+++ b/tests/unit/overlays/test_errors.py
@@ -35,3 +35,11 @@ def test_overlay_unmount_error():
     assert err.brief == "Failed to unmount /mountpoint: something wrong happened"
     assert err.details is None
     assert err.resolution is None
+
+
+def test_overlay_chroot_execution_error():
+    err = errors.OverlayChrootExecutionError("something wrong happened")
+    assert err.message == "something wrong happened"
+    assert err.brief == "Overlay environment execution error: something wrong happened"
+    assert err.details is None
+    assert err.resolution is None


### PR DESCRIPTION
Pass error message string and raise `ChrootExecutionError` instead
of passing the original exception. This avoids implementing `__reduce__`
for unpickling different possible errors.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
