### PR TITLE
sources: add zip file source handler

### DIFF
--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -91,6 +91,7 @@ from .git_source import GitSource
 from .local_source import LocalSource
 from .snap_source import SnapSource
 from .tar_source import TarSource
+from .zip_source import ZipSource
 
 if TYPE_CHECKING:
     from craft_parts.parts import Part
@@ -103,6 +104,7 @@ _source_handler: Dict[str, SourceHandlerType] = {
     "tar": TarSource,
     "git": GitSource,
     "snap": SnapSource,
+    "zip": ZipSource,
 }
 
 

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -30,10 +30,10 @@ from . import errors
 from .base import FileSourceHandler
 
 
-# pylint: disable=too-many-arguments
 class TarSource(FileSourceHandler):
     """The tar source handler."""
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         source: str,
@@ -74,6 +74,8 @@ class TarSource(FileSourceHandler):
         if source_depth:
             raise errors.InvalidSourceOption(source_type="tar", option="source-depth")
 
+    # pylint: enable=too-many-arguments
+
     @overrides
     def provision(
         self,
@@ -82,7 +84,6 @@ class TarSource(FileSourceHandler):
         src: Optional[Path] = None,
     ):
         """Extract tarball contents to the part source dir."""
-        # TODO add unit tests.
         if src:
             tarball = src
         else:

--- a/craft_parts/sources/zip_source.py
+++ b/craft_parts/sources/zip_source.py
@@ -1,0 +1,107 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Implement the zip file source handler."""
+
+import os
+import zipfile
+from pathlib import Path
+from typing import List, Optional
+
+from craft_parts.dirs import ProjectDirs
+
+from . import errors
+from .base import FileSourceHandler
+
+
+class ZipSource(FileSourceHandler):
+    """The zip file source handler."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        source: str,
+        part_src_dir: Path,
+        *,
+        cache_dir: Path,
+        source_tag: Optional[str] = None,
+        source_branch: Optional[str] = None,
+        source_commit: Optional[str] = None,
+        source_depth: Optional[int] = None,
+        source_checksum: Optional[str] = None,
+        source_submodules: Optional[List[str]] = None,
+        project_dirs: Optional[ProjectDirs] = None,
+        ignore_patterns: Optional[List[str]] = None,
+    ):
+        super().__init__(
+            source,
+            part_src_dir,
+            cache_dir=cache_dir,
+            source_tag=source_tag,
+            source_branch=source_branch,
+            source_commit=source_commit,
+            source_depth=source_depth,
+            source_checksum=source_checksum,
+            source_submodules=source_submodules,
+            project_dirs=project_dirs,
+            ignore_patterns=ignore_patterns,
+        )
+        if source_tag:
+            raise errors.InvalidSourceOption(source_type="zip", option="source-tag")
+
+        if source_commit:
+            raise errors.InvalidSourceOption(source_type="zip", option="source-commit")
+
+        if source_branch:
+            raise errors.InvalidSourceOption(source_type="zip", option="source-branch")
+
+        if source_depth:
+            raise errors.InvalidSourceOption(source_type="zip", option="source-depth")
+
+    # pylint: enable=too-many-arguments
+
+    def provision(
+        self,
+        dst: Path,
+        keep: bool = False,
+        src: Optional[Path] = None,
+    ):
+        """Extract zip file contents to the part source dir."""
+        if src:
+            zip_file = src
+        else:
+            zip_file = self.part_src_dir / os.path.basename(self.source)
+
+        # Workaround for: https://bugs.python.org/issue15795
+        with zipfile.ZipFile(zip_file, "r") as zipf:
+            for info in zipf.infolist():
+                extracted_file = zipf.extract(info.filename, path=dst)
+
+                # Extract the mode from the file. Note that external_attr is
+                # a four-byte value, where the high two bytes represent UNIX
+                # permissions and file type bits, and the low two bytes contain
+                # MS-DOS FAT file attributes. Keep the mode to permissions
+                # only-- no sticky bit, uid bit, or gid bit.
+                mode = info.external_attr >> 16 & 0x1FF
+
+                # If the zip file was created on a non-unix system, it's
+                # possible for the mode to end up being zero. That makes it
+                # pretty useless, so ignore it if so.
+                if mode:
+                    os.chmod(extracted_file, mode)
+
+        if not keep:
+            os.remove(zip_file)

--- a/tests/integration/sources/test_zip.py
+++ b/tests/integration/sources/test_zip.py
@@ -1,0 +1,74 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Action, Step
+
+
+def test_source_zip(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: make
+            source: foobar.zip
+        """
+    )
+
+    Path("foobar.txt").write_text("content")
+    with zipfile.ZipFile("foobar.zip", "w") as zipf:
+        zipf.write("foobar.txt")
+
+    parts = yaml.safe_load(_parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_zip", cache_dir=new_dir
+    )
+
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    foo_src_dir = Path("parts", "foo", "src")
+    assert list(foo_src_dir.rglob("*")) == [foo_src_dir / "foobar.txt"]
+    assert Path(foo_src_dir, "foobar.txt").read_text() == "content"
+
+
+def test_source_zip_error(new_dir):
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: make
+            source: foobar.zip
+        """
+    )
+
+    parts = yaml.safe_load(_parts_yaml)
+    Path("foobar.zip").write_text("not a zip file")
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_zip", cache_dir=new_dir
+    )
+
+    with pytest.raises(zipfile.BadZipFile) as raised, lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    assert str(raised.value) == "File is not a zip file"

--- a/tests/unit/sources/test_tar_source.py
+++ b/tests/unit/sources/test_tar_source.py
@@ -17,6 +17,7 @@
 import os
 import tarfile
 from pathlib import Path
+from unittest.mock import call
 
 import pytest
 import requests
@@ -33,11 +34,9 @@ class TestTarSource:
     ):
         mock_prov = mocker.patch("craft_parts.sources.tar_source.TarSource.provision")
 
-        plugin_name = "test_plugin"
-        dest_dir = Path("parts", plugin_name, "src")
+        dest_dir = Path("parts/foo/src")
         dest_dir.mkdir(parents=True)
         tar_file_name = "test.tar"
-        print(type(http_server.server_address))
         source = (
             f"http://{http_server.server_address[0]}:"
             f"{http_server.server_address[1]}/{tar_file_name}"
@@ -48,8 +47,9 @@ class TestTarSource:
         tar_source.pull()
 
         source_file = dest_dir / tar_file_name
-        mock_prov.assert_called_once_with(dest_dir, src=source_file)
-        with open(os.path.join(dest_dir, tar_file_name), "r") as tar_file:
+        assert mock_prov.mock_calls == [call(dest_dir, src=source_file)]
+
+        with (dest_dir / tar_file_name).open("r") as tar_file:
             assert tar_file.read() == "Test fake file"
 
     def test_pull_twice_downloads_once(self, new_dir, mocker, http_server):

--- a/tests/unit/sources/test_zip_source.py
+++ b/tests/unit/sources/test_zip_source.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from unittest.mock import call
+
+import pytest
+
+from craft_parts.sources import sources
+
+
+@pytest.mark.http_request_handler("FakeFileHTTPRequestHandler")
+class TestZipSource:
+    """Tests for the zip source handler."""
+
+    def test_pull_zipfile_must_download_and_extract(self, new_dir, http_server, mocker):
+        mock_prov = mocker.patch("craft_parts.sources.zip_source.ZipSource.provision")
+
+        dest_dir = Path("src")
+        dest_dir.mkdir()
+        zip_file_name = "test.zip"
+        source = (
+            f"http://{http_server.server_address[0]}:"
+            f"{http_server.server_address[1]}/{zip_file_name}"
+        )
+        zip_source = sources.ZipSource(source, dest_dir, cache_dir=new_dir)
+
+        zip_source.pull()
+
+        source_file = dest_dir / zip_file_name
+        assert mock_prov.mock_calls == [call(dest_dir, src=source_file)]
+
+        with (dest_dir / zip_file_name).open("r") as zip_file:
+            assert zip_file.read() == "Test fake file"
+
+    def test_extract_and_keep_zipfile(self, new_dir, http_server, mocker):
+        mock_zip = mocker.patch("zipfile.ZipFile")
+
+        zip_file_name = "test.zip"
+        source = (
+            f"http://{http_server.server_address[0]}:"
+            f"{http_server.server_address[1]}/{zip_file_name}"
+        )
+        dest_dir = Path().absolute()
+        zip_source = sources.ZipSource(source, dest_dir, cache_dir=new_dir)
+
+        zip_source.download()
+        zip_source.provision(dst=dest_dir, keep=True)
+
+        source_file = zip_source.part_src_dir / zip_file_name
+        mock_zip.assert_called_once_with(source_file, "r")
+
+        with source_file.open("r") as zip_file:
+            assert zip_file.read() == "Test fake file"
+
+    def test_has_source_handler_entry(self):
+        assert sources._source_handler["zip"] is sources.ZipSource


### PR DESCRIPTION
Allow parts to specify zip files as sources.

Co-authored-by: Kyle Fazzari <kyle@canonical.com>
Co-authored-by: Sergio Schvezov <sergio.schvezov@canonical.com>
Co-authored-by: Marius Gripsgard <marius@ubports.com>
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
