### PR TITLE
python: unpin dependencies (CRAFT-663)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,54 +14,43 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Add local bin to PATH
-        run: |
-          echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: Install python packages and dependencies
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3-venv libapt-pkg-dev
-          python3 -m venv ${HOME}/.venv
-          source ${HOME}/.venv/bin/activate
-          pip install -U pip wheel setuptools
-          pip install -U -r requirements.txt -r requirements-dev.txt -r requirements-focal.txt
-          pip install -e .
+          sudo apt install -y libapt-pkg-dev
+          pip install -U \
+                         https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz \
+                         https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz \
+                         .[dev]
       - name: Run black
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-black
       - name: Run codespell
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-codespell
       - name: Run flake8
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-flake8
       - name: Run isort
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-isort
       - name: Run mypy
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-mypy
       - name: Run pydocstyle
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-pydocstyle
       - name: Run pyright
         run: |
-          sudo apt install -y npm
-          sudo npm install -g pyright
-          source ${HOME}/.venv/bin/activate
+          sudo snap install --classic node
+          sudo snap install --classic pyright
           make test-pyright
 
   tests:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        python-version: [3.7, 3.8]
+        os: [ubuntu-20.04]
+        python-version: [3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -69,43 +58,30 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Add local bin to PATH
-        run: |
-          echo "${HOME}/.local/bin" >> $GITHUB_PATH
-      - name: Install dependencies
+      - name: Install apt build dependencies
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3-venv libapt-pkg-dev
-          python3 -m venv ${HOME}/.venv
-          source ${HOME}/.venv/bin/activate
-          pip install -U pip wheel setuptools
-          case "${{ matrix.os }}" in
-            ubuntu-18.04)
-              # pip 20.2 breaks python3-apt, so pin the version before building
-              pip install pip==20.1
-              pip install -U -r requirements-bionic.txt
-              ;;
-            ubuntu-20.04)
-              pip install -U -r requirements-focal.txt
-              ;;
-          esac
-          pip install -U -r requirements.txt -r requirements-dev.txt
+          sudo apt install -y libapt-pkg-dev intltool
+      - name: Install python-apt dependencies
+        run: |
+          pip install https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz
+          pip install https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz
+      - name: Install general python dependencies
+        run: |
+          pip install .[dev]
           pip install -e .
       - name: Run unit tests
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-units
       - name: Run integration tests
         run: |
-          source ${HOME}/.venv/bin/activate
           make test-integrations
       - name: Run overlay smoke test
         run: |
-          source ${HOME}/.venv/bin/activate
           wget -q https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.squashfs
           mkdir base
           sudo mount -t squashfs focal-server-cloudimg-amd64.squashfs base/
@@ -134,18 +110,18 @@ jobs:
               override-build: |
                 rev "\$CRAFT_PARTS_OVERLAY/hello.txt" > "\$CRAFT_PARTS_PART_INSTALL/olleh.txt"
           EOF
+          python_exe=$(command -v python)
           cat <<-EOF > run.sh
-            source ${HOME}/.venv/bin/activate
             echo "--- overlay foo"
-            python -mcraft_parts --work-dir=work --trace --overlay-base=base --refresh overlay foo
+            "${python_exe}" -mcraft_parts --work-dir=work --trace --overlay-base=base --refresh overlay foo
             echo "--- next actions plan"
-            python -mcraft_parts --work-dir=work --overlay-base=base --dry-run --show-skipped
+            "${python_exe}" -mcraft_parts --work-dir=work --overlay-base=base --dry-run --show-skipped
             echo "--- next actions execution"
-            python -mcraft_parts --work-dir=work --trace --overlay-base=base
+            "${python_exe}" -mcraft_parts --work-dir=work --trace --overlay-base=base
           EOF
           echo "--- parts.yaml:"
           cat parts.yaml
-          sudo bash run.sh
+          sudo bash -xe run.sh
           echo "* Check if hello executables installed"
           test -x work/prime/usr/bin/hello && echo "hello"
           test -x work/prime/usr/bin/bison && echo "bison"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,24 +2,21 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
 
-# Optionally build your docs in additional formats such as PDF
 formats:
   - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
-    - requirements: requirements-dev.txt
+    - method: pip
+      path: .

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ coverage: ## Run pytest with coverage report.
 docs: ## Generate documentation.
 	rm -f docs/craft_parts.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ craft_parts --force --no-toc --ext-githubpages --separate --module-first
+	pip install -r docs/requirements.txt
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,3 +87,17 @@ typehints_document_rtype = True
 
 # Enable support for google-style instance attributes.
 napoleon_use_ivar = True
+
+def run_apidoc(_):
+    from sphinx.ext.apidoc import main
+    import os
+    import sys
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    module = os.path.join(cur_dir, "..", "craft_parts")
+    main(["-e", "-o", cur_dir, module, "--no-toc", "--force"])
+
+
+def setup(app):
+    app.connect("builder-inited", run_apidoc)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,10 @@
-PyYAML==5.4.1
-progressbar==2.5
-pydantic==1.8.1
-pydantic-yaml==0.2.3
-pyxdg==0.27
-requests==2.25.1
-requests-unixsocket==0.2.0
+Sphinx==4.2.0
+sphinx-autodoc-typehints==1.12.0
+sphinx-jsonschema==1.16.11
+sphinx-pydantic==0.1.1
+sphinx-rtd-theme==1.0.0
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,3 @@ extension-pkg-whitelist = [
 ]
 load-plugins = "pylint_fixme_info,pylint_pytest"
 good-names = "id"
-
-[tool.black]
-exclude = '/((\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|parts|stage|prime)/|setup.py)'

--- a/requirements-bionic.txt
+++ b/requirements-bionic.txt
@@ -1,1 +1,0 @@
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/1.6.5ubuntu0.6/python-apt_1.6.5ubuntu0.6.tar.xz; sys_platform == 'linux'

--- a/requirements-focal.txt
+++ b/requirements-focal.txt
@@ -1,1 +1,0 @@
-python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz; sys.platform == "linux"

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,9 @@ test_requires = [
     "isort",
     "mypy",
     "pydocstyle",
-    "pylint",
+    # Incompatible with current pylint-fixme-info==1.0.2
+    # https://github.com/PyCQA/pylint/issues/5390
+    "pylint<2.12.0",
     "pylint-fixme-info",
     "pylint-pytest",
     "pytest",


### PR DESCRIPTION
- Remove requirements to always test with the latest
- Separate the docs target into its own requirements for readthedocs
- Ensure the right dependencies are used to create the documentation
  assets
- Remove black's file filter which ignores gitignore
- Use 20.04 as the only base with a spread of python versions
- Ensure the sudo context of the GHA for overlays runs the correct
  python interpreter

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

-------

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----