### PR TITLE
executor: enable application-defined environment variables

### DIFF
--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -20,7 +20,7 @@ import io
 import logging
 from typing import Dict, Iterable
 
-from craft_parts.infos import StepInfo
+from craft_parts.infos import ProjectInfo, StepInfo
 from craft_parts.parts import Part
 from craft_parts.plugins import Plugin
 from craft_parts.steps import Step
@@ -41,20 +41,16 @@ def generate_step_environment(
     :return: The environment to use when executing the step.
     """
     # Craft parts' say.
-    our_build_environment = _basic_environment_for_part(part=part, step_info=step_info)
-
-    step = step_info.step
+    parts_environment = _basic_environment_for_part(part=part, step_info=step_info)
 
     # Plugin's say.
-    if step == Step.BUILD:
+    if step_info.step == Step.BUILD:
         plugin_environment = plugin.get_build_environment()
     else:
         plugin_environment = {}
 
     # Part's (user) say.
-    user_build_environment = part.spec.build_environment
-    if not user_build_environment:
-        user_build_environment = []
+    user_environment = part.spec.build_environment or []
 
     # Create the script.
     with io.StringIO() as run_environment:
@@ -63,16 +59,22 @@ def generate_step_environment(
 
         print("# Environment", file=run_environment)
 
-        print("## Part Environment", file=run_environment)
-        for key, val in our_build_environment.items():
+        print("## Part environment", file=run_environment)
+        for key, val in parts_environment.items():
             print(f'export {key}="{val}"', file=run_environment)
 
-        print("## Plugin Environment", file=run_environment)
+        print("## Plugin environment", file=run_environment)
         for key, val in plugin_environment.items():
             print(f'export {key}="{val}"', file=run_environment)
 
-        print("## User Environment", file=run_environment)
-        for env in user_build_environment:
+        print("## Application environment", file=run_environment)
+        for key, val in step_info.global_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+        for key, val in step_info.step_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+
+        print("## User environment", file=run_environment)
+        for env in user_environment:
             for key, val in env.items():
                 print(f'export {key}="{val}"', file=run_environment)
 
@@ -88,7 +90,8 @@ def _basic_environment_for_part(part: Part, *, step_info: StepInfo) -> Dict[str,
 
     :return: A dictionary containing the built-in environment.
     """
-    part_environment: Dict[str, str] = _get_step_environment(step_info)
+    part_environment: Dict[str, str] = _get_global_environment(step_info.project_info)
+    part_environment.update(_get_step_environment(step_info))
     paths = [part.part_install_dir, part.stage_dir]
 
     bin_paths = []
@@ -140,6 +143,28 @@ def _basic_environment_for_part(part: Part, *, step_info: StepInfo) -> Dict[str,
     return part_environment
 
 
+def _get_global_environment(info: ProjectInfo) -> Dict[str, str]:
+    """Add project and part information variables to the environment.
+
+    :param step_info: Information about the current step.
+
+    :return: A dictionary containing environment variables and values.
+    """
+    global_environment = {
+        "CRAFT_ARCH_TRIPLET": info.arch_triplet,
+        "CRAFT_TARGET_ARCH": info.target_arch,
+        "CRAFT_PARALLEL_BUILD_COUNT": str(info.parallel_build_count),
+        "CRAFT_PROJECT_DIR": str(info.project_dir),
+        "CRAFT_OVERLAY": str(info.overlay_mount_dir),
+        "CRAFT_STAGE": str(info.stage_dir),
+        "CRAFT_PRIME": str(info.prime_dir),
+    }
+    if info.project_name is not None:
+        global_environment["CRAFT_PROJECT_NAME"] = str(info.project_name)
+
+    return global_environment
+
+
 def _get_step_environment(step_info: StepInfo) -> Dict[str, str]:
     """Add project and part information variables to the environment.
 
@@ -148,23 +173,14 @@ def _get_step_environment(step_info: StepInfo) -> Dict[str, str]:
     :return: A dictionary containing environment variables and values.
     """
     step_environment = {
-        "CRAFT_ARCH_TRIPLET": step_info.arch_triplet,
-        "CRAFT_TARGET_ARCH": step_info.target_arch,
-        "CRAFT_PARALLEL_BUILD_COUNT": str(step_info.parallel_build_count),
-        "CRAFT_PROJECT_DIR": str(step_info.project_dir),
         "CRAFT_PART_NAME": step_info.part_name,
+        "CRAFT_STEP_NAME": getattr(step_info.step, "name", ""),
         "CRAFT_PART_SRC": str(step_info.part_src_dir),
         "CRAFT_PART_SRC_WORK": str(step_info.part_src_subdir),
         "CRAFT_PART_BUILD": str(step_info.part_build_dir),
         "CRAFT_PART_BUILD_WORK": str(step_info.part_build_subdir),
         "CRAFT_PART_INSTALL": str(step_info.part_install_dir),
-        "CRAFT_OVERLAY": str(step_info.overlay_mount_dir),
-        "CRAFT_STAGE": str(step_info.stage_dir),
-        "CRAFT_PRIME": str(step_info.prime_dir),
     }
-    if step_info.project_name is not None:
-        step_environment["CRAFT_PROJECT_NAME"] = str(step_info.project_name)
-
     return step_environment
 
 

--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -90,8 +90,7 @@ def _basic_environment_for_part(part: Part, *, step_info: StepInfo) -> Dict[str,
 
     :return: A dictionary containing the built-in environment.
     """
-    part_environment: Dict[str, str] = _get_global_environment(step_info.project_info)
-    part_environment.update(_get_step_environment(step_info))
+    part_environment = _get_step_environment(step_info)
     paths = [part.part_install_dir, part.stage_dir]
 
     bin_paths = []
@@ -172,7 +171,10 @@ def _get_step_environment(step_info: StepInfo) -> Dict[str, str]:
 
     :return: A dictionary containing environment variables and values.
     """
+    global_environment = _get_global_environment(step_info.project_info)
+
     step_environment = {
+        **global_environment,
         "CRAFT_PART_NAME": step_info.part_name,
         "CRAFT_STEP_NAME": getattr(step_info.step, "name", ""),
         "CRAFT_PART_SRC": str(step_info.part_src_dir),

--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -59,18 +59,18 @@ def generate_step_environment(
 
         print("# Environment", file=run_environment)
 
+        print("## Application environment", file=run_environment)
+        for key, val in step_info.global_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+        for key, val in step_info.step_environment.items():
+            print(f'export {key}="{val}"', file=run_environment)
+
         print("## Part environment", file=run_environment)
         for key, val in parts_environment.items():
             print(f'export {key}="{val}"', file=run_environment)
 
         print("## Plugin environment", file=run_environment)
         for key, val in plugin_environment.items():
-            print(f'export {key}="{val}"', file=run_environment)
-
-        print("## Application environment", file=run_environment)
-        for key, val in step_info.global_environment.items():
-            print(f'export {key}="{val}"', file=run_environment)
-        for key, val in step_info.step_environment.items():
             print(f'export {key}="{val}"', file=run_environment)
 
         print("## User environment", file=run_environment)

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -93,6 +93,7 @@ class PartHandler:
         self._part_list = part_list
         self._overlay_manager = overlay_manager
         self._base_layer_hash = base_layer_hash
+        self._app_environment: Dict[str, str] = {}
 
         self._plugin = plugins.get_plugin(
             part=part,

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import subprocess
-import sys
 import tempfile
 import textwrap
 import time
@@ -212,21 +211,15 @@ class StepHandler:
             )
 
             script = textwrap.dedent(
-                """\
-                set -e
-                export PARTS_CALL_FIFO={call_fifo}
-                export PARTS_FEEDBACK_FIFO={feedback_fifo}
+                f"""\
+                set -euo pipefail
+                export PARTS_CALL_FIFO={call_fifo.path}
+                export PARTS_FEEDBACK_FIFO={feedback_fifo.path}
 
-                {env}
+                {self._env}
 
                 set -x
                 {scriptlet}"""
-            ).format(
-                interpreter=sys.executable,
-                call_fifo=call_fifo.path,
-                feedback_fifo=feedback_fifo.path,
-                scriptlet=scriptlet,
-                env=self._env,
             )
 
             # FIXME: refactor ctl protocol server

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -93,6 +93,7 @@ class ProjectInfo:
         self._project_vars_part_name = project_vars_part_name
         self._project_vars = {k: ProjectVar(value=v) for k, v in pvars.items()}
         self._custom_args = custom_args
+        self.global_environment: Dict[str, str] = {}
 
         self.execution_finished = False
 
@@ -294,6 +295,11 @@ class PartInfo:
         raise AttributeError(f"{self.__class__.__name__!r} has no attribute {name!r}")
 
     @property
+    def project_info(self) -> ProjectInfo:
+        """Return the project information."""
+        return self._project_info
+
+    @property
     def part_name(self) -> str:
         """Return the name of the part we're providing information about."""
         return self._part_name
@@ -379,6 +385,7 @@ class StepInfo:
     ):
         self._part_info = part_info
         self.step = step
+        self.step_environment: Dict[str, str] = {}
 
     def __getattr__(self, name):
         if hasattr(self._part_info, name):

--- a/tests/integration/executor/test_environment.py
+++ b/tests/integration/executor/test_environment.py
@@ -1,0 +1,163 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import textwrap
+from typing import List
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Action, Part, ProjectInfo, Step, StepInfo, callbacks
+
+
+def setup_function():
+    callbacks.unregister_all()
+
+
+def teardown_module():
+    callbacks.unregister_all()
+
+
+@pytest.fixture(autouse=True)
+def mock_mount_unmount(mocker):
+    mocker.patch("craft_parts.utils.os_utils.mount")
+    mocker.patch("craft_parts.utils.os_utils.mount_overlayfs")
+    mocker.patch("craft_parts.utils.os_utils.umount")
+
+
+@pytest.fixture(autouse=True)
+def mock_prerequisites_for_overlay(mocker):
+    mocker.patch("craft_parts.lifecycle_manager._ensure_overlay_supported")
+    mocker.patch("craft_parts.overlays.OverlayManager.refresh_packages_list")
+
+
+def _prologue_callback(info: ProjectInfo, part_list: List[Part]) -> None:
+    info.global_environment["TEST_GLOBAL"] = "prologue"
+
+
+def _step_callback(info: StepInfo) -> bool:
+    info.step_environment.update(
+        {
+            "TEST_OVERRIDE": "foo",
+            "TEST_STEP": str(info.step),
+        }
+    )
+    return True
+
+
+_parts_yaml = textwrap.dedent(
+    """\
+    parts:
+      foo:
+        plugin: nil
+        override-pull: env | egrep "^(TEST|CRAFT)_" | sort
+        overlay-script: env | egrep "^(TEST|CRAFT)_" | sort
+        override-build: env | egrep "^(TEST|CRAFT)_" | sort
+        override-stage: env | egrep "^(TEST|CRAFT)_" | sort
+        override-prime: env | egrep "^(TEST|CRAFT)_" | sort
+        build-environment:
+          - TEST_OVERRIDE: bar
+    """
+)
+
+
+@pytest.mark.parametrize("step", list(Step))
+def test_step_callback(new_dir, mocker, capfd, step):
+    mocker.patch("platform.machine", return_value="aarch64")
+
+    callbacks.register_pre_step(_step_callback, step_list=[step])
+
+    parts = yaml.safe_load(_parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_step_callback",
+        cache_dir=new_dir,
+        work_dir=new_dir,
+        base_layer_dir=new_dir,
+        base_layer_hash=b"hash",
+    )
+
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", step))
+
+    out, err = capfd.readouterr()
+    assert out == (
+        textwrap.dedent(
+            f"""\
+            CRAFT_ARCH_TRIPLET=aarch64-linux-gnu
+            CRAFT_OVERLAY={new_dir}/overlay/overlay
+            CRAFT_PARALLEL_BUILD_COUNT=1
+            CRAFT_PART_BUILD={new_dir}/parts/foo/build
+            CRAFT_PART_BUILD_WORK={new_dir}/parts/foo/build
+            CRAFT_PART_INSTALL={new_dir}/parts/foo/install
+            CRAFT_PART_NAME=foo
+            CRAFT_PART_SRC={new_dir}/parts/foo/src
+            CRAFT_PART_SRC_WORK={new_dir}/parts/foo/src
+            CRAFT_PRIME={new_dir}/prime
+            CRAFT_PROJECT_DIR={os.getcwd()}
+            CRAFT_STAGE={new_dir}/stage
+            CRAFT_STEP_NAME={Step(step).name}
+            CRAFT_TARGET_ARCH=arm64
+            TEST_OVERRIDE=bar
+            TEST_STEP={step!s}
+            """
+        )
+    )
+
+
+def test_prologue_callback(new_dir, capfd, mocker):
+    mocker.patch("platform.machine", return_value="aarch64")
+
+    callbacks.register_prologue(_prologue_callback)
+
+    parts = yaml.safe_load(_parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_prologue_callback",
+        cache_dir=new_dir,
+        work_dir=new_dir,
+        base_layer_dir=new_dir,
+        base_layer_hash=b"hash",
+    )
+
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    out, err = capfd.readouterr()
+    assert out == (
+        textwrap.dedent(
+            f"""\
+            CRAFT_ARCH_TRIPLET=aarch64-linux-gnu
+            CRAFT_OVERLAY={new_dir}/overlay/overlay
+            CRAFT_PARALLEL_BUILD_COUNT=1
+            CRAFT_PART_BUILD={new_dir}/parts/foo/build
+            CRAFT_PART_BUILD_WORK={new_dir}/parts/foo/build
+            CRAFT_PART_INSTALL={new_dir}/parts/foo/install
+            CRAFT_PART_NAME=foo
+            CRAFT_PART_SRC={new_dir}/parts/foo/src
+            CRAFT_PART_SRC_WORK={new_dir}/parts/foo/src
+            CRAFT_PRIME={new_dir}/prime
+            CRAFT_PROJECT_DIR={os.getcwd()}
+            CRAFT_STAGE={new_dir}/stage
+            CRAFT_STEP_NAME=PULL
+            CRAFT_TARGET_ARCH=arm64
+            TEST_GLOBAL=prologue
+            TEST_OVERRIDE=bar
+            """
+        )
+    )

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -97,6 +97,9 @@ def test_generate_step_environment_build(new_dir):
         #!/bin/bash
         set -euo pipefail
         # Environment
+        ## Application environment
+        export APP_GLOBAL_ENVVAR="from_app"
+        export APP_STEP_ENVVAR="from_app"
         ## Part environment
         export CRAFT_ARCH_TRIPLET="aarch64-linux-gnu"
         export CRAFT_TARGET_ARCH="arm64"
@@ -120,9 +123,6 @@ def test_generate_step_environment_build(new_dir):
         export LDFLAGS="-L{new_dir}/stage/lib -L{new_dir}/stage/usr/lib -L{new_dir}/stage/lib/aarch64-linux-gnu"
         export PKG_CONFIG_PATH="{new_dir}/stage/usr/share/pkgconfig"
         ## Plugin environment
-        ## Application environment
-        export APP_GLOBAL_ENVVAR="from_app"
-        export APP_STEP_ENVVAR="from_app"
         ## User environment
         export PART_ENVVAR="from_part"
         """
@@ -150,6 +150,7 @@ def test_generate_step_environment_no_project_name(new_dir):
         #!/bin/bash
         set -euo pipefail
         # Environment
+        ## Application environment
         ## Part environment
         export CRAFT_ARCH_TRIPLET="aarch64-linux-gnu"
         export CRAFT_TARGET_ARCH="arm64"
@@ -173,7 +174,6 @@ def test_generate_step_environment_no_project_name(new_dir):
         export PKG_CONFIG_PATH="{new_dir}/stage/usr/share/pkgconfig"
         ## Plugin environment
         export PLUGIN_ENVVAR="from_plugin"
-        ## Application environment
         ## User environment
         export PART_ENVVAR="from_part"
         """
@@ -203,6 +203,7 @@ def test_generate_step_environment_no_build(new_dir, step):
         #!/bin/bash
         set -euo pipefail
         # Environment
+        ## Application environment
         ## Part environment
         export CRAFT_ARCH_TRIPLET="aarch64-linux-gnu"
         export CRAFT_TARGET_ARCH="arm64"
@@ -226,7 +227,6 @@ def test_generate_step_environment_no_build(new_dir, step):
         export LDFLAGS="-L{new_dir}/stage/lib -L{new_dir}/stage/usr/lib -L{new_dir}/stage/lib/aarch64-linux-gnu"
         export PKG_CONFIG_PATH="{new_dir}/stage/usr/share/pkgconfig"
         ## Plugin environment
-        ## Application environment
         ## User environment
         export PART_ENVVAR="from_part"
         """
@@ -255,6 +255,7 @@ def test_generate_step_environment_no_user_env(new_dir):
         #!/bin/bash
         set -euo pipefail
         # Environment
+        ## Application environment
         ## Part environment
         export CRAFT_ARCH_TRIPLET="aarch64-linux-gnu"
         export CRAFT_TARGET_ARCH="arm64"
@@ -278,7 +279,6 @@ def test_generate_step_environment_no_user_env(new_dir):
         export LDFLAGS="-L{new_dir}/stage/lib -L{new_dir}/stage/usr/lib -L{new_dir}/stage/lib/aarch64-linux-gnu"
         export PKG_CONFIG_PATH="{new_dir}/stage/usr/share/pkgconfig"
         ## Plugin environment
-        ## Application environment
         ## User environment
         """
     )

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -69,6 +69,7 @@ def test_project_info(mocker, new_dir, tc_arch, tc_target_arch, tc_triplet, tc_c
         "project_vars_part_name": "adopt",
         "project_vars": {"a": ProjectVar(value="b")},
     }
+    assert x.global_environment == {}
 
     assert x.parts_dir == new_dir / "parts"
     assert x.stage_dir == new_dir / "stage"
@@ -277,6 +278,7 @@ def test_part_info(new_dir):
     assert x.cache_dir == new_dir
     assert x.project_name == "project"
     assert x.parallel_build_count == 1
+    assert x.global_environment == {}
 
     assert x.part_name == "foo"
     assert x.part_src_dir == new_dir / "parts/foo/src"
@@ -439,6 +441,8 @@ def test_step_info(new_dir):
     assert x.prime_dir == new_dir / "prime"
 
     assert x.step == Step.BUILD
+    assert x.global_environment == {}
+    assert x.step_environment == {}
 
     assert x.custom_args == ["custom1", "custom2"]
     assert x.custom1 == "foobar"


### PR DESCRIPTION
Allow application-defined variables to be used during step scriptlet
execution. Applications can use the pre-step callback to set step
environment variables or the prologue callback to set global environment
variables.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1070