### PR TITLE
errors: update pydantic validation error checking (CRAFT-788)

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -17,7 +17,10 @@
 """Craft parts errors."""
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, List, Optional, Set
+
+if TYPE_CHECKING:
+    from pydantic.error_wrappers import ErrorDict
 
 
 @dataclasses.dataclass(repr=True)
@@ -117,7 +120,7 @@ class PartSpecificationError(PartsError):
         super().__init__(brief=brief, details=details, resolution=resolution)
 
     @classmethod
-    def from_validation_error(cls, *, part_name: str, error_list: List[Dict[str, Any]]):
+    def from_validation_error(cls, *, part_name: str, error_list: List["ErrorDict"]):
         """Create a PartSpecificationError from a pydantic error list.
 
         :param part_name: The name of the part being processed.

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ with open("README.md") as readme_file:
 
 install_requires = [
     "PyYAML",
-    "pydantic==1.8.2",
-    "pydantic-yaml==0.4.3",
+    "pydantic",
+    "pydantic-yaml",
     "pyxdg",
     "requests",
     "requests-unixsocket",

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -95,7 +95,6 @@ class TestPartHandling:
         assert state == states.OverlayState(
             part_properties=self._part.spec.marshal(),
             project_options=self._part_info.project_options,
-            assets={},
         )
 
     def test_run_overlay_with_filter(self, mocker, new_dir):

--- a/tests/unit/state_manager/test_step_state.py
+++ b/tests/unit/state_manager/test_step_state.py
@@ -95,7 +95,7 @@ class TestStepState:
         }
 
     def test_ignore_additional_data(self):
-        state = SomeStepState(extra="something")
+        state = SomeStepState(extra="something")  # type: ignore
         assert state.marshal() == {
             "part-properties": {},
             "project-options": {},

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -14,7 +14,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import TYPE_CHECKING, List
+
 from craft_parts import errors
+
+if TYPE_CHECKING:
+    from pydantic.error_wrappers import ErrorDict
 
 
 def test_parts_error_brief():
@@ -84,10 +89,14 @@ def test_part_specification_error():
 
 
 def test_part_specification_error_from_validation_error():
-    error_list = [
-        {"loc": ("field-1", 0), "msg": "something is wrong"},
-        {"loc": ("field-2",), "msg": "field required"},
-        {"loc": ("field-3",), "msg": "extra fields not permitted"},
+    error_list: List["ErrorDict"] = [
+        {"loc": ("field-1", 0), "msg": "something is wrong", "type": "value_error"},
+        {"loc": ("field-2",), "msg": "field required", "type": "value_error"},
+        {
+            "loc": ("field-3",),
+            "msg": "extra fields not permitted",
+            "type": "value_error",
+        },
     ]
     err = errors.PartSpecificationError.from_validation_error(
         part_name="foo", error_list=error_list
@@ -99,22 +108,6 @@ def test_part_specification_error_from_validation_error():
         "- field 'field-2' is required\n"
         "- extra field 'field-3' not permitted"
     )
-    assert err.resolution == "Review part 'foo' and make sure it's correct."
-
-
-def test_part_specification_error_from_bad_validation_error():
-    error_list = [
-        {"loc": "field-1", "msg": "something is wrong"},
-        {"loc": "field-1"},
-        {"msg": "something is wrong"},
-        {},
-    ]
-    err = errors.PartSpecificationError.from_validation_error(
-        part_name="foo", error_list=error_list
-    )
-    assert err.part_name == "foo"
-    assert err.brief == "Part 'foo' validation failed."
-    assert err.details == ""
     assert err.resolution == "Review part 'foo' and make sure it's correct."
 
 

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -266,12 +266,12 @@ def test_sequencer_ensure_overlay_consistency_rerun(mocker, new_dir):
     p1 = Part("p1", {})
     p2 = Part("p2", {})
 
-    state = states.OverlayState(
-        # echo "some-hash-value" | sha1sum
-        layer_hash="4fc928c87171c54a4687d55899ca212d1b1c46e5"
-    )
     Path("parts/p1/state").mkdir(parents=True)
-    state.write(Path("parts/p1/state/overlay"))
+    layer_hash = LayerHash(
+        # echo "some-hash-value" | sha1sum
+        bytes.fromhex("4fc928c87171c54a4687d55899ca212d1b1c46e5")
+    )
+    layer_hash.save(p1)
 
     seq = Sequencer(part_list=[p1, p2], project_info=info)
 


### PR DESCRIPTION
Pydantic 1.9 uses `TypedDict` to hold validation error information
instead of a plain dictionary. Update craft-parts to correctly
handle `ErrorDict` data.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
