### PR TITLE
craftctl: set variables from parts adopting metadata

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -178,7 +178,7 @@ class Executor:
                 for var, pvar in action.project_vars.items():
                     if pvar.updated:
                         self._project_info.set_project_var(
-                            var, pvar.value, raw_write=True
+                            var, pvar.value, raw_write=True, part_name=action.part_name
                         )
             return
 

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -55,8 +55,8 @@ class ProjectInfo:
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
     :param project_dirs: The project work directories.
-    :param project_vars_part_name: If defined, project variables can be set
-        only if the part name matches this name.
+    :param project_vars_part_name: Project variables can be set only if
+        the part name matches this name.
     :param project_vars: A dictionary containing the project variables.
     :param custom_args: Any additional arguments defined by the application
         when creating a :class:`LifecycleManager`.
@@ -185,9 +185,14 @@ class ProjectInfo:
         if not raw_write and self._project_vars[name].updated:
             raise RuntimeError(f"variable {name!r} can be set only once")
 
-        if self._project_vars_part_name in [None, part_name]:
+        if self._project_vars_part_name == part_name:
             self._project_vars[name].value = value
             self._project_vars[name].updated = True
+        elif not self._project_vars_part_name:
+            raise RuntimeError(
+                f"variable {name!r} can only be set in a part that "
+                "adopts external metadata"
+            )
         else:
             raise RuntimeError(
                 f"variable {name!r} can only be set "

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -65,8 +65,8 @@ class LifecycleManager:
     :param base_layer_hash: The validation hash of the overlay base image, if using
         overlays. The validation hash should be constant for a given image, and should
         change if a different base image is used.
-    :param project_vars_part_name: If defined, project variables can only be set
-        in the part matching this name.
+    :param project_vars_part_name: Project variables can only be set in the part
+        matching this name.
     :param project_vars: A dictionary containing project variables.
     :param custom_args: Any additional arguments that will be passed directly
         to :ref:`callbacks<callbacks>`.

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -138,12 +138,27 @@ def test_project_info_set_project_var_part_name():
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_var_part_name="part1",
+        project_vars_part_name="part1",
         project_vars={"var": "foo"},
     )
 
     info.set_project_var("var", "bar", part_name="part1")
     assert info.get_project_var("var", raw_read=True) == "bar"
+
+
+def test_project_info_set_project_var_no_part_name():
+    info = ProjectInfo(
+        application_name="test",
+        cache_dir=Path(),
+        project_vars={"var": "foo"},
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        info.set_project_var("var", "bar", part_name="part2")
+
+    assert str(raised.value) == (
+        "variable 'var' can only be set in a part that adopts external metadata"
+    )
 
 
 def test_project_info_set_project_var_other_part_name():
@@ -260,7 +275,10 @@ def test_part_info_invalid_custom_args():
 
 def test_part_info_set_project_var():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     x = PartInfo(project_info=info, part=part)
@@ -271,7 +289,10 @@ def test_part_info_set_project_var():
 
 def test_part_info_set_project_var_raw_write():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     x = PartInfo(project_info=info, part=part)
@@ -296,6 +317,23 @@ def test_part_info_set_project_var_part_name():
 
     x.set_project_var("var", "bar")
     assert x.get_project_var("var", raw_read=True) == "bar"
+
+
+def test_part_info_set_project_var_no_part_name():
+    info = ProjectInfo(
+        application_name="test",
+        cache_dir=Path(),
+        project_vars={"var": "foo"},
+    )
+    part = Part("p1", {})
+    x = PartInfo(project_info=info, part=part)
+
+    with pytest.raises(RuntimeError) as raised:
+        x.set_project_var("var", "bar")
+
+    assert str(raised.value) == (
+        "variable 'var' can only be set in a part that adopts external metadata"
+    )
 
 
 def test_part_info_set_project_var_other_part_name():
@@ -326,7 +364,10 @@ def test_part_info_set_invalid_project_vars():
 
 def test_part_info_get_project_var():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     x = PartInfo(project_info=info, part=part)
@@ -382,7 +423,10 @@ def test_step_info_invalid_custom_args():
 
 def test_step_info_set_project_var():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     part_info = PartInfo(project_info=info, part=part)
@@ -394,7 +438,10 @@ def test_step_info_set_project_var():
 
 def test_step_info_set_project_var_raw_write():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     part_info = PartInfo(project_info=info, part=part)
@@ -421,6 +468,24 @@ def test_step_info_set_project_var_part_name():
 
     x.set_project_var("var", "bar")
     assert x.get_project_var("var", raw_read=True) == "bar"
+
+
+def test_step_info_set_project_var_no_part_name():
+    info = ProjectInfo(
+        application_name="test",
+        cache_dir=Path(),
+        project_vars={"var": "foo"},
+    )
+    part = Part("p1", {})
+    part_info = PartInfo(project_info=info, part=part)
+    x = StepInfo(part_info=part_info, step=Step.PULL)
+
+    with pytest.raises(RuntimeError) as raised:
+        x.set_project_var("var", "bar")
+
+    assert str(raised.value) == (
+        "variable 'var' can only be set in a part that adopts external metadata"
+    )
 
 
 def test_step_info_set_project_var_other_part_name():
@@ -453,7 +518,10 @@ def test_step_info_set_invalid_project_vars():
 
 def test_step_info_get_project_var():
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars_part_name="p1",
+        project_vars={"var": "foo"},
     )
     part = Part("p1", {})
     part_info = PartInfo(project_info=info, part=part)


### PR DESCRIPTION
Restrict variable setting to the part specified when creating the
parts lifecycle. Applications that don't declare project variables
don't need to specify an adopting part.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-963