### PR TITLE
packages: run snap operations silently

### DIFF
--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -19,8 +19,8 @@
 import contextlib
 import logging
 import os
+import subprocess
 import sys
-from subprocess import CalledProcessError, check_call, check_output
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from urllib import parse
 
@@ -203,8 +203,14 @@ class SnapPackage:
         if self._original_channel:
             snap_download_cmd.extend(["--channel", self._original_channel])
         try:
-            check_output(snap_download_cmd, cwd=directory)
-        except CalledProcessError as err:
+            subprocess.run(
+                snap_download_cmd,
+                cwd=directory,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError as err:
             raise errors.SnapDownloadError(
                 snap_name=self.name, snap_channel=self.channel
             ) from err
@@ -222,8 +228,13 @@ class SnapPackage:
             pass
 
         try:
-            check_call(snap_install_cmd)
-        except CalledProcessError as err:
+            subprocess.run(
+                snap_install_cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError as err:
             raise errors.SnapInstallError(
                 snap_name=self.name, snap_channel=self.channel
             ) from err
@@ -242,8 +253,13 @@ class SnapPackage:
             pass
 
         try:
-            check_call(snap_refresh_cmd)
-        except CalledProcessError as err:
+            subprocess.run(
+                snap_refresh_cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError as err:
             raise errors.SnapRefreshError(
                 snap_name=self.name, snap_channel=self.channel
             ) from err
@@ -302,8 +318,8 @@ def get_assertion(assertion_params: Sequence[str]) -> bytes:
     :rtype: bytes
     """
     try:
-        return check_output(["snap", "known", *assertion_params])
-    except CalledProcessError as call_error:
+        return subprocess.check_output(["snap", "known", *assertion_params])
+    except subprocess.CalledProcessError as call_error:
         raise errors.SnapGetAssertionError(
             assertion_params=assertion_params
         ) from call_error

--- a/tests/fake_snap_command.py
+++ b/tests/fake_snap_command.py
@@ -36,11 +36,11 @@ class FakeSnapCommand:
         self.fake_download = None
         self._email = "-"
 
-        original_check_call = craft_parts.packages.snaps.check_call
-        original_check_output = craft_parts.packages.snaps.check_output
+        original_run = craft_parts.packages.snaps.subprocess.run
+        original_check_output = craft_parts.packages.snaps.subprocess.check_output
 
-        def side_effect_check_call(cmd, *args, **kwargs):
-            return side_effect(original_check_call, cmd, *args, **kwargs)
+        def side_effect_run(cmd, *args, **kwargs):
+            return side_effect(original_run, cmd, *args, **kwargs)
 
         def side_effect_check_output(cmd, *args, **kwargs):
             if self._is_snap_command(cmd):
@@ -56,9 +56,10 @@ class FakeSnapCommand:
 
             return original(cmd, *args, **kwargs)
 
-        mocker.patch("craft_parts.packages.snaps.check_call", side_effect_check_call)
+        mocker.patch("craft_parts.packages.snaps.subprocess.run", side_effect_run)
         mocker.patch(
-            "craft_parts.packages.snaps.check_output", side_effect_check_output
+            "craft_parts.packages.snaps.subprocess.check_output",
+            side_effect_check_output,
         )
 
     def login(self, email):


### PR DESCRIPTION
Snap installation leaks stdout output that conflicts with craft-cli
when executing the lifecycle from an application. Run subprocesses
silently to avoid this problem.

Fixes #218

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
