### PR TITLE
plugins: export additional public api names (CRAFT-583)

### DIFF
--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -30,6 +30,9 @@ from .plugins import (  # noqa: F401
 __all__ = [
     "Plugin",
     "PluginProperties",
+    "extract_part_properties",
+    "get_plugin",
+    "get_plugin_class",
     "register",
     "unregister_all",
 ]


### PR DESCRIPTION
Export plugin API functions needed to validate parts definition
externally. This is used by applications to validate parts before
executing a build provider.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
