### PR TITLE
callbacks: don't pass part list to prologue callback

### DIFF
--- a/craft_parts/callbacks.py
+++ b/craft_parts/callbacks.py
@@ -22,12 +22,11 @@ from typing import Callable, List, Optional, Union
 
 from craft_parts import errors
 from craft_parts.infos import ProjectInfo, StepInfo
-from craft_parts.parts import Part
 from craft_parts.steps import Step
 
 CallbackHook = namedtuple("CallbackHook", ["function", "step_list"])
 
-ExecutionCallback = Callable[[ProjectInfo, List[Part]], None]
+ExecutionCallback = Callable[[ProjectInfo], None]
 StepCallback = Callable[[StepInfo], bool]
 Callback = Union[ExecutionCallback, StepCallback]
 
@@ -93,24 +92,22 @@ def unregister_all() -> None:
     _POST_STEP_HOOKS = []
 
 
-def run_prologue(project_info: ProjectInfo, *, part_list: List[Part]) -> None:
+def run_prologue(project_info: ProjectInfo) -> None:
     """Run all registered execution prologue callbacks.
 
-    :param project_info: The project information.
-    :param part_list: A list with all parts in the project.
+    :param project_info: The project information to be sent to callback functions.
     """
     for hook in _PROLOGUE_HOOKS:
-        hook.function(project_info, part_list)
+        hook.function(project_info)
 
 
-def run_epilogue(project_info: ProjectInfo, *, part_list: List[Part]) -> None:
+def run_epilogue(project_info: ProjectInfo) -> None:
     """Run all registered execution epilogue callbacks.
 
-    :param project_info: The project information.
-    :param part_list: A list with all parts in the project.
+    :param project_info: The project information to be sent to callback functions.
     """
     for hook in _EPILOGUE_HOOKS:
-        hook.function(project_info, part_list)
+        hook.function(project_info)
 
 
 def run_pre_step(step_info: StepInfo) -> None:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -95,7 +95,7 @@ class Executor:
             with overlays.PackageCacheMount(self._overlay_manager) as ctx:
                 ctx.refresh_packages_list()
 
-        callbacks.run_prologue(self._project_info, part_list=self._part_list)
+        callbacks.run_prologue(self._project_info)
 
     def epilogue(self) -> None:
         """Finish and clean the execution environment.
@@ -103,7 +103,7 @@ class Executor:
         This method is called after executing lifecycle actions.
         """
         self._project_info.execution_finished = True
-        callbacks.run_epilogue(self._project_info, part_list=self._part_list)
+        callbacks.run_epilogue(self._project_info)
 
     def execute(
         self,

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -393,40 +393,6 @@ class StepInfo:
 
         raise AttributeError(f"{self.__class__.__name__!r} has no attribute {name!r}")
 
-    def set_project_var(
-        self, name: str, value: str, *, raw_write: bool = False
-    ) -> None:
-        """Set the value of a project variable.
-
-        Variable values can be set once. Project variables are not intended for
-        logic construction in user scripts, setting it multiple times is likely to
-        be an error.
-
-        :param name: The project variable name.
-        :param value: The new project variable value.
-        :param raw_write: Whether the variable is written without access verifications.
-
-        :raise ValueError: If there is no custom argument with the given name.
-        :raise RuntimeError: If a write-once variable is set a second time, or if a
-            part name is specified and the variable is set from a different part.
-        """
-        self._part_info.set_project_var(name, value, raw_write=raw_write)
-
-    def get_project_var(self, name: str, *, raw_read: bool = False) -> str:
-        """Get the value of a project variable.
-
-        Variables must be consumed by the application only after the lifecycle
-        execution ends to prevent unexpected behavior if steps are skipped.
-
-        :param name: The project variable name.
-        :param raw_read: Whether the variable is read without access verifications.
-        :return: The value of the variable.
-
-        :raise ValueError: If there is no project variable with the given name.
-        :raise RuntimeError: If the variable is consumed during the lifecycle execution.
-        """
-        return self._part_info.get_project_var(name, raw_read=raw_read)
-
 
 def _get_host_architecture() -> str:
     """Obtain the host system architecture."""

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import textwrap
-from typing import List
 
 import pytest
 import yaml
@@ -24,7 +23,6 @@ import craft_parts
 from craft_parts import (
     Action,
     ActionType,
-    Part,
     ProjectInfo,
     Step,
     StepInfo,
@@ -62,9 +60,8 @@ def _step_callback(info: StepInfo) -> bool:
     return True
 
 
-def _exec_callback(info: ProjectInfo, part_list: List[Part]) -> None:
+def _exec_callback(info: ProjectInfo) -> None:
     print(f"application_name = {info.application_name}")
-    print(f"parts = {', '.join([x.name for x in part_list])}")
 
 
 _parts_yaml = textwrap.dedent(
@@ -125,9 +122,7 @@ def test_prologue_callback(tmpdir, capfd):
         ctx.execute(Action("foo", Step.PULL))
 
     out, err = capfd.readouterr()
-    assert out == (
-        "application_name = test_prologue_callback\n" "parts = foo\n" "step Step.PULL\n"
-    )
+    assert out == ("application_name = test_prologue_callback\nstep Step.PULL\n")
 
 
 def _my_step_callback(info: StepInfo) -> bool:
@@ -299,9 +294,8 @@ def test_invalid_update_callback_post(tmpdir, step):
     assert raised.value.message == f"cannot update step {name!r} of 'foo'"
 
 
-def _my_exec_callback(info: ProjectInfo, part_list: List[Part]) -> None:
-    for part in part_list:
-        print(f"{part.name}: {getattr(info, 'message')}")
+def _my_exec_callback(info: ProjectInfo) -> None:
+    print(f"{getattr(info, 'message')}")
 
 
 _exec_yaml = textwrap.dedent(
@@ -343,7 +337,7 @@ def test_callback_prologue(tmpdir, capfd):
         ctx.execute(Action("foo", Step.PULL))
 
     out, err = capfd.readouterr()
-    assert out == "bar: prologue\nfoo: prologue\nfoo Step.PULL\n"
+    assert out == "prologue\nfoo Step.PULL\n"
 
 
 def test_callback_epilogue(tmpdir, capfd):
@@ -364,4 +358,4 @@ def test_callback_epilogue(tmpdir, capfd):
         ctx.execute(Action("foo", Step.PULL))
 
     out, err = capfd.readouterr()
-    assert out == "foo Step.PULL\nbar: epilogue\nfoo: epilogue\n"
+    assert out == "foo Step.PULL\nepilogue\n"

--- a/tests/integration/executor/test_environment.py
+++ b/tests/integration/executor/test_environment.py
@@ -16,13 +16,12 @@
 
 import os
 import textwrap
-from typing import List
 
 import pytest
 import yaml
 
 import craft_parts
-from craft_parts import Action, Part, ProjectInfo, Step, StepInfo, callbacks
+from craft_parts import Action, ProjectInfo, Step, StepInfo, callbacks
 
 
 def setup_function():
@@ -46,7 +45,7 @@ def mock_prerequisites_for_overlay(mocker):
     mocker.patch("craft_parts.overlays.OverlayManager.refresh_packages_list")
 
 
-def _prologue_callback(info: ProjectInfo, part_list: List[Part]) -> None:
+def _prologue_callback(info: ProjectInfo) -> None:
     info.global_environment["TEST_GLOBAL"] = "prologue"
 
 

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -151,8 +151,8 @@ class TestExecutionContext:
         callbacks.unregister_all()
 
     def test_prologue(self, capfd, new_dir):
-        def cbf(info, part_list):
-            print(f"prologue {info.custom} for {part_list[0].name}")
+        def cbf(info):
+            print(f"prologue {info.custom}")
 
         callbacks.register_prologue(cbf)
         p1 = Part("p1", {"plugin": "nil", "override-build": "echo build"})
@@ -163,11 +163,11 @@ class TestExecutionContext:
             ctx.execute(Action("p1", Step.BUILD))
 
         captured = capfd.readouterr()
-        assert captured.out == "prologue custom for p1\nbuild\n"
+        assert captured.out == "prologue custom\nbuild\n"
 
     def test_epilogue(self, capfd, new_dir):
-        def cbf(info, part_list):
-            print(f"epilogue {info.custom} for {part_list[0].name}")
+        def cbf(info):
+            print(f"epilogue {info.custom}")
 
         callbacks.register_epilogue(cbf)
         p1 = Part("p1", {"plugin": "nil", "override-build": "echo build"})
@@ -178,11 +178,11 @@ class TestExecutionContext:
             ctx.execute(Action("p1", Step.BUILD))
 
         captured = capfd.readouterr()
-        assert captured.out == "build\nepilogue custom for p1\n"
+        assert captured.out == "build\nepilogue custom\n"
 
     def test_capture_stdout(self, capfd, new_dir):
-        def cbf(info, part_list):
-            print(f"prologue {info.custom} for {part_list[0].name}")
+        def cbf(info):
+            print(f"prologue {info.custom}")
 
         callbacks.register_prologue(cbf)
         p1 = Part("p1", {"plugin": "nil", "override-build": "echo out; echo err >&2"})
@@ -197,6 +197,6 @@ class TestExecutionContext:
                 ctx.execute(Action("p1", Step.BUILD), stdout=output, stderr=error)
 
         captured = capfd.readouterr()
-        assert captured.out == "prologue custom for p1\n"
+        assert captured.out == "prologue custom\n"
         assert output_path.read_text() == "out\n"
         assert error_path.read_text() == "+ echo out\n+ echo err\nerr\n"

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -37,16 +36,14 @@ def _callback_2(info: StepInfo) -> bool:
     return False
 
 
-def _callback_3(info: ProjectInfo, part_list: List[Part]) -> None:
+def _callback_3(info: ProjectInfo) -> None:
     greet = getattr(info, "greet")
-    names = " ".join([x.name for x in part_list])
-    print(f"{greet} callback 3 ({names})")
+    print(f"{greet} callback 3")
 
 
-def _callback_4(info: ProjectInfo, part_list: List[Part]) -> None:
+def _callback_4(info: ProjectInfo) -> None:
     greet = getattr(info, "greet")
-    names = " ".join([x.name for x in part_list])
-    print(f"{greet} callback 4 ({names})")
+    print(f"{greet} callback 4")
 
 
 class TestCallbackRegistration:
@@ -178,21 +175,17 @@ class TestCallbackExecution:
         assert out == "hello callback 1\nhello callback 2\n"
 
     def test_run_prologue(self, capfd):
-        part1 = Part("p1", {})
-        part2 = Part("p2", {})
         callbacks.register_prologue(_callback_3)
         callbacks.register_prologue(_callback_4)
-        callbacks.run_prologue(self._project_info, part_list=[part1, part2])
+        callbacks.run_prologue(self._project_info)
         out, err = capfd.readouterr()
         assert not err
-        assert out == "hello callback 3 (p1 p2)\nhello callback 4 (p1 p2)\n"
+        assert out == "hello callback 3\nhello callback 4\n"
 
     def test_run_epilogue(self, capfd):
-        part1 = Part("p1", {})
-        part2 = Part("p2", {})
         callbacks.register_epilogue(_callback_3)
         callbacks.register_epilogue(_callback_4)
-        callbacks.run_epilogue(self._project_info, part_list=[part1, part2])
+        callbacks.run_epilogue(self._project_info)
         out, err = capfd.readouterr()
         assert not err
-        assert out == "hello callback 3 (p1 p2)\nhello callback 4 (p1 p2)\n"
+        assert out == "hello callback 3\nhello callback 4\n"


### PR DESCRIPTION
Be more conservative on what we expose to the application in the
prologue/epilogue callbacks. Pass only project info for now,
and add more later if needed.

Also remove unnecessary method definition from step information.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
