### PR TITLE
sources: use pathlib paths in source provision calls

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -780,7 +780,7 @@ class PartHandler:
         )
 
         for snap_source in snap_sources:
-            snap_source.provision(str(install_dir), clean_target=False, keep=True)
+            snap_source.provision(install_dir, clean_target=False, keep=True)
 
 
 def _remove(filename: Path) -> None:

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -22,7 +22,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import requests
 
@@ -48,8 +48,8 @@ class SourceHandler(abc.ABC):
 
     def __init__(
         self,
-        source: Union[str, Path],
-        part_src_dir: Union[str, Path],
+        source: str,
+        part_src_dir: Path,
         *,
         cache_dir: Path,
         source_tag: Optional[str] = None,
@@ -67,8 +67,8 @@ class SourceHandler(abc.ABC):
         if not ignore_patterns:
             ignore_patterns = []
 
-        self.source = str(source)
-        self.part_src_dir = str(part_src_dir)
+        self.source = source
+        self.part_src_dir = part_src_dir
         self._cache_dir = cache_dir
         self.source_tag = source_tag
         self.source_commit = source_commit
@@ -130,8 +130,8 @@ class FileSourceHandler(SourceHandler):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        source: Union[str, Path],
-        part_src_dir: Union[str, Path],
+        source: str,
+        part_src_dir: Path,
         *,
         cache_dir: Path,
         source_tag: Optional[str] = None,
@@ -162,7 +162,7 @@ class FileSourceHandler(SourceHandler):
 
     @abc.abstractmethod
     def provision(
-        self, dst: str, clean_target: bool = True, keep: bool = False, src: str = None
+        self, dst: Path, clean_target: bool = True, keep: bool = False, src: Path = None
     ) -> None:
         """Process the source file to extract its payload."""
 
@@ -191,7 +191,7 @@ class FileSourceHandler(SourceHandler):
 
         # We finally provision, but we don't clean the target so override-pull
         # can actually have meaning when using these sources.
-        self.provision(self.part_src_dir, src=str(source_file), clean_target=False)
+        self.provision(self.part_src_dir, src=source_file, clean_target=False)
 
     def download(self, filepath: Optional[Path] = None) -> Path:
         """Download the URL from a remote location.

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -65,7 +65,7 @@ class LocalSource(SourceHandler):
         """Retrieve the local source files."""
         file_utils.link_or_copy_tree(
             self.source_abspath,
-            self.part_src_dir,
+            str(self.part_src_dir),
             ignore=self._ignore,
             copy_function=self.copy_function,
         )

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -36,8 +36,8 @@ class TarSource(FileSourceHandler):
 
     def __init__(
         self,
-        source,
-        part_src_dir,
+        source: str,
+        part_src_dir: Path,
         *,
         cache_dir: Path,
         source_tag: Optional[str] = None,

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -819,7 +819,7 @@ class TestPackages:
 
         handler._unpack_stage_snaps()
         mock_snap_provision.assert_called_once_with(
-            str(new_dir / "parts/p1/install"),
+            new_dir / "parts/p1/install",
             clean_target=False,
             keep=True,
         )

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -38,7 +38,7 @@ class TestSourceHandler:
     def setup_method_fixture(self, new_dir):
         self.source = FooSourceHandler(
             source="source",
-            part_src_dir="parts/foo/src",
+            part_src_dir=Path("parts/foo/src"),
             cache_dir=new_dir,
         )
 
@@ -71,7 +71,7 @@ class TestSourceHandler:
         with pytest.raises(TypeError, match=expected):
             # pylint: disable=abstract-class-instantiated
             FaultySource(  # type: ignore
-                source=Path(), part_src_dir=Path(), cache_dir=Path()
+                source=".", part_src_dir=Path(), cache_dir=Path()
             )
 
 
@@ -79,7 +79,7 @@ class BarFileSource(FileSourceHandler):
     """A file source handler."""
 
     def provision(
-        self, dst: str, clean_target: bool = True, keep: bool = False, src: str = None
+        self, dst: Path, clean_target: bool = True, keep: bool = False, src: Path = None
     ) -> None:
         """Extract source payload."""
         self.provision_dst = dst
@@ -95,7 +95,7 @@ class TestFileSourceHandler:
     def setup_method_fixture(self, new_dir):
         self.source = BarFileSource(
             source="source",
-            part_src_dir="parts/foo/src",
+            part_src_dir=Path("parts/foo/src"),
             cache_dir=new_dir,
         )
 
@@ -115,10 +115,10 @@ class TestFileSourceHandler:
 
         self.source.pull()
 
-        assert self.source.provision_dst == "parts/foo/src"
+        assert self.source.provision_dst == Path("parts/foo/src")
         assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
-        assert self.source.provision_src == "parts/foo/src/my_file"
+        assert self.source.provision_src == Path("parts/foo/src/my_file")
 
         dest = Path(new_dir, "parts", "foo", "src", "my_file")
         assert dest.is_file()
@@ -139,10 +139,10 @@ class TestFileSourceHandler:
 
         self.source.pull()
 
-        assert self.source.provision_dst == "parts/foo/src"
+        assert self.source.provision_dst == Path("parts/foo/src")
         assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
-        assert self.source.provision_src == "parts/foo/src/my_file"
+        assert self.source.provision_src == Path("parts/foo/src/my_file")
 
         dest = Path(new_dir, "parts", "foo", "src", "my_file")
         assert dest.is_file()
@@ -167,10 +167,10 @@ class TestFileSourceHandler:
 
         self.source.pull()
 
-        assert self.source.provision_dst == "parts/foo/src"
+        assert self.source.provision_dst == Path("parts/foo/src")
         assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
-        assert self.source.provision_src == "parts/foo/src/some_file"
+        assert self.source.provision_src == Path("parts/foo/src/some_file")
 
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert downloaded.is_file()
@@ -183,10 +183,10 @@ class TestFileSourceHandler:
 
         self.source.pull()
 
-        assert self.source.provision_dst == "parts/foo/src"
+        assert self.source.provision_dst == Path("parts/foo/src")
         assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
-        assert self.source.provision_src == "parts/foo/src/some_file"
+        assert self.source.provision_src == Path("parts/foo/src/some_file")
 
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert downloaded.is_file()
@@ -209,10 +209,10 @@ class TestFileSourceHandler:
 
         self.source.pull()
 
-        assert self.source.provision_dst == "parts/foo/src"
+        assert self.source.provision_dst == Path("parts/foo/src")
         assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
-        assert self.source.provision_src == "parts/foo/src/some_file"
+        assert self.source.provision_src == Path("parts/foo/src/some_file")
 
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert downloaded.is_file()

--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -17,6 +17,7 @@
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import List
 from unittest import mock
 
@@ -63,7 +64,7 @@ def fake_run(mocker):
 @pytest.mark.usefixtures("mock_get_source_details")
 class TestGitSource:
     def test_pull(self, fake_run, new_dir):
-        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        git = GitSource("git://my-source", Path("source_dir"), cache_dir=new_dir)
         git.pull()
 
         fake_run.assert_called_once_with(
@@ -72,7 +73,7 @@ class TestGitSource:
 
     def test_pull_with_depth(self, fake_run, new_dir):
         git = GitSource(
-            "git://my-source", "source_dir", cache_dir=new_dir, source_depth=2
+            "git://my-source", Path("source_dir"), cache_dir=new_dir, source_depth=2
         )
 
         git.pull()
@@ -92,7 +93,7 @@ class TestGitSource:
     def test_pull_branch(self, fake_run, new_dir):
         git = GitSource(
             "git://my-source",
-            "source_dir",
+            Path("source_dir"),
             cache_dir=new_dir,
             source_branch="my-branch",
         )
@@ -112,7 +113,7 @@ class TestGitSource:
 
     def test_pull_tag(self, fake_run, new_dir):
         git = GitSource(
-            "git://my-source", "source_dir", cache_dir=new_dir, source_tag="tag"
+            "git://my-source", Path("source_dir"), cache_dir=new_dir, source_tag="tag"
         )
         git.pull()
 
@@ -131,7 +132,7 @@ class TestGitSource:
     def test_pull_commit(self, fake_run, new_dir):
         git = GitSource(
             "git://my-source",
-            "source_dir",
+            Path("source_dir"),
             cache_dir=new_dir,
             source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
         )
@@ -165,9 +166,9 @@ class TestGitSource:
         )
 
     def test_pull_existing(self, mocker, fake_run, new_dir):
-        mocker.patch("os.path.exists", return_value=True)
+        Path("source_dir/.git").mkdir(parents=True)
 
-        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        git = GitSource("git://my-source", Path("source_dir"), cache_dir=new_dir)
         git.pull()
 
         fake_run.assert_has_calls(
@@ -200,10 +201,10 @@ class TestGitSource:
         )
 
     def test_pull_existing_with_tag(self, mocker, fake_run, new_dir):
-        mocker.patch("os.path.exists", return_value=True)
+        Path("source_dir/.git").mkdir(parents=True)
 
         git = GitSource(
-            "git://my-source", "source_dir", cache_dir=new_dir, source_tag="tag"
+            "git://my-source", Path("source_dir"), cache_dir=new_dir, source_tag="tag"
         )
         git.pull()
 
@@ -237,11 +238,11 @@ class TestGitSource:
         )
 
     def test_pull_existing_with_commit(self, mocker, fake_run, new_dir):
-        mocker.patch("os.path.exists", return_value=True)
+        Path("source_dir/.git").mkdir(parents=True)
 
         git = GitSource(
             "git://my-source",
-            "source_dir",
+            Path("source_dir"),
             cache_dir=new_dir,
             source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
         )
@@ -284,11 +285,11 @@ class TestGitSource:
         )
 
     def test_pull_existing_with_branch(self, mocker, fake_run, new_dir):
-        mocker.patch("os.path.exists", return_value=True)
+        Path("source_dir/.git").mkdir(parents=True)
 
         git = GitSource(
             "git://my-source",
-            "source_dir",
+            Path("source_dir"),
             cache_dir=new_dir,
             source_branch="my-branch",
         )
@@ -334,7 +335,7 @@ class TestGitSource:
         with pytest.raises(errors.IncompatibleSourceOptions) as raised:
             GitSource(
                 "git://mysource",
-                "source_dir",
+                Path("source_dir"),
                 cache_dir=new_dir,
                 source_tag="tag",
                 source_branch="branch",
@@ -346,7 +347,7 @@ class TestGitSource:
         with pytest.raises(errors.IncompatibleSourceOptions) as raised:
             GitSource(
                 "git://mysource",
-                "source_dir",
+                Path("source_dir"),
                 cache_dir=new_dir,
                 source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
                 source_branch="branch",
@@ -358,7 +359,7 @@ class TestGitSource:
         with pytest.raises(errors.IncompatibleSourceOptions) as raised:
             GitSource(
                 "git://mysource",
-                "source_dir",
+                Path("source_dir"),
                 cache_dir=new_dir,
                 source_commit="2514f9533ec9b45d07883e10a561b248497a8e3c",
                 source_tag="tag",
@@ -370,7 +371,7 @@ class TestGitSource:
         with pytest.raises(errors.InvalidSourceOption) as raised:
             GitSource(
                 "git://mysource",
-                "source_dir",
+                Path("source_dir"),
                 cache_dir=new_dir,
                 source_checksum="md5/d9210476aac5f367b14e513bdefdee08",
             )
@@ -384,7 +385,7 @@ class TestGitSource:
         mock_process_run = mocker.patch("craft_parts.utils.os_utils.process_run")
         mock_process_run.side_effect = subprocess.CalledProcessError(1, [])
 
-        git = GitSource("git://my-source", "source_dir", cache_dir=new_dir)
+        git = GitSource("git://my-source", Path("source_dir"), cache_dir=new_dir)
         with pytest.raises(errors.PullError) as raised:
             git.pull()
         assert raised.value.command == [
@@ -433,7 +434,7 @@ class TestGitConflicts(GitBaseTestCase):
 
     def test_git_conflicts(self, new_dir):
         repo = os.path.abspath("conflict-test.git")
-        working_tree = os.path.abspath("git-conflict-test")
+        working_tree = Path("git-conflict-test").absolute()
         conflicting_tree = "{}-conflict".format(working_tree)
         git = GitSource(repo, working_tree, cache_dir=new_dir)
 
@@ -473,7 +474,7 @@ class TestGitConflicts(GitBaseTestCase):
         """Test that updates to submodules are pulled"""
         repo = os.path.abspath("submodules.git")
         sub_repo = os.path.abspath("subrepo")
-        working_tree = os.path.abspath("git-submodules")
+        working_tree = Path("git-submodules").absolute()
         working_tree_two = "{}-two".format(working_tree)
         sub_working_tree = os.path.abspath("git-submodules-sub")
         git = GitSource(repo, working_tree, cache_dir=new_dir)
@@ -558,7 +559,7 @@ class TestGitDetails(GitBaseTestCase):
             _call(["git", "commit", "-am", message])
 
         self.working_tree = "git-test"
-        self.source_dir = "git-checkout"
+        self.source_dir = Path("git-checkout")
         self.clean_dir(self.working_tree)
 
         os.chdir(self.working_tree)

--- a/tests/unit/sources/test_snap_source.py
+++ b/tests/unit/sources/test_snap_source.py
@@ -46,12 +46,14 @@ class TestSnapSource:
         with pytest.raises(errors.InvalidSourceOption) as raised:
             kwargs = {param: "foo"}
             sources.SnapSource(
-                source="test.snap", part_src_dir=".", cache_dir=new_dir, **kwargs
+                source="test.snap", part_src_dir=Path(), cache_dir=new_dir, **kwargs
             )
         assert raised.value.option == param.replace("_", "-")
 
     def test_pull_snap_file_must_extract(self, new_dir):
-        source = sources.SnapSource(self._test_file, self._dest_dir, cache_dir=new_dir)
+        source = sources.SnapSource(
+            str(self._test_file), self._dest_dir, cache_dir=new_dir
+        )
         source.pull()
 
         assert Path(self._dest_dir / "meta.basic").is_dir()
@@ -59,13 +61,15 @@ class TestSnapSource:
 
     def test_pull_snap_must_not_clean_targets(self, new_dir, mocker):
         mock_provision = mocker.patch.object(sources.SnapSource, "provision")
-        source = sources.SnapSource(self._test_file, self._dest_dir, cache_dir=new_dir)
+        source = sources.SnapSource(
+            str(self._test_file), self._dest_dir, cache_dir=new_dir
+        )
         source.pull()
 
         mock_provision.assert_called_once_with(
             self._dest_dir,
             clean_target=False,
-            src=os.path.join(self._dest_dir, "test-snap.snap"),
+            src=self._dest_dir / "test-snap.snap",
         )
 
     def test_has_source_handler_entry_on_linux(self):
@@ -78,7 +82,9 @@ class TestSnapSource:
         mocker.patch(
             "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, [])
         )
-        source = sources.SnapSource(self._test_file, self._dest_dir, cache_dir=new_dir)
+        source = sources.SnapSource(
+            str(self._test_file), self._dest_dir, cache_dir=new_dir
+        )
 
         with pytest.raises(sources.errors.PullError) as raised:
             source.pull()

--- a/tests/unit/sources/test_tar_source.py
+++ b/tests/unit/sources/test_tar_source.py
@@ -16,6 +16,7 @@
 
 import os
 import tarfile
+from pathlib import Path
 
 import pytest
 import requests
@@ -33,8 +34,8 @@ class TestTarSource:
         mock_prov = mocker.patch("craft_parts.sources.tar_source.TarSource.provision")
 
         plugin_name = "test_plugin"
-        dest_dir = os.path.join("parts", plugin_name, "src")
-        os.makedirs(dest_dir)
+        dest_dir = Path("parts", plugin_name, "src")
+        dest_dir.mkdir(parents=True)
         tar_file_name = "test.tar"
         source = "http://{}:{}/{file_name}".format(
             *http_server.server_address, file_name=tar_file_name
@@ -44,7 +45,7 @@ class TestTarSource:
 
         tar_source.pull()
 
-        source_file = os.path.join(dest_dir, tar_file_name)
+        source_file = dest_dir / tar_file_name
         mock_prov.assert_called_once_with(dest_dir, src=source_file, clean_target=False)
         with open(os.path.join(dest_dir, tar_file_name), "r") as tar_file:
             assert tar_file.read() == "Test fake file"
@@ -63,7 +64,7 @@ class TestTarSource:
             "085b0c3"
         )
         tar_source = sources.TarSource(
-            source, ".", cache_dir=new_dir, source_checksum=expected_checksum
+            source, Path(), cache_dir=new_dir, source_checksum=expected_checksum
         )
 
         tar_source.pull()
@@ -81,7 +82,7 @@ class TestTarSource:
             tar.add(file_to_tar)
 
         tar_source = sources.TarSource(
-            os.path.join("src", "test.tar"), "dst", cache_dir=new_dir
+            os.path.join("src", "test.tar"), Path("dst"), cache_dir=new_dir
         )
         os.mkdir("dst")
         tar_source.pull()
@@ -112,7 +113,7 @@ class TestTarSource:
             tar.add(file_to_link, filter=check_for_symlink)
 
         tar_source = sources.TarSource(
-            os.path.join("src", "test.tar"), "dst", cache_dir=new_dir
+            os.path.join("src", "test.tar"), Path("dst"), cache_dir=new_dir
         )
         os.mkdir("dst")
         tar_source.pull()
@@ -143,7 +144,7 @@ class TestTarSource:
             tar.add(file_to_link, filter=check_for_hardlink)
 
         tar_source = sources.TarSource(
-            os.path.join("src", "test.tar"), "dst", cache_dir=new_dir
+            os.path.join("src", "test.tar"), Path("dst"), cache_dir=new_dir
         )
         os.mkdir("dst")
         tar_source.pull()


### PR DESCRIPTION
Refactor source provision calls to use pathlib.Path instead of strings
and add missing type annotations for source and part_src_dir. Source
is typed as string because it can also be a URL.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
