### PR TITLE
Add groups dependency support

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -280,6 +280,20 @@ class Part:
         )
 
 
+def get_dependencies_full(part: Part, part_list: List[Part]) -> List[str]:
+    """Return the dependencies, taking into account the groups."""
+    dep_list = []
+    part_names = [p.name for p in part_list]
+    for dep in part.dependencies:
+        if dep in part_names:
+            dep_list.append(dep)
+            continue
+        for other in part_list:
+            if (dep in other.groups) and (other.name not in dep_list):
+                dep_list.append(other.name)
+    return dep_list
+
+
 def part_by_name(name: str, part_list: List[Part]) -> Part:
     """Obtain the part with the given name from the part list.
 
@@ -371,7 +385,7 @@ def part_dependencies(
 
     :returns: The set of parts the given part depends on.
     """
-    dependency_names = set(part.dependencies)
+    dependency_names = set(get_dependencies_full(part, part_list))
     dependencies = {p for p in part_list if p.name in dependency_names}
 
     if recursive:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -58,6 +58,7 @@ class PartSpec(BaseModel):
     override_build: Optional[str] = None
     override_stage: Optional[str] = None
     override_prime: Optional[str] = None
+    groups: Optional[List[str]] = []
 
     class Config:
         """Pydantic model configuration."""
@@ -263,6 +264,13 @@ class Part:
         return self.spec.after
 
     @property
+    def groups(self) -> List[str]:
+        """Return the list of groups to which this part belongs."""
+        if not self.spec.groups:
+            return []
+        return self.spec.groups
+
+    @property
     def has_overlay(self) -> bool:
         """Return whether this part declares overlay content."""
         return bool(
@@ -338,6 +346,10 @@ def sort_parts(part_list: List[Part]) -> List[Part]:
                 if part.name in other.dependencies:
                     mentioned = True
                     break
+                for group in part.groups:
+                    if group in other.dependencies:
+                        mentioned = True
+                        break
             if not mentioned:
                 top_part = part
                 break

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -300,6 +300,14 @@ class TestPartOrdering:
         x = parts.sort_parts([p1, p2, p3])
         assert x == [p3, p2, p1]
 
+    def test_find_dependencies_with_groups(self):
+        p1 = Part("baz", {"after": ["foogroup"]})
+        p2 = Part("bar", {"after": ["foo"], "groups": ["foogroup"]})
+        p3 = Part("foo", {"groups": ["foogroup"]})
+
+        part_list = [p1, p2, p3]
+        assert parts.get_dependencies_full(p1, part_list) == ["bar", "foo"]
+
 
 class TestPartUnmarshal:
     """Verify data unmarshaling on part creation."""

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -41,6 +41,7 @@ class TestPartSpecs:
             "source-tag": "v2.3",
             "source-type": "tar",
             "disable-parallel": True,
+            "groups": ["group1"],
             "after": ["bar"],
             "overlay-packages": ["overlay-pkg1", "overlay-pkg2"],
             "stage-snaps": ["stage-snap1", "stage-snap2"],
@@ -290,6 +291,14 @@ class TestPartOrdering:
 
         with pytest.raises(errors.PartDependencyCycle):
             parts.sort_parts([p1, p2, p3])
+
+    def test_sort_parts_group(self):
+        p1 = Part("baz", {"after": ["foogroup"]})
+        p2 = Part("bar", {"after": ["foo"], "groups": ["foogroup"]})
+        p3 = Part("foo", {"groups": ["foogroup"]})
+
+        x = parts.sort_parts([p1, p2, p3])
+        assert x == [p3, p2, p1]
 
 
 class TestPartUnmarshal:


### PR DESCRIPTION
This patch allows to add a 'groups' statement to each part,
define one or more groups for each one, and use the groups for
dependency management.

This way, it is possible to add all the binaries and libraries
parts to a "binaries" group, and make another part deppend on
that group (just using the 'after' statement like with a part
name).

This is mainly useful in big snapcraft.yaml files with a lot
of parts, like the gnome-XX-sdk ones.

This MR replaces https://github.com/snapcore/snapcraft/pull/3823

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
