### PR TITLE
docs: fix readthedocs documentation generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.8"
+  apt_packages:
+    - libapt-pkg-dev
 
 formats:
   - pdf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,12 @@ final artifacts.
    reference
 
 
+.. toctree::
+   :caption About the project
+
+   changelog
+
+
 Indices and tables
 ==================
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
+wheel
+setuptools
+python-distutils-extra @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz
+python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz
 Sphinx==4.2.0
 sphinx-autodoc-typehints==1.12.0
 sphinx-jsonschema==1.16.11

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,12 @@
 
 """The setup script."""
 
+import os
+
 from setuptools import find_packages, setup  # type: ignore
+
+with open("README.md") as readme_file:
+    readme = readme_file.read()
 
 
 def is_ubuntu() -> bool:
@@ -29,8 +34,10 @@ def is_ubuntu() -> bool:
         return False
 
 
-with open("README.md") as readme_file:
-    readme = readme_file.read()
+def is_rtd() -> bool:
+    """Verify if running on ReadTheDocs."""
+    return "READTHEDOCS" in os.environ
+
 
 install_requires = [
     "overrides",
@@ -43,10 +50,11 @@ install_requires = [
 ]
 
 
-if is_ubuntu():
+if is_ubuntu() and not is_rtd():
     install_requires += [
         "python-apt",
     ]
+
 
 dev_requires = [
     "autoflake",


### PR DESCRIPTION
Install missing packages in readthedocs environment and add changelog
to the documentation index.

Removing python-apt from setup packages was also required because the
version of python-apt in PyPI is outdated and readthedocs tries to
install it over the existing version previously installed from sources.
This shouldn't be a problem because applications are also required to
install python-apt.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
