### PR TITLE
source: git: handle git init.defaultbranch and pull existing from remote

### DIFF
--- a/tests/unit/executor/test_collisions.py
+++ b/tests/unit/executor/test_collisions.py
@@ -60,7 +60,6 @@ def part3(tmpdir) -> Part:
     (p / "a").mkdir(parents=True)
     (p / "b").mkdir()
     (p / "1").write_text("2")
-    # (p / "2").write_text("1")
     (p / "a" / "2").write_text("")
     return part
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Resolving two problems:
### init.defaultbranch=main
Unit tests fail on systems with the git config option `init.defaultbranch`.
Setting the global config `init.defaultbranch=main` is becoming more common on developer systems for inclusivity. 

### pull_existing()
When `source_branch` is defined, `pull_existing()` function wasn't pulling the latest changes.  
I wrote regression tests and updated the `git reset --hard <refspec>` call.
