### PR TITLE
source: snap: Forward unmatched parameters

### DIFF
--- a/craft_parts/sources/snap_source.py
+++ b/craft_parts/sources/snap_source.py
@@ -52,6 +52,7 @@ class SnapSource(FileSourceHandler):
         source_depth: Optional[int] = None,
         source_checksum: Optional[str] = None,
         project_dirs: Optional[ProjectDirs] = None,
+        **kwargs,
     ) -> None:
         super().__init__(
             source,
@@ -64,6 +65,7 @@ class SnapSource(FileSourceHandler):
             source_checksum=source_checksum,
             project_dirs=project_dirs,
             command="unsquashfs",
+            **kwargs,
         )
 
         if source_tag:


### PR DESCRIPTION
Some parameters like `source_submodules` are passed when source
is instantiated. Constructor needs to handle those parameters.
