### PR TITLE
executor: use source type specified in part (CRAFT-831)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -869,7 +869,11 @@ def _get_build_packages(*, part: Part, plugin: Plugin) -> List[str]:
     source = part.spec.source
     if source:
         repo = packages.Repository
-        source_type = sources.get_source_type_from_uri(source)
+
+        source_type = part.spec.source_type
+        if not source_type:
+            source_type = sources.get_source_type_from_uri(source)
+
         source_build_packages = repo.get_packages_for_source_type(source_type)
         if source_build_packages:
             logger.debug("source build packages: %s", source_build_packages)

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -33,6 +33,8 @@ from craft_parts.state_manager import states
 from craft_parts.steps import Step
 from craft_parts.utils import os_utils
 
+# pylint: disable=too-many-lines
+
 
 @pytest.mark.usefixtures("new_dir")
 class TestPartHandling:
@@ -834,6 +836,24 @@ class TestPackages:
             p1, part_info=part_info, part_list=[p1], overlay_manager=ovmgr
         )
         assert sorted(handler.build_packages) == ["gcc", "make", "pkg1", "tar"]
+
+    def test_get_build_packages_with_source_type(self, new_dir):
+        p1 = Part(
+            "p1",
+            {
+                "plugin": "make",
+                "source": "source",
+                "source-type": "git",
+                "build-packages": ["pkg1"],
+            },
+        )
+        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        part_info = PartInfo(info, p1)
+        ovmgr = OverlayManager(project_info=info, part_list=[p1], base_layer_dir=None)
+        handler = PartHandler(
+            p1, part_info=part_info, part_list=[p1], overlay_manager=ovmgr
+        )
+        assert sorted(handler.build_packages) == ["gcc", "git", "make", "pkg1"]
 
     def test_get_build_snaps(self, new_dir):
         p1 = Part("p1", {"plugin": "nil", "build-snaps": ["word-salad"]})


### PR DESCRIPTION
When obtaining the consolidated list of build packages, honor the
source type specified by the user before attempting to infer it
from the source URI. Fixes #171.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
