### PR TITLE
overlays: mount overlayfs using fuse-overlayfs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Install apt build dependencies
         run: |
           sudo apt update
-          sudo apt install -y libapt-pkg-dev intltool
+          sudo apt install -y libapt-pkg-dev intltool fuse-overlayfs
       - name: Install python-apt dependencies
         run: |
           pip install https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz

--- a/craft_parts/overlays/overlay_fs.py
+++ b/craft_parts/overlays/overlay_fs.py
@@ -49,10 +49,8 @@ class OverlayFS:
         lower_dir = ":".join([str(p) for p in self._lower_dirs])
 
         try:
-            os_utils.mount(
-                "overlay",
+            os_utils.mount_overlayfs(
                 str(mountpoint),
-                "-toverlay",
                 f"-olowerdir={lower_dir!s},upperdir={self._upper_dir!s},"
                 f"workdir={self._work_dir!s}",
             )

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -239,6 +239,18 @@ def mount(device: str, mountpoint: str, *args) -> None:
     subprocess.check_call(["/bin/mount", *args, device, mountpoint])
 
 
+def mount_overlayfs(mountpoint: str, *args) -> None:
+    """Mount an overlay filesystem using fuse-overlayfs.
+
+    :param mountpoint: Where the device will be mounted.
+    :param *args: Additional arguments to ``mount(8)``.
+
+    :raises subprocess.CalledProcessError: on error.
+    """
+    logger.debug("fuse-overlayfs mountpoint=%r, args=%r", mountpoint, args)
+    subprocess.check_call(["fuse-overlayfs", *args, mountpoint])
+
+
 _UMOUNT_RETRIES = 5
 
 

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -44,6 +44,7 @@ def teardown_module():
 @pytest.fixture(autouse=True)
 def mock_mount_unmount(mocker):
     mocker.patch("craft_parts.utils.os_utils.mount")
+    mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
     mocker.patch("craft_parts.utils.os_utils.umount")
 
 

--- a/tests/integration/lifecycle/test_partsctl.py
+++ b/tests/integration/lifecycle/test_partsctl.py
@@ -42,6 +42,7 @@ def setup_fixture(new_dir, mocker):
     )
 
     mocker.patch("craft_parts.utils.os_utils.mount")
+    mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
     mocker.patch("craft_parts.utils.os_utils.umount")
 
 

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -66,6 +66,9 @@ class TestPartHandling:
             overlay_manager=ovmgr,
         )
         self._mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+        self._mock_mount_overlayfs = mocker.patch(
+            "craft_parts.utils.os_utils.mount_overlayfs"
+        )
         self._mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
         # pylint: enable=attribute-defined-outside-init
 
@@ -158,10 +161,8 @@ class TestPartHandling:
             overlay_hash="d12e3f53ba91f94656abc940abb50b12b209d246",
         )
 
-        self._mock_mount.assert_called_with(
-            "overlay",
+        self._mock_mount_overlayfs.assert_called_with(
             f"{self._part_info.overlay_mount_dir}",
-            "-toverlay",
             (
                 f"-olowerdir={self._part_info.overlay_packages_dir}:/base,"
                 f"upperdir={self._part.part_layer_dir},"
@@ -218,7 +219,7 @@ class TestPartHandling:
         )
         handler._run_build(StepInfo(part_info, Step.BUILD), stdout=None, stderr=None)
 
-        assert self._mock_mount.mock_calls == []
+        assert self._mock_mount_overlayfs.mock_calls == []
 
     def test_run_stage(self, mocker):
         mocker.patch(
@@ -477,6 +478,7 @@ class TestPartReapplyHandler:
         )
 
         mocker.patch("craft_parts.utils.os_utils.mount")
+        mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
         mocker.patch("craft_parts.utils.os_utils.umount")
         # pylint: enable=attribute-defined-outside-init
 

--- a/tests/unit/overlays/test_overlay_fs.py
+++ b/tests/unit/overlays/test_overlay_fs.py
@@ -36,32 +36,32 @@ class TestOverlayFS:
         )
 
     def test_mount_single_lower(self, mocker):
-        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_mount_overlayfs = mocker.patch(
+            "craft_parts.utils.os_utils.mount_overlayfs"
+        )
 
         ovfs = self._make_overlay_fs([Path("/lower")])
         ovfs.mount(Path("/mountpoint"))
-        mock_mount.assert_called_once_with(
-            "overlay",
+        mock_mount_overlayfs.assert_called_once_with(
             "/mountpoint",
-            "-toverlay",
             "-olowerdir=/lower,upperdir=/upper,workdir=/work",
         )
 
     def test_mount_multiple_lower(self, mocker):
-        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_mount_overlayfs = mocker.patch(
+            "craft_parts.utils.os_utils.mount_overlayfs"
+        )
 
         ovfs = self._make_overlay_fs([Path("/lower1"), Path("/lower2")])
         ovfs.mount(Path("/mountpoint"))
-        mock_mount.assert_called_once_with(
-            "overlay",
+        mock_mount_overlayfs.assert_called_once_with(
             "/mountpoint",
-            "-toverlay",
             "-olowerdir=/lower1:/lower2,upperdir=/upper,workdir=/work",
         )
 
     def test_mount_error(self, mocker):
         mocker.patch(
-            "craft_parts.utils.os_utils.mount",
+            "craft_parts.utils.os_utils.mount_overlayfs",
             side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),
         )
 
@@ -75,7 +75,7 @@ class TestOverlayFS:
         )
 
     def test_unmount(self, mocker):
-        mocker.patch("craft_parts.utils.os_utils.mount")
+        mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
 
         ovfs = self._make_overlay_fs([Path("/lower")])
@@ -91,7 +91,7 @@ class TestOverlayFS:
         mock_umount.assert_not_called()
 
     def test_unmount_multiple(self, mocker):
-        mocker.patch("craft_parts.utils.os_utils.mount")
+        mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
 
         ovfs = self._make_overlay_fs([Path("/lower")])
@@ -102,7 +102,7 @@ class TestOverlayFS:
         mock_umount.assert_called_once_with("/mountpoint")
 
     def test_unmount_error(self, mocker):
-        mocker.patch("craft_parts.utils.os_utils.mount")
+        mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
         mocker.patch(
             "craft_parts.utils.os_utils.umount",
             side_effect=CalledProcessError(cmd=["some", "command"], returncode=42),

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -398,6 +398,13 @@ class TestMount:
             ["/bin/mount", "some", "args", "/dev/node", "/mountpoint"]
         )
 
+    def test_mount_overlayfs(self, mocker):
+        mock_call = mocker.patch("subprocess.check_call")
+        os_utils.mount_overlayfs("/mountpoint", "some", "args")
+        mock_call.assert_called_once_with(
+            ["fuse-overlayfs", "some", "args", "/mountpoint"]
+        )
+
     def test_umount(self, mocker):
         mock_call = mocker.patch("subprocess.check_call")
         os_utils.umount("/mountpoint")


### PR DESCRIPTION
Use fuse-overlayfs instead of the kernel implementation to enable
mounting inside idmapped containers in focal with updated kernels.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
