### PR TITLE
plugins: make plugin options available in validator

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -261,7 +261,9 @@ class Executor:
                 plugin=plugin,
                 step_info=StepInfo(part_info, Step.BUILD),
             )
-            validator = plugin_class.validator_class(part_name=part.name, env=env)
+            validator = plugin_class.validator_class(
+                part_name=part.name, env=env, properties=part.plugin_properties
+            )
             validator.validate_environment(part_dependencies=part.dependencies)
 
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -439,7 +439,9 @@ class PartHandler:
             # can add elements to the build environment. All part dependencies
             # have already ran at this point.
             validator = self._plugin.validator_class(
-                part_name=step_info.part_name, env=step_env
+                part_name=step_info.part_name,
+                env=step_env,
+                properties=self._part.plugin_properties,
             )
             validator.validate_environment()
 

--- a/craft_parts/plugins/validator.py
+++ b/craft_parts/plugins/validator.py
@@ -23,6 +23,8 @@ from typing import List, Optional
 
 from craft_parts import errors
 
+from .properties import PluginProperties
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,9 +46,10 @@ class PluginEnvironmentValidator:
     :param env: A string containing the build step environment setup.
     """
 
-    def __init__(self, *, part_name: str, env: str):
+    def __init__(self, *, part_name: str, env: str, properties: PluginProperties):
         self._part_name = part_name
         self._env = env
+        self._options = properties
 
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def is_rtd() -> bool:
 install_requires = [
     "overrides",
     "PyYAML",
-    "pydantic",
+    "pydantic==1.9.0",  # needed by pydanic-yaml 0.6.3
     "pydantic-yaml",
     "pyxdg",
     "requests",

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -63,7 +63,7 @@ def test_plugin(new_dir):
     props = FooPluginProperties.unmarshal({"foo-name": "world"})
     plugin = FooPlugin(properties=props, part_info=part_info)
 
-    validator = FooPlugin.validator_class(part_name=part.name, env="")
+    validator = FooPlugin.validator_class(part_name=part.name, env="", properties=props)
     validator.validate_environment()
 
     assert plugin.get_build_snaps() == {"build_snap"}

--- a/tests/unit/plugins/test_dotnet_plugin.py
+++ b/tests/unit/plugins/test_dotnet_plugin.py
@@ -38,7 +38,7 @@ def test_validate_environment(dependency_fixture, part_info):
     dotnet = dependency_fixture("dotnet")
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(dotnet.parent)}"
+        part_name="my-part", env=f"PATH={str(dotnet.parent)}", properties=properties
     )
     validator.validate_environment()
 
@@ -47,7 +47,9 @@ def test_validate_environment_missing_dotnet(part_info):
     properties = DotnetPlugin.properties_class.unmarshal({"source": "."})
     plugin = DotnetPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
@@ -60,7 +62,7 @@ def test_validate_environment_broken_dotnet(dependency_fixture, part_info):
     dotnet = dependency_fixture("dotnet", broken=True)
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(dotnet.parent)}"
+        part_name="my-part", env=f"PATH={str(dotnet.parent)}", properties=properties
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -72,7 +74,9 @@ def test_validate_environment_with_dotnet_part(part_info):
     properties = DotnetPlugin.properties_class.unmarshal({"source": "."})
     plugin = DotnetPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     validator.validate_environment(part_dependencies=["dotnet"])
 
 
@@ -80,7 +84,9 @@ def test_validate_environment_without_dotnet_part(part_info):
     properties = DotnetPlugin.properties_class.unmarshal({"source": "."})
     plugin = DotnetPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment(part_dependencies=[])
 

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -38,7 +38,7 @@ def test_validate_environment(dependency_fixture, part_info):
     go = dependency_fixture("go", output="go version go1.17 linux/amd64")
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(go.parent)}"
+        part_name="my-part", env=f"PATH={str(go.parent)}", properties=properties
     )
     validator.validate_environment()
 
@@ -47,7 +47,9 @@ def test_validate_environment_missing_go(part_info):
     properties = GoPlugin.properties_class.unmarshal({"source": "."})
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
@@ -60,7 +62,7 @@ def test_validate_environment_broken_go(dependency_fixture, part_info):
     go = dependency_fixture("go", broken=True)
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(go.parent)}"
+        part_name="my-part", env=f"PATH={str(go.parent)}", properties=properties
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -74,7 +76,7 @@ def test_validate_environment_invalid_go(dependency_fixture, part_info):
     go = dependency_fixture("go", invalid=True)
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(go.parent)}"
+        part_name="my-part", env=f"PATH={str(go.parent)}", properties=properties
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -86,7 +88,9 @@ def test_validate_environment_with_go_part(part_info):
     properties = GoPlugin.properties_class.unmarshal({"source": "."})
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     validator.validate_environment(part_dependencies=["go"])
 
 
@@ -94,7 +98,9 @@ def test_validate_environment_without_go_part(part_info):
     properties = GoPlugin.properties_class.unmarshal({"source": "."})
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment(part_dependencies=[])
 

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -39,7 +39,9 @@ def test_validate_environment(dependency_fixture, part_info):
     ninja = dependency_fixture("ninja")
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(meson.parent)}:{str(ninja.parent)}"
+        part_name="my-part",
+        env=f"PATH={str(meson.parent)}:{str(ninja.parent)}",
+        properties=properties,
     )
     validator.validate_environment()
 
@@ -50,7 +52,9 @@ def test_validate_environment_missing_meson(dependency_fixture, part_info):
     ninja = dependency_fixture("ninja")
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(ninja.parent)}"
+        part_name="my-part",
+        env=f"PATH={str(ninja.parent)}",
+        properties=properties,
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -64,7 +68,9 @@ def test_validate_environment_missing_ninja(dependency_fixture, part_info):
     meson = dependency_fixture("meson")
 
     validator = plugin.validator_class(
-        part_name="my-part", env=f"PATH={str(meson.parent)}"
+        part_name="my-part",
+        env=f"PATH={str(meson.parent)}",
+        properties=properties,
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -81,6 +87,7 @@ def test_validate_environment_broken_meson(dependency_fixture, part_info):
     validator = plugin.validator_class(
         part_name="my-part",
         env=f"PATH={str(ninja.parent)}:{str(meson.parent)}",
+        properties=properties,
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -97,6 +104,7 @@ def test_validate_environment_broken_ninja(dependency_fixture, part_info):
     validator = plugin.validator_class(
         part_name="my-part",
         env=f"PATH={str(meson.parent)}:{str(ninja.parent)}",
+        properties=properties,
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
@@ -108,7 +116,9 @@ def test_validate_environment_with_meson_and_ninja_part(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     validator.validate_environment(part_dependencies=["meson", "ninja"])
 
 
@@ -116,7 +126,9 @@ def test_validate_environment_without_meson_part(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment(part_dependencies=["ninja"])
 
@@ -129,7 +141,9 @@ def test_validate_environment_without_ninja_part(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)
 
-    validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment(part_dependencies=["meson"])
 

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -44,6 +44,7 @@ class TestPluginNpmPlugin:
         validator = plugin.validator_class(
             part_name="my-part",
             env=f"PATH={str(node.parent)}:{str(npm.parent)}",
+            properties=properties,
         )
 
         validator.validate_environment()
@@ -72,7 +73,9 @@ class TestPluginNpmPlugin:
 
         properties = NpmPlugin.properties_class.unmarshal({"source": "."})
         plugin = NpmPlugin(properties=properties, part_info=part_info)
-        validator = plugin.validator_class(part_name="my-part", env=path)
+        validator = plugin.validator_class(
+            part_name="my-part", env=path, properties=properties
+        )
 
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment()
@@ -104,7 +107,9 @@ class TestPluginNpmPlugin:
 
         properties = NpmPlugin.properties_class.unmarshal({"source": "."})
         plugin = NpmPlugin(properties=properties, part_info=part_info)
-        validator = plugin.validator_class(part_name="my-part", env=path)
+        validator = plugin.validator_class(
+            part_name="my-part", env=path, properties=properties
+        )
 
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment()
@@ -117,7 +122,9 @@ class TestPluginNpmPlugin:
     def test_validate_environment_part_dependencies(self, new_dir, part_info):
         properties = NpmPlugin.properties_class.unmarshal({"source": "."})
         plugin = NpmPlugin(properties=properties, part_info=part_info)
-        validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+        validator = plugin.validator_class(
+            part_name="my-part", env="PATH=/foo", properties=properties
+        )
 
         validator.validate_environment(part_dependencies=["node", "npm"])
 
@@ -140,7 +147,9 @@ class TestPluginNpmPlugin:
 
         properties = NpmPlugin.properties_class.unmarshal({"source": "."})
         plugin = NpmPlugin(properties=properties, part_info=part_info)
-        validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+        validator = plugin.validator_class(
+            part_name="my-part", env="PATH=/foo", properties=properties
+        )
 
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment(

--- a/tests/unit/plugins/test_rust_plugin.py
+++ b/tests/unit/plugins/test_rust_plugin.py
@@ -43,6 +43,7 @@ class TestPluginRustPlugin:
         validator = plugin.validator_class(
             part_name="my-part",
             env=f"PATH={str(cargo.parent)}:{str(rustc.parent)}",
+            properties=properties,
         )
         validator.validate_environment()
 
@@ -71,7 +72,9 @@ class TestPluginRustPlugin:
         properties = RustPlugin.properties_class.unmarshal({"source": "."})
         plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(part_name="my-part", env=path)
+        validator = plugin.validator_class(
+            part_name="my-part", env=path, properties=properties
+        )
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment()
 
@@ -103,7 +106,9 @@ class TestPluginRustPlugin:
         properties = RustPlugin.properties_class.unmarshal({"source": "."})
         plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(part_name="my-part", env=path)
+        validator = plugin.validator_class(
+            part_name="my-part", env=path, properties=properties
+        )
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment()
 
@@ -116,7 +121,9 @@ class TestPluginRustPlugin:
         properties = RustPlugin.properties_class.unmarshal({"source": "."})
         plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+        validator = plugin.validator_class(
+            part_name="my-part", env="PATH=/foo", properties=properties
+        )
         validator.validate_environment(part_dependencies=["cargo", "rustc"])
 
     @pytest.mark.parametrize(
@@ -139,7 +146,9 @@ class TestPluginRustPlugin:
         properties = RustPlugin.properties_class.unmarshal({"source": "."})
         plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(part_name="my-part", env="PATH=/foo")
+        validator = plugin.validator_class(
+            part_name="my-part", env="PATH=/foo", properties=properties
+        )
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
             validator.validate_environment(
                 part_dependencies=valid_part_dependency_names

--- a/tests/unit/plugins/test_validator.py
+++ b/tests/unit/plugins/test_validator.py
@@ -115,14 +115,20 @@ class FooPlugin(Plugin):
 
 
 def test_validation_happy(part_info, foo_exe):
+    properties = FooPluginProperties()
     validator = FooPlugin.validator_class(
-        part_name=part_info.part_name, env=f"PATH={str(foo_exe.parent)}"
+        part_name=part_info.part_name,
+        env=f"PATH={str(foo_exe.parent)}",
+        properties=properties,
     )
     validator.validate_environment()
 
 
 def test_validation_error(part_info):
-    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    properties = FooPluginProperties()
+    validator = FooPlugin.validator_class(
+        part_name=part_info.part_name, env="", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()
 
@@ -132,12 +138,18 @@ def test_validation_error(part_info):
 
 
 def test_validation_built_by_part(part_info):
-    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    properties = FooPluginProperties()
+    validator = FooPlugin.validator_class(
+        part_name=part_info.part_name, env="", properties=properties
+    )
     validator.validate_environment(part_dependencies=["build-foo"])
 
 
 def test_validation_built_by_part_error(part_info):
-    validator = FooPlugin.validator_class(part_name=part_info.part_name, env="")
+    properties = FooPluginProperties()
+    validator = FooPlugin.validator_class(
+        part_name=part_info.part_name, env="", properties=properties
+    )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment(part_dependencies=[])
 
@@ -150,8 +162,11 @@ def test_validation_built_by_part_error(part_info):
 
 
 def test_validation_output_error(part_info, empty_foo_exe):
+    properties = FooPluginProperties()
     validator = FooPlugin.validator_class(
-        part_name=part_info.part_name, env=f"PATH={str(empty_foo_exe.parent)}"
+        part_name=part_info.part_name,
+        env=f"PATH={str(empty_foo_exe.parent)}",
+        properties=properties,
     )
     with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
         validator.validate_environment()


### PR DESCRIPTION
Plugin environment validators may need to use plugin options values,
add that to the validator instance.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
