### PR TITLE
docs: fix typo in lifecycle manager docstrings

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -181,7 +181,7 @@ class LifecycleManager:
         Cleaning a step removes its state and all artifacts generated in that
         step and subsequent steps for the specified parts.
 
-        :para step: The step to clean. If not specified, all steps will be
+        :param step: The step to clean. If not specified, all steps will be
             cleaned.
         :param part_names: The list of part names to clean. If not specified,
             all parts will be cleaned and work directories will be removed.


### PR DESCRIPTION
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
