### PR TITLE
plugins: validate dependencies

### DIFF
--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -17,10 +17,7 @@
 """The Dotnet plugin."""
 
 import logging
-import subprocess
 from typing import Any, Dict, List, Optional, Set, cast
-
-from craft_parts import errors
 
 from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
@@ -65,33 +62,10 @@ class DotPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         """Ensure the environment contains dependencies needed by the plugin.
 
         :param part_dependencies: A list of the parts this part depends on.
-
-        :raises PluginEnvironmentValidationError: If the environment is invalid.
         """
-        try:
-            version = self._execute("dotnet --version").strip()
-            logger.debug("found %s", version)
-        except subprocess.CalledProcessError as err:
-            if err.returncode != validator.COMMAND_NOT_FOUND:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason=f"dotnet failed with error code {err.returncode}",
-                ) from err
-
-            if part_dependencies is None:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason="dotnet not found",
-                ) from err
-
-            if "dotnet" not in part_dependencies:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason=(
-                        f"dotnet not found and part {self._part_name!r} "
-                        f"does not depend on a part named 'dotnet'"
-                    ),
-                ) from err
+        self.validate_dependency(
+            dependency="dotnet", part_dependencies=part_dependencies
+        )
 
 
 class DotnetPlugin(Plugin):

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -19,10 +19,7 @@
 
 import logging
 import shlex
-import subprocess
 from typing import Any, Dict, List, Optional, Set, cast
-
-from craft_parts import errors
 
 from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
@@ -69,34 +66,10 @@ class MesonPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
 
         :raises PluginEnvironmentValidationError: If the environment is invalid.
         """
-        for dep in ["meson", "ninja"]:
-            self._validate_dep(dep, part_dependencies)
-
-    def _validate_dep(self, dep: str, part_dependencies: Optional[List[str]]) -> None:
-        try:
-            version = self._execute(f"{dep} --version").strip()
-            logger.debug("found %s %s", dep, version)
-        except subprocess.CalledProcessError as err:
-            if err.returncode != validator.COMMAND_NOT_FOUND:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason=f"{dep!r} failed with error code {err.returncode}",
-                ) from err
-
-            if part_dependencies is None:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason=f"{dep!r} not found",
-                ) from err
-
-            if dep not in part_dependencies:
-                raise errors.PluginEnvironmentValidationError(
-                    part_name=self._part_name,
-                    reason=(
-                        f"{dep!r} not found and part {self._part_name!r} "
-                        f"does not depend on a part named {dep!r}"
-                    ),
-                ) from err
+        for dependency in ["meson", "ninja"]:
+            self.validate_dependency(
+                dependency=dependency, part_dependencies=part_dependencies
+            )
 
 
 class MesonPlugin(Plugin):

--- a/tests/unit/plugins/test_dotnet_plugin.py
+++ b/tests/unit/plugins/test_dotnet_plugin.py
@@ -69,7 +69,7 @@ def test_validate_environment_missing_dotnet(part_info):
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
-    assert raised.value.reason == "dotnet not found"
+    assert raised.value.reason == "'dotnet' not found"
 
 
 def test_validate_environment_broken_dotnet(broken_dotnet_exe, part_info):
@@ -82,7 +82,7 @@ def test_validate_environment_broken_dotnet(broken_dotnet_exe, part_info):
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
-    assert raised.value.reason == "dotnet failed with error code 33"
+    assert raised.value.reason == "'dotnet' failed with error code 33"
 
 
 def test_validate_environment_with_dotnet_part(part_info):
@@ -102,8 +102,7 @@ def test_validate_environment_without_dotnet_part(part_info):
         validator.validate_environment(part_dependencies=[])
 
     assert raised.value.reason == (
-        "dotnet not found and part 'my-part' "
-        "does not depend on a part named 'dotnet'"
+        "'dotnet' not found and part 'my-part' depends on a part named 'dotnet'"
     )
 
 

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -78,7 +78,7 @@ def test_validate_environment_missing_go(part_info):
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
-    assert raised.value.reason == "go compiler not found"
+    assert raised.value.reason == "'go' not found"
 
 
 def test_validate_environment_broken_go(broken_go_exe, part_info):
@@ -91,7 +91,7 @@ def test_validate_environment_broken_go(broken_go_exe, part_info):
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
-    assert raised.value.reason == "go compiler failed with error code 33"
+    assert raised.value.reason == "'go' failed with error code 33"
 
 
 def test_validate_environment_invalid_go(invalid_go_exe, part_info):
@@ -124,8 +124,7 @@ def test_validate_environment_without_go_part(part_info):
         validator.validate_environment(part_dependencies=[])
 
     assert raised.value.reason == (
-        "go compiler not found and part 'my-part' "
-        "does not depend on a part named 'go'"
+        "'go' not found and part 'my-part' depends on a part named 'go'"
     )
 
 

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -44,15 +44,6 @@ def broken_meson_exe(new_dir):
 
 
 @pytest.fixture
-def invalid_meson_exe(new_dir):
-    meson_bin = Path(new_dir, "mock_bin", "meson")
-    meson_bin.parent.mkdir(exist_ok=True)
-    meson_bin.touch()
-    meson_bin.chmod(0o755)
-    yield meson_bin
-
-
-@pytest.fixture
 def ninja_exe(new_dir):
     ninja_bin = Path(new_dir, "mock_bin", "ninja")
     ninja_bin.parent.mkdir(exist_ok=True)
@@ -66,15 +57,6 @@ def broken_ninja_exe(new_dir):
     ninja_bin = Path(new_dir, "mock_bin", "ninja")
     ninja_bin.parent.mkdir(exist_ok=True)
     ninja_bin.write_text("#!/bin/sh\nexit 33")
-    ninja_bin.chmod(0o755)
-    yield ninja_bin
-
-
-@pytest.fixture
-def invalid_ninja_exe(new_dir):
-    ninja_bin = Path(new_dir, "mock_bin", "ninja")
-    ninja_bin.parent.mkdir(exist_ok=True)
-    ninja_bin.touch()
     ninja_bin.chmod(0o755)
     yield ninja_bin
 
@@ -168,8 +150,7 @@ def test_validate_environment_without_meson_part(part_info):
         validator.validate_environment(part_dependencies=["ninja"])
 
     assert raised.value.reason == (
-        "'meson' not found and part 'my-part' "
-        "does not depend on a part named 'meson'"
+        "'meson' not found and part 'my-part' depends on a part named 'meson'"
     )
 
 
@@ -182,8 +163,7 @@ def test_validate_environment_without_ninja_part(part_info):
         validator.validate_environment(part_dependencies=["meson"])
 
     assert raised.value.reason == (
-        "'ninja' not found and part 'my-part' "
-        "does not depend on a part named 'ninja'"
+        "'ninja' not found and part 'my-part' depends on a part named 'ninja'"
     )
 
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Laying groundwork prior to adding the plugins `conda`, `npm`, and `rust`.

Redundant code for validating plugin dependencies has been normalized in the validator class. (Don't Repeat Yourself)