### PR TITLE
setup: pin pydantic-yaml and pydantic versions (CRAFT-718)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ with open("README.md") as readme_file:
 
 install_requires = [
     "PyYAML",
-    "pydantic",
-    "pydantic-yaml",
+    "pydantic==1.8.2",
+    "pydantic-yaml==0.4.3",
     "pyxdg",
     "requests",
     "requests-unixsocket",


### PR DESCRIPTION
Pin dependencies with API changes to allow craft-parts to run correctly.
Code will be updated to the current API in a separate PR. Pylint will
be unpinned after warnings issued by newer versions are addressed.

Fixes #158.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
