### PR TITLE
executor: store primed stage packages in prime state

### DIFF
--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -159,6 +159,7 @@ def _action_message(action: craft_parts.Action) -> str:
             ActionType.RERUN: "Re-overlay",
             ActionType.SKIP: "Skip overlay",
             ActionType.REAPPLY: "Reapply overlay for",
+            ActionType.UPDATE: "Update overlay for",
         },
         Step.BUILD: {
             ActionType.RUN: "Build",

--- a/tests/integration/executor/test_environment.py
+++ b/tests/integration/executor/test_environment.py
@@ -164,6 +164,7 @@ def test_prologue_callback(new_dir, capfd, mocker):
 
 def test_expand_environment(new_dir, mocker):
     mocker.patch("platform.machine", return_value="aarch64")
+    mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
 
     parts_yaml = """\
         parts:

--- a/tests/integration/executor/test_steps.py
+++ b/tests/integration/executor/test_steps.py
@@ -23,7 +23,9 @@ import craft_parts
 from craft_parts import Action, Step
 
 
-def test_run(tmpdir):
+def test_run(tmpdir, mocker):
+    mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
+
     _parts_yaml = textwrap.dedent(
         f"""\
         parts:

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -23,6 +23,12 @@ import yaml
 import craft_parts
 from craft_parts import Action, ActionType, Step
 
+
+@pytest.fixture(autouse=True)
+def setup(mocker):
+    mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
+
+
 parts_yaml = textwrap.dedent(
     """\
     parts:

--- a/tests/integration/plugins/conftest.py
+++ b/tests/integration/plugins/conftest.py
@@ -1,0 +1,22 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_getxattr(mocker):
+    mocker.patch("os.getxattr", new=lambda x, y: b"pkg")

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -243,6 +243,7 @@ class TestPartHandling:
             "craft_parts.executor.step_handler.StepHandler._builtin_prime",
             return_value=StepContents({"file"}, {"dir"}),
         )
+        mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
 
         state = self._handler._run_prime(
             StepInfo(self._part_info, Step.PRIME), stdout=None, stderr=None
@@ -252,6 +253,7 @@ class TestPartHandling:
             project_options=self._part_info.project_options,
             files={"file"},
             directories={"dir"},
+            primed_stage_packages={"pkg"},
         )
 
     @pytest.mark.parametrize(
@@ -685,7 +687,9 @@ class TestOverlayMigration:
     @pytest.mark.parametrize(
         "step,step_dir", [(Step.STAGE, "stage"), (Step.PRIME, "prime")]
     )
-    def test_clean_overlay_shared_file(self, step, step_dir):
+    def test_clean_overlay_shared_file(self, mocker, step, step_dir):
+        mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
+
         Path("parts/p1/layer/file1").write_text("content")
         Path("parts/p3/install/file1").write_text("content")
 
@@ -706,7 +710,9 @@ class TestOverlayMigration:
     @pytest.mark.parametrize(
         "step,step_dir", [(Step.STAGE, "stage"), (Step.PRIME, "prime")]
     )
-    def test_clean_part_shared_file(self, step, step_dir):
+    def test_clean_part_shared_file(self, mocker, step, step_dir):
+        mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
+
         Path("parts/p1/layer/file1").write_text("content")
         Path("parts/p3/install/file1").write_text("content")
 
@@ -764,7 +770,9 @@ class TestPartCleanHandler:
             (Step.PRIME, "prime", "prime"),
         ],
     )
-    def test_clean_step(self, step, test_dir, state_file):
+    def test_clean_step(self, mocker, step, test_dir, state_file):
+        mocker.patch("os.getxattr", new=lambda x, y: b"pkg")
+
         self._handler._make_dirs()
         for each_step in step.previous_steps() + [step]:
             self._handler.run_action(Action("foo", each_step))

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -18,6 +18,7 @@
 
 import sys
 import textwrap
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import ANY, call
 
@@ -27,6 +28,7 @@ import yaml
 from craft_parts import errors
 from craft_parts.lifecycle_manager import LifecycleManager
 from craft_parts.plugins import nil_plugin
+from craft_parts.state_manager import states
 
 
 class TestLifecycleManager:
@@ -160,6 +162,49 @@ class TestLifecycleManager:
                 base_layer_hash=None,
             )
         ]
+
+    def test_get_primed_stage_packages(self, new_dir):
+        lf = LifecycleManager(
+            self._data,
+            application_name="test_manager",
+            cache_dir=new_dir,
+        )
+
+        state = states.PrimeState(primed_stage_packages={"pkg2==2", "pkg1==1"})
+        state.write(Path(new_dir, "parts/foo/state/prime"))
+
+        assert lf.get_primed_stage_packages(part_name="foo") == ["pkg1==1", "pkg2==2"]
+
+    def test_get_primed_stage_packages_no_state(self, new_dir):
+        lf = LifecycleManager(
+            self._data,
+            application_name="test_manager",
+            cache_dir=new_dir,
+        )
+        assert lf.get_primed_stage_packages(part_name="foo") is None
+
+    def test_get_pull_assets(self, new_dir):
+        lf = LifecycleManager(
+            self._data,
+            application_name="test_manager",
+            cache_dir=new_dir,
+        )
+
+        state = states.PullState(assets={"asset1": "val1", "asset2": "val2"})
+        state.write(Path(new_dir, "parts/foo/state/pull"))
+
+        assert lf.get_pull_assets(part_name="foo") == {
+            "asset1": "val1",
+            "asset2": "val2",
+        }
+
+    def test_get_pull_assets_no_state(self, new_dir):
+        lf = LifecycleManager(
+            self._data,
+            application_name="test_manager",
+            cache_dir=new_dir,
+        )
+        assert lf.get_pull_assets(part_name="foo") is None
 
 
 class TestOverlaySupport:


### PR DESCRIPTION
Add the list of primed stage packages to the prime state, and make
the list of pull assets and primed stage packages available from the
lifecycle manager.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1174