### PR TITLE
sources: add the git source handler (CRAFT-588)

### DIFF
--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -161,5 +161,16 @@ class PullError(SourceError):
         brief = (
             f"Failed to pull source: command {command!r} exited with code {exit_code}."
         )
+        resolution = "Make sure sources are correctly specified."
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
+class VCSError(SourceError):
+    """A version control system command failed."""
+
+    def __init__(self, message: str):
+        self.message = message
+        brief = message
 
         super().__init__(brief=brief)

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -1,0 +1,260 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Implement the git source handler."""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from craft_parts.dirs import ProjectDirs
+
+from . import errors
+from .base import SourceHandler
+
+
+class GitSource(SourceHandler):
+    """The git source handler."""
+
+    @classmethod
+    def version(cls) -> str:
+        """Get git version information."""
+        return (
+            subprocess.check_output(["git", "version"], stderr=subprocess.DEVNULL)
+            .decode(sys.getfilesystemencoding())
+            .strip()
+        )
+
+    @classmethod
+    def check_command_installed(cls) -> bool:
+        """Check if git is installed."""
+        try:
+            cls.version()
+        except FileNotFoundError:
+            return False
+        return True
+
+    @classmethod
+    def generate_version(cls, *, part_src_dir=None):
+        """Return the latest git tag from PWD or defined part_src_dir.
+
+        The output depends on the use of annotated tags and will return
+        something like: '2.28+git.10.abcdef' where '2.28 is the
+        tag, '+git' indicates there are commits ahead of the tag, in
+        this case it is '10' and the latest commit hash begins with
+        'abcdef'. If there are no tags or the revision cannot be
+        determined, this will return 0 as the tag and only the commit
+        hash of the latest commit.
+        """
+        if not part_src_dir:
+            part_src_dir = os.getcwd()
+
+        encoding = sys.getfilesystemencoding()
+        try:
+            output = (
+                subprocess.check_output(
+                    ["git", "-C", part_src_dir, "describe", "--dirty"],
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode(encoding)
+                .strip()
+            )
+        except subprocess.CalledProcessError as err:
+            # If we fall into this exception it is because the repo is not
+            # tagged at all.
+            proc = subprocess.Popen(  # pylint: disable=consider-using-with
+                ["git", "-C", part_src_dir, "describe", "--dirty", "--always"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = proc.communicate()
+            if proc.returncode != 0:
+                # This most likely means the project we are in is not driven
+                # by git.
+                raise errors.VCSError(message=stderr.decode(encoding).strip()) from err
+            return "0+git.{}".format(stdout.decode(encoding).strip())
+
+        match = re.search(
+            r"^(?P<tag>[a-zA-Z0-9.+~-]+)-"
+            r"(?P<revs_ahead>\d+)-"
+            r"g(?P<commit>[0-9a-fA-F]+(?:-dirty)?)$",
+            output,
+        )
+
+        if not match:
+            # This means we have a pure tag
+            return output
+
+        tag = match.group("tag")
+        revs_ahead = match.group("revs_ahead")
+        commit = match.group("commit")
+
+        return "{}+git{}.{}".format(tag, revs_ahead, commit)
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        source,
+        part_src_dir,
+        *,
+        cache_dir: Path,
+        source_tag: str = None,
+        source_commit: str = None,
+        source_branch: str = None,
+        source_depth: Optional[int] = None,
+        source_checksum: str = None,
+        project_dirs: ProjectDirs = None,
+        ignore_patterns: Optional[List[str]] = None,
+    ):
+        super().__init__(
+            source,
+            part_src_dir,
+            cache_dir=cache_dir,
+            source_tag=source_tag,
+            source_commit=source_commit,
+            source_branch=source_branch,
+            source_depth=source_depth,
+            source_checksum=source_checksum,
+            project_dirs=project_dirs,
+            ignore_patterns=ignore_patterns,
+            command="git",
+        )
+
+        if not self.command:
+            raise RuntimeError("command not specified")
+
+        if source_tag and source_branch:
+            raise errors.IncompatibleSourceOptions(
+                "git", ["source-tag", "source-branch"]
+            )
+        if source_tag and source_commit:
+            raise errors.IncompatibleSourceOptions(
+                "git", ["source-tag", "source-commit"]
+            )
+        if source_branch and source_commit:
+            raise errors.IncompatibleSourceOptions(
+                "git", ["source-branch", "source-commit"]
+            )
+        if source_checksum:
+            raise errors.InvalidSourceOption(
+                source_type="git", option="source-checksum"
+            )
+
+    def _fetch_origin_commit(self):
+        command = [
+            self.command,
+            "-C",
+            self.part_src_dir,
+            "fetch",
+            "origin",
+        ]
+        if self.source_commit:
+            command.append(self.source_commit)
+
+        self._run(command)
+
+    def _pull_existing(self):
+        refspec = "HEAD"
+        if self.source_branch:
+            refspec = "refs/heads/" + self.source_branch
+        elif self.source_tag:
+            refspec = "refs/tags/" + self.source_tag
+        elif self.source_commit:
+            refspec = self.source_commit
+            self._fetch_origin_commit()
+
+        reset_spec = refspec if refspec != "HEAD" else "origin/master"
+
+        command = [
+            self.command,
+            "-C",
+            self.part_src_dir,
+            "fetch",
+            "--prune",
+            "--recurse-submodules=yes",
+        ]
+        self._run(command)
+
+        command = [self.command, "-C", self.part_src_dir, "reset", "--hard"]
+        if reset_spec:
+            command.append(reset_spec)
+
+        self._run(command)
+
+        # Merge any updates for the submodules (if any).
+        command = [
+            self.command,
+            "-C",
+            self.part_src_dir,
+            "submodule",
+            "update",
+            "--recursive",
+            "--force",
+        ]
+        self._run(command)
+
+    def _clone_new(self):
+        command = [self.command, "clone", "--recursive"]
+        if self.source_tag or self.source_branch:
+            command.extend(["--branch", self.source_tag or self.source_branch])
+        if self.source_depth:
+            command.extend(["--depth", str(self.source_depth)])
+        self._run(command + [self.source, self.part_src_dir])
+
+        if self.source_commit:
+            self._fetch_origin_commit()
+            command = [
+                self.command,
+                "-C",
+                self.part_src_dir,
+                "checkout",
+                self.source_commit,
+            ]
+            self._run(command)
+
+    def is_local(self):
+        """Verify whether the git repository is on the local filesystem."""
+        return os.path.exists(os.path.join(self.part_src_dir, ".git"))
+
+    def pull(self):
+        """Retrieve the local or remote source files."""
+        if self.is_local():
+            self._pull_existing()
+        else:
+            self._clone_new()
+        self.source_details = self._get_source_details()
+
+    def _get_source_details(self):
+        tag = self.source_tag
+        commit = self.source_commit
+        branch = self.source_branch
+        source = self.source
+        checksum = self.source_checksum
+
+        if not tag and not branch and not commit:
+            commit = self._run_output(
+                ["git", "-C", self.part_src_dir, "rev-parse", "HEAD"]
+            )
+
+        return {
+            "source-commit": commit,
+            "source-branch": branch,
+            "source": source,
+            "source-tag": tag,
+            "source-checksum": checksum,
+        }

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -80,6 +80,7 @@ from craft_parts.dirs import ProjectDirs
 
 from . import errors
 from .base import SourceHandler
+from .git_source import GitSource
 from .local_source import LocalSource
 from .snap_source import SnapSource
 from .tar_source import TarSource
@@ -93,6 +94,7 @@ SourceHandlerType = Type[SourceHandler]
 _source_handler: Dict[str, SourceHandlerType] = {
     "local": LocalSource,
     "tar": TarSource,
+    "git": GitSource,
     "snap": SnapSource,
 }
 

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -101,4 +101,12 @@ def test_pull_error():
         err.brief == "Failed to pull source: command ['ls', '-l'] exited with code 66."
     )
     assert err.details is None
+    assert err.resolution == "Make sure sources are correctly specified."
+
+
+def test_vcs_error():
+    err = errors.VCSError("cvs: everything failed")
+    assert err.message == "cvs: everything failed"
+    assert err.brief == "cvs: everything failed"
+    assert err.details is None
     assert err.resolution is None

--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -1,0 +1,662 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import subprocess
+from typing import List
+from unittest import mock
+
+import pytest
+
+from craft_parts.sources import errors, sources
+from craft_parts.sources.git_source import GitSource
+
+
+def _call(cmd: List[str]) -> None:
+    subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _call_with_output(cmd: List[str]) -> str:
+    return subprocess.check_output(cmd).decode("utf-8").strip()
+
+
+def _fake_git_command_error(*args, **kwargs):
+    raise subprocess.CalledProcessError(44, ["git"], output=b"git: some error")
+
+
+@pytest.fixture
+def mock_get_source_details(mocker) -> None:
+    mocker.patch(
+        "craft_parts.sources.git_source.GitSource._get_source_details", return_value=""
+    )
+
+
+@pytest.fixture
+def fake_check_output(mocker):
+    return mocker.patch("subprocess.check_output")
+
+
+@pytest.fixture
+def fake_run(mocker):
+    return mocker.patch("craft_parts.sources.base.SourceHandler._run")
+
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-public-methods
+
+# LP: #1733584
+@pytest.mark.usefixtures("mock_get_source_details")
+class TestGitSource:
+    def test_pull(self, fake_run, new_dir):
+        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        git.pull()
+
+        fake_run.assert_called_once_with(
+            ["git", "clone", "--recursive", "git://my-source", "source_dir"]
+        )
+
+    def test_pull_with_depth(self, fake_run, new_dir):
+        git = GitSource(
+            "git://my-source", "source_dir", cache_dir=new_dir, source_depth=2
+        )
+
+        git.pull()
+
+        fake_run.assert_called_once_with(
+            [
+                "git",
+                "clone",
+                "--recursive",
+                "--depth",
+                "2",
+                "git://my-source",
+                "source_dir",
+            ]
+        )
+
+    def test_pull_branch(self, fake_run, new_dir):
+        git = GitSource(
+            "git://my-source",
+            "source_dir",
+            cache_dir=new_dir,
+            source_branch="my-branch",
+        )
+        git.pull()
+
+        fake_run.assert_called_once_with(
+            [
+                "git",
+                "clone",
+                "--recursive",
+                "--branch",
+                "my-branch",
+                "git://my-source",
+                "source_dir",
+            ]
+        )
+
+    def test_pull_tag(self, fake_run, new_dir):
+        git = GitSource(
+            "git://my-source", "source_dir", cache_dir=new_dir, source_tag="tag"
+        )
+        git.pull()
+
+        fake_run.assert_called_once_with(
+            [
+                "git",
+                "clone",
+                "--recursive",
+                "--branch",
+                "tag",
+                "git://my-source",
+                "source_dir",
+            ]
+        )
+
+    def test_pull_commit(self, fake_run, new_dir):
+        git = GitSource(
+            "git://my-source",
+            "source_dir",
+            cache_dir=new_dir,
+            source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
+        )
+        git.pull()
+
+        fake_run.assert_has_calls(
+            [
+                mock.call(
+                    ["git", "clone", "--recursive", "git://my-source", "source_dir"]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "origin",
+                        "2514f9533ec9b45d07883e10a561b248497a8e3c",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "checkout",
+                        "2514f9533ec9b45d07883e10a561b248497a8e3c",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing(self, mocker, fake_run, new_dir):
+        mocker.patch("os.path.exists", return_value=True)
+
+        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        git.pull()
+
+        fake_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    ["git", "-C", "source_dir", "reset", "--hard", "origin/master"]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_tag(self, mocker, fake_run, new_dir):
+        mocker.patch("os.path.exists", return_value=True)
+
+        git = GitSource(
+            "git://my-source", "source_dir", cache_dir=new_dir, source_tag="tag"
+        )
+        git.pull()
+
+        fake_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    ["git", "-C", "source_dir", "reset", "--hard", "refs/tags/tag"]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_commit(self, mocker, fake_run, new_dir):
+        mocker.patch("os.path.exists", return_value=True)
+
+        git = GitSource(
+            "git://my-source",
+            "source_dir",
+            cache_dir=new_dir,
+            source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
+        )
+        git.pull()
+
+        fake_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "reset",
+                        "--hard",
+                        "2514f9533ec9b45d07883e10a561b248497a8e3c",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_pull_existing_with_branch(self, mocker, fake_run, new_dir):
+        mocker.patch("os.path.exists", return_value=True)
+
+        git = GitSource(
+            "git://my-source",
+            "source_dir",
+            cache_dir=new_dir,
+            source_branch="my-branch",
+        )
+        git.pull()
+
+        fake_run.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "fetch",
+                        "--prune",
+                        "--recurse-submodules=yes",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "reset",
+                        "--hard",
+                        "refs/heads/my-branch",
+                    ]
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "-C",
+                        "source_dir",
+                        "submodule",
+                        "update",
+                        "--recursive",
+                        "--force",
+                    ]
+                ),
+            ]
+        )
+
+    def test_init_with_source_branch_and_tag_raises_exception(self, new_dir):
+        with pytest.raises(errors.IncompatibleSourceOptions) as raised:
+            GitSource(
+                "git://mysource",
+                "source_dir",
+                cache_dir=new_dir,
+                source_tag="tag",
+                source_branch="branch",
+            )
+        assert raised.value.source_type == "git"
+        assert raised.value.options == ["source-tag", "source-branch"]
+
+    def test_init_with_source_branch_and_commit_raises_exception(self, new_dir):
+        with pytest.raises(errors.IncompatibleSourceOptions) as raised:
+            GitSource(
+                "git://mysource",
+                "source_dir",
+                cache_dir=new_dir,
+                source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
+                source_branch="branch",
+            )
+        assert raised.value.source_type == "git"
+        assert raised.value.options == ["source-branch", "source-commit"]
+
+    def test_init_with_source_tag_and_commit_raises_exception(self, new_dir):
+        with pytest.raises(errors.IncompatibleSourceOptions) as raised:
+            GitSource(
+                "git://mysource",
+                "source_dir",
+                cache_dir=new_dir,
+                source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
+                source_tag="tag",
+            )
+        assert raised.value.source_type == "git"
+        assert raised.value.options == ["source-tag", "source-commit"]
+
+    def test_source_checksum_raises_exception(self, new_dir):
+        with pytest.raises(errors.InvalidSourceOption) as raised:
+            GitSource(
+                "git://mysource",
+                "source_dir",
+                cache_dir=new_dir,
+                source_checksum="md5/d9210476aac5f367b14e513bdefdee08",
+            )
+        assert raised.value.source_type == "git"
+        assert raised.value.option == "source-checksum"
+
+    def test_has_source_handler_entry(self):
+        assert sources._source_handler["git"] is GitSource
+
+    def test_pull_failure(self, mocker, new_dir):
+        mock_process_run = mocker.patch("craft_parts.utils.os_utils.process_run")
+        mock_process_run.side_effect = subprocess.CalledProcessError(1, [])
+
+        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        with pytest.raises(errors.PullError) as raised:
+            git.pull()
+        assert raised.value.command == [
+            "git",
+            "clone",
+            "--recursive",
+            "git://my-source",
+            "source_dir",
+        ]
+        assert raised.value.exit_code == 1
+
+
+@pytest.mark.usefixtures("new_dir")
+class GitBaseTestCase:
+    def rm_dir(self, dir_name):
+        if os.path.exists(dir_name):
+            shutil.rmtree(dir_name)
+
+    def clean_dir(self, dir_name):
+        self.rm_dir(dir_name)
+        os.mkdir(dir_name)
+
+    def clone_repo(self, repo, tree):
+        self.clean_dir(tree)
+        _call(["git", "clone", repo, tree])
+        os.chdir(tree)
+        _call(["git", "config", "--local", "user.name", '"Example Dev"'])
+        _call(["git", "config", "--local", "user.email", "dev@example.com"])
+
+    def add_file(self, filename, body, message):
+        with open(filename, "w") as fp:
+            fp.write(body)
+
+        _call(["git", "add", filename])
+        _call(["git", "commit", "-am", message])
+
+    def check_file_contents(self, path, expected):
+        body = None
+        with open(path) as fp:
+            body = fp.read()
+        assert body == expected
+
+
+class TestGitConflicts(GitBaseTestCase):
+    """Test that git pull errors don't kill the parser"""
+
+    def test_git_conflicts(self, new_dir):
+        repo = os.path.abspath("conflict-test.git")
+        working_tree = os.path.abspath("git-conflict-test")
+        conflicting_tree = "{}-conflict".format(working_tree)
+        git = GitSource(repo, working_tree, cache_dir=new_dir)
+
+        self.clean_dir(repo)
+        self.clean_dir(working_tree)
+        self.clean_dir(conflicting_tree)
+
+        os.chdir(repo)
+        _call(["git", "init", "--bare"])
+
+        self.clone_repo(repo, working_tree)
+
+        # check out the original repo
+        self.clone_repo(repo, conflicting_tree)
+
+        # add a file to the repo
+        os.chdir(working_tree)
+        self.add_file("fake", "fake 1", "fake 1")
+        _call(["git", "push", repo])
+
+        git.pull()
+
+        os.chdir(conflicting_tree)
+        self.add_file("fake", "fake 2", "fake 2")
+        _call(["git", "push", "-f", repo])
+
+        os.chdir(working_tree)
+        git.pull()
+
+        body = None
+        with open(os.path.join(working_tree, "fake")) as fp:
+            body = fp.read()
+
+        assert body == "fake 2"
+
+    def test_git_submodules(self, new_dir):
+        """Test that updates to submodules are pulled"""
+        repo = os.path.abspath("submodules.git")
+        sub_repo = os.path.abspath("subrepo")
+        working_tree = os.path.abspath("git-submodules")
+        working_tree_two = "{}-two".format(working_tree)
+        sub_working_tree = os.path.abspath("git-submodules-sub")
+        git = GitSource(repo, working_tree, cache_dir=new_dir)
+
+        self.clean_dir(repo)
+        self.clean_dir(sub_repo)
+        self.clean_dir(working_tree)
+        self.clean_dir(working_tree_two)
+        self.clean_dir(sub_working_tree)
+
+        os.chdir(sub_repo)
+        _call(["git", "init", "--bare"])
+
+        self.clone_repo(sub_repo, sub_working_tree)
+        self.add_file("sub-file", "sub-file", "sub-file")
+        _call(["git", "push", sub_repo])
+
+        os.chdir(repo)
+        _call(["git", "init", "--bare"])
+
+        self.clone_repo(repo, working_tree)
+        _call(["git", "submodule", "add", sub_repo])
+        _call(["git", "commit", "-am", "added submodule"])
+        _call(["git", "push", repo])
+
+        git.pull()
+
+        self.check_file_contents(
+            os.path.join(working_tree, "subrepo", "sub-file"), "sub-file"
+        )
+
+        # add a file to the repo
+        os.chdir(sub_working_tree)
+        self.add_file("fake", "fake 1", "fake 1")
+        _call(["git", "push", sub_repo])
+
+        os.chdir(working_tree)
+        git.pull()
+
+        # this shouldn't cause any change
+        self.check_file_contents(
+            os.path.join(working_tree, "subrepo", "sub-file"), "sub-file"
+        )
+        assert os.path.exists(os.path.join(working_tree, "subrepo", "fake")) is False
+
+        # update the submodule
+        self.clone_repo(repo, working_tree_two)
+        _call(["git", "submodule", "update", "--init", "--recursive", "--remote"])
+        _call(["git", "add", "subrepo"])
+        _call(["git", "commit", "-am", "updated submodule"])
+        _call(["git", "push"])
+
+        os.chdir(working_tree)
+        git.pull()
+
+        # new file should be there now
+        self.check_file_contents(
+            os.path.join(working_tree, "subrepo", "sub-file"), "sub-file"
+        )
+        self.check_file_contents(
+            os.path.join(working_tree, "subrepo", "fake"), "fake 1"
+        )
+
+
+# pylint: disable=attribute-defined-outside-init
+
+
+class TestGitDetails(GitBaseTestCase):
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, new_dir):  # pylint: disable=unused-argument
+        def _add_and_commit_file(filename, content=None, message=None):
+            if not content:
+                content = filename
+
+            if not message:
+                message = filename
+
+            with open(filename, "w") as fp:
+                fp.write(content)
+
+            _call(["git", "add", filename])
+            _call(["git", "commit", "-am", message])
+
+        self.working_tree = "git-test"
+        self.source_dir = "git-checkout"
+        self.clean_dir(self.working_tree)
+
+        os.chdir(self.working_tree)
+        _call(["git", "init"])
+        _call(["git", "config", "user.name", '"Example Dev"'])
+        _call(["git", "config", "user.email", "dev@example.com"])
+        _add_and_commit_file("testing")
+        self.expected_commit = _call_with_output(["git", "rev-parse", "HEAD"])
+
+        _add_and_commit_file("testing-2")
+        _call(["git", "tag", "test-tag"])
+        self.expected_tag = "test-tag"
+
+        _add_and_commit_file("testing-3")
+        self.expected_branch = "test-branch"
+        _call(["git", "branch", self.expected_branch])
+
+        os.chdir("..")
+
+        self.git = GitSource(
+            self.working_tree,
+            self.source_dir,
+            cache_dir=new_dir,
+            source_commit=self.expected_commit,
+        )
+        self.git.pull()
+
+        self.source_details = self.git._get_source_details()
+
+    def test_git_details_commit(self):
+        assert self.source_details["source-commit"] == self.expected_commit
+
+    def test_git_details_branch(self, new_dir):
+        shutil.rmtree(self.source_dir)
+        self.git = GitSource(
+            self.working_tree,
+            self.source_dir,
+            cache_dir=new_dir,
+            source_branch=self.expected_branch,
+        )
+        self.git.pull()
+
+        self.source_details = self.git._get_source_details()
+        assert self.source_details["source-branch"] == self.expected_branch
+
+    def test_git_details_tag(self, new_dir):
+        self.git = GitSource(
+            self.working_tree,
+            self.source_dir,
+            cache_dir=new_dir,
+            source_tag="test-tag",
+        )
+        self.git.pull()
+
+        self.source_details = self.git._get_source_details()
+        assert self.source_details["source-tag"] == self.expected_tag
+
+
+# pylint: enable=attribute-defined-outside-init
+
+
+class TestGitGenerateVersion:
+    @pytest.mark.parametrize(
+        "return_value,expected",
+        [
+            ("2.28", "2.28"),  # only_tag
+            ("2.28-28-gabcdef1", "2.28+git28.abcdef1"),  # tag+commits
+            ("2.28-29-gabcdef1-dirty", "2.28+git29.abcdef1-dirty"),  # tag+dirty
+        ],
+    )
+    def test_version(self, mocker, return_value, expected):
+        mocker.patch("subprocess.check_output", return_value=return_value.encode())
+        assert GitSource.generate_version() == expected
+
+
+class TestGitGenerateVersionNoTag:
+    def test_version(self, mocker, fake_check_output):
+        popen_mock = mocker.patch("subprocess.Popen")
+
+        fake_check_output.side_effect = subprocess.CalledProcessError(1, [])
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 0
+        proc_mock.communicate.return_value = (b"abcdef1", b"")
+        popen_mock.return_value = proc_mock
+
+        expected = "0+git.abcdef1"
+        assert GitSource.generate_version() == expected
+
+
+class TestGitGenerateVersionNoGit:
+    def test_version(self, mocker, fake_check_output):
+        popen_mock = mocker.patch("subprocess.Popen")
+
+        fake_check_output.side_effect = subprocess.CalledProcessError(1, [])
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 2
+        proc_mock.communicate.return_value = (b"", b"No .git")
+        popen_mock.return_value = proc_mock
+
+        with pytest.raises(errors.VCSError):
+            GitSource.generate_version()


### PR DESCRIPTION
The git source handler allows specifying git repositories as a part
source. Code and tests ported from snapcraft, with repository
initialization and write methods removed.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
