### PR TITLE
plugins: add plugin environment validation (CRAFT-611)

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -395,6 +395,20 @@ class StageFilesConflict(PartsError):
         super().__init__(brief=brief, details=details)
 
 
+class PluginEnvironmentValidationError(PartsError):
+    """Plugin build script failed at runtime.
+
+    :param part_name: The name of the part being processed.
+    """
+
+    def __init__(self, *, part_name: str, reason: str):
+        self.part_name = part_name
+        self.reason = reason
+        brief = f"Environment validation failed for part {part_name!r}: {reason}."
+
+        super().__init__(brief=brief)
+
+
 class PluginBuildError(PartsError):
     """Plugin build script failed at runtime.
 

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -396,7 +396,7 @@ class StageFilesConflict(PartsError):
 
 
 class PluginEnvironmentValidationError(PartsError):
-    """Plugin build script failed at runtime.
+    """Plugin environment validation failed at runtime.
 
     :param part_name: The name of the part being processed.
     """

--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -29,7 +29,7 @@ from craft_parts.utils import os_utils
 logger = logging.getLogger(__name__)
 
 
-def generate_part_environment(
+def generate_step_environment(
     *, part: Part, plugin: Plugin, step_info: StepInfo
 ) -> str:
     """Generate an environment to use during step execution.
@@ -154,15 +154,15 @@ def _get_step_environment(step_info: StepInfo) -> Dict[str, str]:
     return {
         f"{prefix}_ARCH_TRIPLET": step_info.arch_triplet,
         f"{prefix}_TARGET_ARCH": step_info.target_arch,
-        f"{prefix}_PARALLEL_BUILD_COUNT": step_info.parallel_build_count,
+        f"{prefix}_PARALLEL_BUILD_COUNT": str(step_info.parallel_build_count),
         f"{prefix}_PART_NAME": step_info.part_name,
-        f"{prefix}_PART_SRC": step_info.part_src_dir,
-        f"{prefix}_PART_BUILD": step_info.part_build_dir,
-        f"{prefix}_PART_BUILD_WORK": step_info.part_build_subdir,
-        f"{prefix}_PART_INSTALL": step_info.part_install_dir,
-        f"{prefix}_OVERLAY": step_info.overlay_mount_dir,
-        f"{prefix}_STAGE": step_info.stage_dir,
-        f"{prefix}_PRIME": step_info.prime_dir,
+        f"{prefix}_PART_SRC": str(step_info.part_src_dir),
+        f"{prefix}_PART_BUILD": str(step_info.part_build_dir),
+        f"{prefix}_PART_BUILD_WORK": str(step_info.part_build_subdir),
+        f"{prefix}_PART_INSTALL": str(step_info.part_install_dir),
+        f"{prefix}_OVERLAY": str(step_info.overlay_mount_dir),
+        f"{prefix}_STAGE": str(step_info.stage_dir),
+        f"{prefix}_PRIME": str(step_info.prime_dir),
     }
 
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -345,8 +345,11 @@ class PartHandler:
             part=self._part, plugin=self._plugin, step_info=step_info
         )
 
-        # Validate build environment
         if step_info.step == Step.BUILD:
+            # Validate build environment. Unlike the pre-validation we did in
+            # the execution prologue, we don't assume that a different part
+            # can add elements to the build environment. All part dependencies
+            # have already ran at this point.
             validator = self._plugin.validator_class(
                 part_name=step_info.part_name, env=step_env
             )

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -36,6 +36,7 @@ from craft_parts.steps import Step
 from craft_parts.utils import file_utils, os_utils
 
 from . import filesets, migration
+from .environment import generate_step_environment
 from .organize import organize_files
 from .step_handler import StepContents, StepHandler
 
@@ -340,12 +341,25 @@ class PartHandler:
         :return: If step is Stage or Prime, return a tuple of sets containing
             the step's file and directory artifacts.
         """
+        step_env = generate_step_environment(
+            part=self._part, plugin=self._plugin, step_info=step_info
+        )
+
+        # Validate build environment
+        if step_info.step == Step.BUILD:
+            validator = self._plugin.validator_class(
+                part_name=step_info.part_name, env=step_env
+            )
+            validator.validate_environment()
+
         step_handler = StepHandler(
             self._part,
             step_info=step_info,
             plugin=self._plugin,
             source_handler=self._source_handler,
+            env=step_env,
         )
+
         scriptlet = self._part.spec.get_scriptlet(step_info.step)
         if scriptlet:
             step_handler.run_scriptlet(

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -37,7 +37,7 @@ from craft_parts.sources import SourceHandler
 from craft_parts.steps import Step
 from craft_parts.utils import file_utils, os_utils
 
-from . import environment, filesets
+from . import filesets
 from .filesets import Fileset
 from .migration import migrate_files
 
@@ -71,14 +71,13 @@ class StepHandler:
         step_info: StepInfo,
         plugin: Plugin,
         source_handler: Optional[SourceHandler],
+        env: str,
     ):
         self._part = part
         self._step_info = step_info
         self._plugin = plugin
         self._source_handler = source_handler
-        self._env = environment.generate_part_environment(
-            part=part, plugin=plugin, step_info=step_info
-        )
+        self._env = env
 
     def run_builtin(self) -> StepContents:
         """Run the built-in commands for the current step."""

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -26,9 +26,11 @@ from .plugins import (  # noqa: F401
     register,
     unregister_all,
 )
+from .validator import PluginEnvironmentValidator
 
 __all__ = [
     "Plugin",
+    "PluginEnvironmentValidator",
     "PluginProperties",
     "extract_part_properties",
     "get_plugin",

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type
 from pydantic import BaseModel
 
 from .properties import PluginProperties
+from .validator import PluginEnvironmentValidator
 
 if TYPE_CHECKING:
     # import module to avoid circular imports in sphinx doc generation
@@ -32,17 +33,18 @@ class Plugin(abc.ABC):
     """The base class for plugins.
 
     :cvar properties_class: The plugin properties class.
+    :cvar validator_class: The plugin environment validator class.
 
     :param part_info: The part information for the applicable part.
     :param properties: Part-defined properties.
     """
 
     properties_class: Type[PluginProperties]
+    validator_class = PluginEnvironmentValidator
 
     def __init__(
         self, *, properties: PluginProperties, part_info: "infos.PartInfo"
     ) -> None:
-        self._name = part_info.part_name
         self._options = properties
         self._part_info = part_info
 

--- a/craft_parts/plugins/validator.py
+++ b/craft_parts/plugins/validator.py
@@ -1,0 +1,87 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definitions and helpers for plugin environment validation."""
+
+import logging
+import subprocess
+import tempfile
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PluginEnvironmentValidator:
+    """Base class for plugin environment validators.
+
+    Plugins may require certain environment elements to be present in
+    order to build a part, regardless of how these elements were installed
+    on the system. For example, a compiler may have been installed from a
+    deb package, a snap, built from sources or even built by a different
+    part. Plugin environment validators allow a plugin to ensure its
+    execution environment is correct before building a part.
+    """
+
+    def __init__(self, *, part_name: str, env: str):
+        self._part_name = part_name
+        self._env = env
+
+    def validate_environment(
+        self, *, part_dependencies: Optional[List[str]] = None
+    ) -> None:
+        """Ensure the plugin execution environment is valid.
+
+        The environment is verified twice: during the execution prologue after
+        build packages and snaps are installed (to provide an early error message
+        if the environment is invalid), and before running the build step for the
+        part. During the prologue validation the environment may be incomplete,
+        so we pass a list of the part dependencies as a hint of which parts may
+        be used to build the environment.
+
+        :param part_dependencies: A list of the parts this part depends on, so
+            the validator can check if the required environment elements are
+            supplied by another part when the method is called from the execution
+            prologue. If the validation fails and list is empty, the error is
+            final (the missing elements can't be supplied by a different part).
+            The plugin may require a specific part name as a hint that the
+            part will attempt to supply missing environment elements.
+
+        :raises PluginEnvironmentValidationError: If the environment is invalid.
+        """
+
+    def _execute(self, cmd: str) -> str:
+        """Execute a command in a build environment shell.
+
+        :param cmd: The command to execute.
+
+        :return: The command output or error message.
+        """
+        logger.debug("plugin validation environment: %s", self._env)
+        logger.debug("plugin validation command: %r", cmd)
+
+        with tempfile.NamedTemporaryFile(mode="w+") as env_file:
+            print(self._env, file=env_file)
+            print(cmd, file=env_file)
+            env_file.flush()
+
+            proc = subprocess.run(
+                ["/bin/bash", env_file.name],
+                check=True,
+                capture_output=True,
+                universal_newlines=True,
+            )
+
+        return proc.stderr if proc.stderr else proc.stdout

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -53,6 +53,9 @@ def mytool_error(new_dir):
     yield tool
 
 
+_COMMAND_NOT_FOUND = 127  # shell return code for command not found
+
+
 class AppPluginProperties(plugins.PluginProperties, plugins.PluginModel):
     """The application-defined plugin properties."""
 
@@ -77,7 +80,7 @@ class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):
                     reason="mytool is expected to print ok",
                 )
         except subprocess.CalledProcessError as err:
-            if err.returncode != 127:
+            if err.returncode != _COMMAND_NOT_FOUND:
                 raise errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason=f"mytool failed with error code {err.returncode}",
@@ -162,7 +165,7 @@ def test_validate_plugin(new_dir, mytool):
         exe.execute(actions)
 
 
-def test_validate_plugin_created_in_part(new_dir):
+def test_validate_plugin_satisfied_with_part(new_dir):
     _parts_yaml = textwrap.dedent(
         """\
         parts:

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -1,0 +1,281 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Step, errors, plugins
+
+
+@pytest.fixture
+def mytool(new_dir):
+    tool = Path(new_dir, "mock_bin", "mytool")
+    tool.parent.mkdir(exist_ok=True)
+    tool.write_text("echo ok")
+    tool.chmod(0o755)
+    yield tool
+
+
+@pytest.fixture
+def mytool_not_ok(new_dir):
+    tool = Path(new_dir, "mock_bin", "mytool")
+    tool.parent.mkdir(exist_ok=True)
+    tool.write_text("echo not ok")
+    tool.chmod(0o755)
+    yield tool
+
+
+@pytest.fixture
+def mytool_error(new_dir):
+    tool = Path(new_dir, "mock_bin", "mytool")
+    tool.parent.mkdir(exist_ok=True)
+    tool.write_text("exit 22")
+    tool.chmod(0o755)
+    yield tool
+
+
+class AppPluginProperties(plugins.PluginProperties, plugins.PluginModel):
+    """The application-defined plugin properties."""
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        return cls()
+
+
+class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):
+    """Check the execution environment for the app plugin."""
+
+    def validate_environment(self, *, part_dependencies: Optional[List[str]] = None):
+        """Ensure the environment contains dependencies needed by the plugin.
+
+        If mytool is created by a part, that part must be named `mytool`.
+        """
+        try:
+            output = self._execute("mytool")
+            if output.strip() != "ok":
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="mytool is expected to print ok",
+                )
+        except subprocess.CalledProcessError as err:
+            if err.returncode != 127:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=f"mytool failed with error code {err.returncode}",
+                ) from err
+
+            if part_dependencies is None:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="mytool not found",
+                ) from err
+
+            if "mytool" not in part_dependencies:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=(
+                        f"mytool not found and part {self._part_name!r} "
+                        f"does not depend on a part named 'mytool'"
+                    ),
+                ) from err
+
+
+class AppPlugin(plugins.Plugin):
+    """Our application plugin."""
+
+    properties_class = AppPluginProperties
+    validator_class = AppPluginEnvironmentValidator
+
+    def validate_environment(self, env: Dict[str, str]):
+        try:
+            subprocess.run("mytool", shell=True, check=True, env=env)
+        except subprocess.CalledProcessError as err:
+            raise errors.PluginEnvironmentValidationError(
+                part_name=self._part_info.part_name,
+                reason="mytool not found",
+            ) from err
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+def setup_function():
+    plugins.unregister_all()
+
+
+def teardown_module():
+    plugins.unregister_all()
+
+
+def test_validate_plugin(new_dir, mytool):
+    _parts_yaml = textwrap.dedent(
+        f"""\
+        parts:
+          foo:
+            plugin: app
+            build-environment:
+              - PATH: "$PATH:{new_dir}/mock_bin"
+        """
+    )
+
+    # register our application plugin
+    plugins.register({"app": AppPlugin})
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="mytest", cache_dir=new_dir
+    )
+
+    # plugins act on the build step
+    actions = lf.plan(Step.BUILD)
+
+    with lf.action_executor() as exe:
+        exe.execute(actions)
+
+
+def test_validate_plugin_created_in_part(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: app
+            after: [mytool]
+          mytool:
+            plugin: nil
+            override-build: |
+              mkdir "$MYTEST_PART_INSTALL"/bin
+              echo "echo ok" > "$MYTEST_PART_INSTALL"/bin/mytool
+              chmod +x "$MYTEST_PART_INSTALL"/bin/mytool
+        """
+    )
+
+    # register our application plugin
+    plugins.register({"app": AppPlugin})
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="mytest", cache_dir=new_dir
+    )
+
+    # plugins act on the build step
+    actions = lf.plan(Step.BUILD)
+
+    with lf.action_executor() as exe:
+        exe.execute(actions)
+
+
+def test_validate_plugin_early_error(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: app
+        """
+    )
+
+    # register our application plugin
+    plugins.register({"app": AppPlugin})
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="mytest", cache_dir=new_dir
+    )
+
+    # plugins act on the build step
+    actions = lf.plan(Step.BUILD)
+
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        with lf.action_executor() as exe:
+            exe.execute(actions)
+    assert raised.value.reason == (
+        "mytool not found and part 'foo' does not depend on a part named 'mytool'"
+    )
+
+
+def test_validate_plugin_bad_output(new_dir, mytool_not_ok):
+    _parts_yaml = textwrap.dedent(
+        f"""\
+        parts:
+          foo:
+            plugin: app
+            build-environment:
+              - PATH: "$PATH:{new_dir}/mock_bin"
+        """
+    )
+
+    # register our application plugin
+    plugins.register({"app": AppPlugin})
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="mytest", cache_dir=new_dir
+    )
+
+    # plugins act on the build step
+    actions = lf.plan(Step.BUILD)
+
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        with lf.action_executor() as exe:
+            exe.execute(actions)
+    assert raised.value.reason == "mytool is expected to print ok"
+
+
+def test_validate_plugin_command_error(new_dir, mytool_error):
+    _parts_yaml = textwrap.dedent(
+        f"""\
+        parts:
+          foo:
+            plugin: app
+            build-environment:
+              - PATH: "$PATH:{new_dir}/mock_bin"
+        """
+    )
+
+    # register our application plugin
+    plugins.register({"app": AppPlugin})
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="mytest", cache_dir=new_dir
+    )
+
+    # plugins act on the build step
+    actions = lf.plan(Step.BUILD)
+
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        with lf.action_executor() as exe:
+            exe.execute(actions)
+    assert raised.value.reason == "mytool failed with error code 22"

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -73,7 +73,7 @@ def directories(new_dir):  # pylint: disable=unused-argument
 # pylint: disable=line-too-long
 
 
-def test_generate_part_environment_build(new_dir):
+def test_generate_step_environment_build(new_dir):
     p1 = Part("p1", {"build-environment": [{"PART_ENVVAR": "from_part"}]})
     info = ProjectInfo(arch="aarch64", application_name="xyz", cache_dir=new_dir)
     part_info = PartInfo(project_info=info, part=p1)
@@ -81,7 +81,7 @@ def test_generate_part_environment_build(new_dir):
     props = plugins.PluginProperties()
     plugin = FooPlugin(properties=props, part_info=part_info)
 
-    env = environment.generate_part_environment(
+    env = environment.generate_step_environment(
         part=p1, plugin=plugin, step_info=step_info
     )
 
@@ -118,7 +118,7 @@ def test_generate_part_environment_build(new_dir):
     )
 
 
-def test_generate_part_environment_no_build(new_dir):
+def test_generate_step_environment_no_build(new_dir):
     p1 = Part("p1", {"build-environment": [{"PART_ENVVAR": "from_part"}]})
     info = ProjectInfo(arch="aarch64", application_name="xyz", cache_dir=new_dir)
     part_info = PartInfo(project_info=info, part=p1)
@@ -126,7 +126,7 @@ def test_generate_part_environment_no_build(new_dir):
     props = plugins.PluginProperties()
     plugin = FooPlugin(properties=props, part_info=part_info)
 
-    env = environment.generate_part_environment(
+    env = environment.generate_step_environment(
         part=p1, plugin=plugin, step_info=step_info
     )
 
@@ -162,7 +162,7 @@ def test_generate_part_environment_no_build(new_dir):
     )
 
 
-def test_generate_part_environment_no_user_env(new_dir):
+def test_generate_step_environment_no_user_env(new_dir):
     p1 = Part("p1", {})
     info = ProjectInfo(arch="aarch64", application_name="xyz", cache_dir=new_dir)
     part_info = PartInfo(project_info=info, part=p1)
@@ -170,7 +170,7 @@ def test_generate_part_environment_no_user_env(new_dir):
     props = plugins.PluginProperties()
     plugin = FooPlugin(properties=props, part_info=part_info)
 
-    env = environment.generate_part_environment(
+    env = environment.generate_step_environment(
         part=p1, plugin=plugin, step_info=step_info
     )
 

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -21,6 +21,7 @@ import pytest
 
 from craft_parts import plugins, sources
 from craft_parts.dirs import ProjectDirs
+from craft_parts.executor.environment import generate_step_environment
 from craft_parts.executor.step_handler import StepContents, StepHandler
 from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
 from craft_parts.parts import Part
@@ -58,12 +59,14 @@ def _step_handler_for_step(step: Step, cache_dir: Path) -> StepHandler:
         part=p1,
         project_dirs=dirs,
     )
+    step_env = generate_step_environment(part=p1, plugin=plugin, step_info=step_info)
 
     return StepHandler(
         part=p1,
         step_info=step_info,
         plugin=plugin,
         source_handler=source_handler,
+        env=step_env,
     )
 
 

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -37,7 +37,7 @@ class FooPluginProperties(PluginProperties):
 
 
 class FooPlugin(Plugin):
-    """An empty plugin."""
+    """A test plugin."""
 
     properties_class = FooPluginProperties
 
@@ -62,6 +62,9 @@ def test_plugin(new_dir):
 
     props = FooPluginProperties.unmarshal({"foo-name": "world"})
     plugin = FooPlugin(properties=props, part_info=part_info)
+
+    validator = FooPlugin.validator_class(part_name=part.name, env="")
+    validator.validate_environment()
 
     assert plugin.get_build_snaps() == {"build_snap"}
     assert plugin.get_build_packages() == {"build_package"}

--- a/tests/unit/plugins/test_validator.py
+++ b/tests/unit/plugins/test_validator.py
@@ -1,0 +1,161 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.infos import PartInfo, ProjectInfo
+from craft_parts.parts import Part
+from craft_parts.plugins import Plugin, PluginEnvironmentValidator, PluginProperties
+
+
+@pytest.fixture
+def foo_exe(new_dir):
+    exe = Path(new_dir, "mock_bin", "foo")
+    exe.parent.mkdir(exist_ok=True)
+    exe.write_text("echo bar")
+    exe.chmod(0o755)
+    yield exe
+
+
+@pytest.fixture
+def empty_foo_exe(new_dir):
+    exe = Path(new_dir, "mock_bin", "foo")
+    exe.parent.mkdir(exist_ok=True)
+    exe.touch()
+    exe.chmod(0o755)
+    yield exe
+
+
+@pytest.fixture
+def part_info(new_dir):
+    yield PartInfo(
+        project_info=ProjectInfo(application_name="test", cache_dir=new_dir),
+        part=Part("my-part", {}),
+    )
+
+
+@dataclass
+class FooPluginProperties(PluginProperties):
+    """Test plugin properties."""
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        return cls()
+
+
+class FooPluginEnvironmentValidator(PluginEnvironmentValidator):
+    """Check the execution environment for the test plugin."""
+
+    def validate_environment(self, *, part_dependencies: Optional[List[str]] = None):
+        """Ensure the environment contains dependencies needed by the plugin.
+
+        If the foo executable is created in a part, that part must be named
+        `build-foo`.
+        """
+        try:
+            output = self._execute("foo")
+            if output.strip() != "bar":
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="foo is expected to print bar",
+                )
+        except subprocess.CalledProcessError as err:
+            if part_dependencies is None:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="foo executable not found",
+                ) from err
+
+            if "build-foo" not in part_dependencies:
+                raise errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason=(
+                        f"foo executable not found and part {self._part_name!r} "
+                        f"does not depend on a part named 'build-foo'"
+                    ),
+                ) from err
+
+
+class FooPlugin(Plugin):
+    """The test plugin."""
+
+    properties_class = FooPluginProperties
+    validator_class = FooPluginEnvironmentValidator
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return ["foo"]
+
+
+def test_validation_happy(part_info, foo_exe):
+    validator = FooPlugin.validator_class(
+        part_name=part_info.part_name, env=f"PATH={str(foo_exe.parent)}"
+    )
+    validator.validate_environment()
+
+
+def test_validation_error(part_info):
+    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    err = raised.value
+    assert err.part_name == "my-part"
+    assert err.reason == "foo executable not found"
+
+
+def test_validation_built_by_part(part_info):
+    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    validator.validate_environment(part_dependencies=["build-foo"])
+
+
+def test_validation_built_by_part_error(part_info):
+    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment(part_dependencies=[])
+
+    err = raised.value
+    assert err.part_name == "my-part"
+    assert err.reason == (
+        "foo executable not found and part 'my-part' "
+        "does not depend on a part named 'build-foo'"
+    )
+
+
+def test_validation_output_error(part_info, empty_foo_exe):
+    validator = FooPlugin.validator_class(
+        part_name=part_info.part_name, env=f"PATH={str(empty_foo_exe.parent)}"
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    err = raised.value
+    assert err.part_name == "my-part"
+    assert err.reason == "foo is expected to print bar"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -268,6 +268,19 @@ def test_stage_files_conflict():
     assert err.resolution is None
 
 
+def test_plugin_environment_validation_error():
+    err = errors.PluginEnvironmentValidationError(
+        part_name="foo", reason="compiler not found"
+    )
+    assert err.part_name == "foo"
+    assert err.reason == "compiler not found"
+    assert err.brief == (
+        "Environment validation failed for part 'foo': compiler not found."
+    )
+    assert err.details is None
+    assert err.resolution is None
+
+
 def test_plugin_build_error():
     err = errors.PluginBuildError(part_name="foo")
     assert err.part_name == "foo"


### PR DESCRIPTION
Plugins may require certain environment elements to be present in
order to build a part, regardless of how these elements were installed
on the system. For example, a compiler may have been installed from a
deb package, a snap, built from sources or even built by a different
part. This commit adds plugin environment validators, allowing plugins
to verify if the system environment is correct before building a part.

**Note to reviewers**: see the integration test for use cases.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
