### PR TITLE
sources: remove provisioning option to clean target

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -914,7 +914,7 @@ class PartHandler:
         )
 
         for snap_source in snap_sources:
-            snap_source.provision(install_dir, clean_target=False, keep=True)
+            snap_source.provision(install_dir, keep=True)
 
 
 def _remove(filename: Path) -> None:

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence
 
 import requests
+from overrides import overrides
 
 from craft_parts.dirs import ProjectDirs
 from craft_parts.utils import os_utils, url_utils
@@ -168,12 +169,12 @@ class FileSourceHandler(SourceHandler):
     def provision(
         self,
         dst: Path,
-        clean_target: bool = True,
         keep: bool = False,
         src: Optional[Path] = None,
     ) -> None:
         """Process the source file to extract its payload."""
 
+    @overrides
     def pull(self) -> None:
         """Retrieve this source from its origin."""
         source_file = None
@@ -197,9 +198,7 @@ class FileSourceHandler(SourceHandler):
         if self.source_checksum:
             verify_checksum(self.source_checksum, source_file)
 
-        # We finally provision, but we don't clean the target so override-pull
-        # can actually have meaning when using these sources.
-        self.provision(self.part_src_dir, src=source_file, clean_target=False)
+        self.provision(self.part_src_dir, src=source_file)
 
     def download(self, filepath: Optional[Path] = None) -> Path:
         """Download the URL from a remote location.

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -22,6 +22,8 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+from overrides import overrides
+
 from craft_parts.dirs import ProjectDirs
 
 from . import errors
@@ -248,6 +250,7 @@ class GitSource(SourceHandler):
         """Verify whether the git repository is on the local filesystem."""
         return Path(self.part_src_dir, ".git").exists()
 
+    @overrides
     def pull(self) -> None:
         """Retrieve the local or remote source files."""
         if self.is_local():

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -24,6 +24,8 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
+from overrides import overrides
+
 from craft_parts.utils import file_utils
 
 from .base import SourceHandler
@@ -61,6 +63,7 @@ class LocalSource(SourceHandler):
         self._updated_files = set()
         self._updated_directories = set()
 
+    @overrides
     def pull(self):
         """Retrieve the local source files."""
         file_utils.link_or_copy_tree(
@@ -70,6 +73,7 @@ class LocalSource(SourceHandler):
             copy_function=self.copy_function,
         )
 
+    @overrides
     def check_if_outdated(
         self, target: str, *, ignore_files: Optional[List[str]] = None
     ) -> bool:
@@ -127,6 +131,7 @@ class LocalSource(SourceHandler):
 
         return len(self._updated_files) > 0 or len(self._updated_directories) > 0
 
+    @overrides
     def update(self):
         """Update pulled source.
 

--- a/craft_parts/sources/snap_source.py
+++ b/craft_parts/sources/snap_source.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from overrides import overrides
 
 from craft_parts.dirs import ProjectDirs
 from craft_parts.utils import file_utils
@@ -77,17 +78,16 @@ class SnapSource(FileSourceHandler):
         if source_depth:
             raise errors.InvalidSourceOption(source_type="snap", option="source-depth")
 
+    @overrides
     def provision(
         self,
         dst: Path,
-        clean_target: bool = True,
         keep: bool = False,
         src: Optional[Path] = None,
     ) -> None:
         """Provision the snap source.
 
         :param dst: The destination directory to provision to.
-        :param clean_target: Whether to clean dst before provisioning.
         :param keep: Whether to keep the snap after provisioning is complete.
         :param src: Force a new source to use for extraction.
 
@@ -98,14 +98,6 @@ class SnapSource(FileSourceHandler):
         else:
             snap_file = self.part_src_dir / os.path.basename(self.source)
         snap_file = snap_file.resolve()
-
-        if clean_target:
-            with tempfile.NamedTemporaryFile() as tmp_file:
-                tmp_snap = tmp_file.name
-                shutil.move(str(snap_file), tmp_snap)  # path-like arg requires 3.9
-                shutil.rmtree(dst)
-                os.makedirs(dst)
-                shutil.move(tmp_snap, str(snap_file))
 
         # unsquashfs [options] filesystem [directories or files to extract]
         # options:

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -18,11 +18,11 @@
 
 import os
 import re
-import shutil
 import tarfile
-import tempfile
 from pathlib import Path
 from typing import List, Optional
+
+from overrides import overrides
 
 from craft_parts.dirs import ProjectDirs
 
@@ -74,10 +74,10 @@ class TarSource(FileSourceHandler):
         if source_depth:
             raise errors.InvalidSourceOption(source_type="tar", option="source-depth")
 
+    @overrides
     def provision(
         self,
         dst: Path,
-        clean_target: bool = True,
         keep: bool = False,
         src: Optional[Path] = None,
     ):
@@ -87,14 +87,6 @@ class TarSource(FileSourceHandler):
             tarball = src
         else:
             tarball = self.part_src_dir / os.path.basename(self.source)
-
-        if clean_target:
-            with tempfile.NamedTemporaryFile() as tmp_file:
-                tmp_tarball = tmp_file.name
-                shutil.move(str(tarball), tmp_tarball)
-                shutil.rmtree(dst)
-                os.makedirs(dst)
-                shutil.move(tmp_tarball, tarball)
 
         _extract(tarball, dst)
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 install_requires = [
+    "overrides",
     "PyYAML",
     "pydantic",
     "pydantic-yaml",

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -914,7 +914,6 @@ class TestPackages:
         handler._unpack_stage_snaps()
         mock_snap_provision.assert_called_once_with(
             new_dir / "parts/p1/install",
-            clean_target=False,
             keep=True,
         )
 

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
+from overrides import overrides
 
 from craft_parts.sources import cache, errors
 from craft_parts.sources.base import FileSourceHandler, SourceHandler
@@ -80,16 +81,15 @@ class TestSourceHandler:
 class BarFileSource(FileSourceHandler):
     """A file source handler."""
 
+    @overrides
     def provision(
         self,
         dst: Path,
-        clean_target: bool = True,
         keep: bool = False,
         src: Optional[Path] = None,
     ) -> None:
         """Extract source payload."""
         self.provision_dst = dst
-        self.provision_clean_target = clean_target
         self.provision_keep = keep
         self.provision_src = src
 
@@ -123,7 +123,6 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert self.source.provision_dst == Path("parts/foo/src")
-        assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
         assert self.source.provision_src == Path("parts/foo/src/my_file")
 
@@ -147,7 +146,6 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert self.source.provision_dst == Path("parts/foo/src")
-        assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
         assert self.source.provision_src == Path("parts/foo/src/my_file")
 
@@ -175,7 +173,6 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert self.source.provision_dst == Path("parts/foo/src")
-        assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
         assert self.source.provision_src == Path("parts/foo/src/some_file")
 
@@ -191,7 +188,6 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert self.source.provision_dst == Path("parts/foo/src")
-        assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
         assert self.source.provision_src == Path("parts/foo/src/some_file")
 
@@ -217,7 +213,6 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert self.source.provision_dst == Path("parts/foo/src")
-        assert self.source.provision_clean_target is False
         assert self.source.provision_keep is False
         assert self.source.provision_src == Path("parts/foo/src/some_file")
 

--- a/tests/unit/sources/test_snap_source.py
+++ b/tests/unit/sources/test_snap_source.py
@@ -59,19 +59,6 @@ class TestSnapSource:
         assert Path(self._dest_dir / "meta.basic").is_dir()
         assert Path(self._dest_dir / "meta.basic/snap.yaml").is_file()
 
-    def test_pull_snap_must_not_clean_targets(self, new_dir, mocker):
-        mock_provision = mocker.patch.object(sources.SnapSource, "provision")
-        source = sources.SnapSource(
-            str(self._test_file), self._dest_dir, cache_dir=new_dir
-        )
-        source.pull()
-
-        mock_provision.assert_called_once_with(
-            self._dest_dir,
-            clean_target=False,
-            src=self._dest_dir / "test-snap.snap",
-        )
-
     def test_has_source_handler_entry_on_linux(self):
         if sys.platform == "linux":
             assert sources._source_handler["snap"] is sources.SnapSource

--- a/tests/unit/sources/test_tar_source.py
+++ b/tests/unit/sources/test_tar_source.py
@@ -48,7 +48,7 @@ class TestTarSource:
         tar_source.pull()
 
         source_file = dest_dir / tar_file_name
-        mock_prov.assert_called_once_with(dest_dir, src=source_file, clean_target=False)
+        mock_prov.assert_called_once_with(dest_dir, src=source_file)
         with open(os.path.join(dest_dir, tar_file_name), "r") as tar_file:
             assert tar_file.read() == "Test fake file"
 


### PR DESCRIPTION
Target cleaning was used in snapcraft only for plugins v1 and is not
used in craft_parts, so remove the option to simplify source handlers.
Existing target cleaning implementation was also flawed, see
https://github.com/python/cpython/issues/73759.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
