### PR TITLE
plugin: plugin validation with only one part dep

### DIFF
--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -64,7 +64,9 @@ class DotPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         :param part_dependencies: A list of the parts this part depends on.
         """
         self.validate_dependency(
-            dependency="dotnet", part_dependencies=part_dependencies
+            dependency="dotnet",
+            plugin_name="dotnet",
+            part_dependencies=part_dependencies,
         )
 
 

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -68,10 +68,13 @@ class GoPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         and there are no parts named go.
         """
         version = self.validate_dependency(
-            dependency="go", part_dependencies=part_dependencies, argument="version"
+            dependency="go",
+            plugin_name="go",
+            part_dependencies=part_dependencies,
+            argument="version",
         )
         if not version.startswith("go version") and (
-            part_dependencies is None or "go" not in part_dependencies
+            part_dependencies is None or "go-deps" not in part_dependencies
         ):
             raise errors.PluginEnvironmentValidationError(
                 part_name=self._part_name,

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -68,7 +68,9 @@ class MesonPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         """
         for dependency in ["meson", "ninja"]:
             self.validate_dependency(
-                dependency=dependency, part_dependencies=part_dependencies
+                dependency=dependency,
+                plugin_name="meson",
+                part_dependencies=part_dependencies,
             )
 
 

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -87,9 +87,15 @@ class NpmPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
 
         :param part_dependencies: A list of the parts this part depends on.
         """
+        options = cast(NpmPluginProperties, self._options)
+        if options.npm_include_node:
+            return
+
         for dependency in ["node", "npm"]:
             self.validate_dependency(
-                dependency=dependency, part_dependencies=part_dependencies
+                dependency=dependency,
+                plugin_name="npm",
+                part_dependencies=part_dependencies,
             )
 
 

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -73,7 +73,9 @@ class RustPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         """
         for dependency in ["cargo", "rustc"]:
             self.validate_dependency(
-                dependency=dependency, part_dependencies=part_dependencies
+                dependency=dependency,
+                plugin_name="rust",
+                part_dependencies=part_dependencies,
             )
 
 

--- a/craft_parts/plugins/validator.py
+++ b/craft_parts/plugins/validator.py
@@ -77,6 +77,7 @@ class PluginEnvironmentValidator:
     def validate_dependency(
         self,
         dependency: str,
+        plugin_name: str,
         part_dependencies: Optional[List[str]],
         argument: str = "--version",
     ) -> str:
@@ -85,6 +86,8 @@ class PluginEnvironmentValidator:
         `<dependency-name> --version` is executed to confirm the dependency is valid.
 
         :param dependency: name of the dependency to validate.
+        :param plugin_name: used to generate the part name that would satisfy
+                            the dependency.
         :param part_dependencies: A list of the parts this part depends on.
         :param argument: argument to call with the dependency. Default is `--version`.
 
@@ -110,12 +113,14 @@ class PluginEnvironmentValidator:
                     reason=f"{dependency!r} not found",
                 ) from err
 
-            if dependency not in part_dependencies:
+            part_dependency = f"{plugin_name}-deps"
+            if part_dependency not in part_dependencies:
                 raise errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason=(
                         f"{dependency!r} not found and part {self._part_name!r} "
-                        f"depends on a part named {dependency!r}"
+                        f"does not depend on a part named {part_dependency!r} "
+                        "that would satisfy the dependency"
                     ),
                 ) from err
         return ""

--- a/tests/unit/plugins/test_dotnet_plugin.py
+++ b/tests/unit/plugins/test_dotnet_plugin.py
@@ -77,7 +77,7 @@ def test_validate_environment_with_dotnet_part(part_info):
     validator = plugin.validator_class(
         part_name="my-part", env="PATH=/foo", properties=properties
     )
-    validator.validate_environment(part_dependencies=["dotnet"])
+    validator.validate_environment(part_dependencies=["dotnet-deps"])
 
 
 def test_validate_environment_without_dotnet_part(part_info):
@@ -91,7 +91,8 @@ def test_validate_environment_without_dotnet_part(part_info):
         validator.validate_environment(part_dependencies=[])
 
     assert raised.value.reason == (
-        "'dotnet' not found and part 'my-part' depends on a part named 'dotnet'"
+        "'dotnet' not found and part 'my-part' does not depend on a part named "
+        "'dotnet-deps' that would satisfy the dependency"
     )
 
 

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -91,7 +91,7 @@ def test_validate_environment_with_go_part(part_info):
     validator = plugin.validator_class(
         part_name="my-part", env="PATH=/foo", properties=properties
     )
-    validator.validate_environment(part_dependencies=["go"])
+    validator.validate_environment(part_dependencies=["go-deps"])
 
 
 def test_validate_environment_without_go_part(part_info):
@@ -105,7 +105,8 @@ def test_validate_environment_without_go_part(part_info):
         validator.validate_environment(part_dependencies=[])
 
     assert raised.value.reason == (
-        "'go' not found and part 'my-part' depends on a part named 'go'"
+        "'go' not found and part 'my-part' does not depend on a part named "
+        "'go-deps' that would satisfy the dependency"
     )
 
 

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -112,14 +112,14 @@ def test_validate_environment_broken_ninja(dependency_fixture, part_info):
     assert raised.value.reason == "'ninja' failed with error code 33"
 
 
-def test_validate_environment_with_meson_and_ninja_part(part_info):
+def test_validate_environment_with_meson_deps_part(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)
 
     validator = plugin.validator_class(
         part_name="my-part", env="PATH=/foo", properties=properties
     )
-    validator.validate_environment(part_dependencies=["meson", "ninja"])
+    validator.validate_environment(part_dependencies=["meson-deps"])
 
 
 def test_validate_environment_without_meson_part(part_info):
@@ -133,7 +133,8 @@ def test_validate_environment_without_meson_part(part_info):
         validator.validate_environment(part_dependencies=["ninja"])
 
     assert raised.value.reason == (
-        "'meson' not found and part 'my-part' depends on a part named 'meson'"
+        "'meson' not found and part 'my-part' does not depend on a part named "
+        "'meson-deps' that would satisfy the dependency"
     )
 
 
@@ -148,7 +149,8 @@ def test_validate_environment_without_ninja_part(part_info):
         validator.validate_environment(part_dependencies=["meson"])
 
     assert raised.value.reason == (
-        "'ninja' not found and part 'my-part' depends on a part named 'ninja'"
+        "'meson' not found and part 'my-part' does not depend on a part named "
+        "'meson-deps' that would satisfy the dependency"
     )
 
 

--- a/tests/unit/plugins/test_rust_plugin.py
+++ b/tests/unit/plugins/test_rust_plugin.py
@@ -124,39 +124,45 @@ class TestPluginRustPlugin:
         validator = plugin.validator_class(
             part_name="my-part", env="PATH=/foo", properties=properties
         )
-        validator.validate_environment(part_dependencies=["cargo", "rustc"])
+        validator.validate_environment(part_dependencies=["rust-deps"])
 
     @pytest.mark.parametrize(
-        "dependencies",
+        "satisfied_dependency,error_dependency",
         [
-            ("cargo", ["rustc"]),
-            ("rustc", ["cargo"]),
+            ("cargo", "rustc"),
+            ("rustc", "cargo"),
         ],
     )
     def test_validate_environment_missing_part_dependencies(
-        self, dependencies, dependency_fixture, part_info
+        self,
+        satisfied_dependency,
+        error_dependency,
+        dependency_fixture,
+        new_dir,
+        part_info,
     ):
         """Validate that missing part dependencies raise an exception.
 
         :param dependencies: tuple consisting of 1 missing part dependency
         and a list of valid part dependencies
         """
-        missing_part_dependency_name, valid_part_dependency_names = dependencies
+        dependency = dependency_fixture(name=satisfied_dependency)
 
         properties = RustPlugin.properties_class.unmarshal({"source": "."})
         plugin = RustPlugin(properties=properties, part_info=part_info)
 
         validator = plugin.validator_class(
-            part_name="my-part", env="PATH=/foo", properties=properties
+            part_name="my-part",
+            properties=properties,
+            env=f"PATH={str(dependency.parent)}",
         )
         with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
-            validator.validate_environment(
-                part_dependencies=valid_part_dependency_names
-            )
+            validator.validate_environment(part_dependencies=[])
 
         assert raised.value.reason == (
-            f"'{missing_part_dependency_name}' not found and part 'my-part' "
-            f"depends on a part named '{missing_part_dependency_name}'"
+            f"{error_dependency!r} not found and part 'my-part' "
+            "does not depend on a part named 'rust-deps' that "
+            "would satisfy the dependency"
         )
 
     def test_get_build_snaps(self, part_info):


### PR DESCRIPTION
Setup plugin validation so it only mentions a dependency on one
part. This is still not the best solution to the problem.

Also fixup the node verification for it to check if node is to be
included and if so, skip verification.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
I am not entirely happy with this solution. Proposing for discussion.