### PR TITLE
filters: prevent wildcard symbol conflict

### DIFF
--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -65,19 +65,19 @@ class Fileset:
 
         :param other: The fileset to combine with.
         """
-        my_excludes = set(self.excludes)
-        other_includes = set(other.includes)
-
-        contradicting_set = set.intersection(my_excludes, other_includes)
-        if contradicting_set:
-            raise errors.FilesetConflict(contradicting_set)
-
         to_combine = False
         # combine if the other fileset has a wildcard
         # XXX: should this only be a single wildcard and possibly excludes?
         if "*" in other.entries:
             to_combine = True
             other.remove("*")
+
+        my_excludes = set(self.excludes)
+        other_includes = set(other.includes)
+
+        contradicting_set = set.intersection(my_excludes, other_includes)
+        if contradicting_set:
+            raise errors.FilesetConflict(contradicting_set)
 
         # combine if the other fileset is only excludes
         if {x[0] for x in other.entries} == set("-"):

--- a/tests/unit/executor/test_filesets.py
+++ b/tests/unit/executor/test_filesets.py
@@ -67,6 +67,9 @@ def test_remove():
         (["-foo"], ["bar"], ["bar"]),
         (["foo"], ["-bar", "baz"], ["-bar", "baz"]),
         (["-foo", "bar"], ["bar"], ["bar"]),
+        # combine wildcards
+        (["-*"], ["*"], ["-*"]),
+        (["-*"], ["somefile", "*"], ["-*", "somefile"]),
     ],
 )
 def test_combine(tc_fs1, tc_fs2, tc_result):
@@ -74,6 +77,15 @@ def test_combine(tc_fs1, tc_fs2, tc_result):
     fs2 = Fileset(tc_fs2)
     fs1.combine(fs2)
     assert sorted(fs1.entries) == sorted(tc_result)
+
+
+def test_fileset_combine_conflicts():
+    stage_set = Fileset(["thisfile", "otherfile"])
+    prime_set = Fileset(["-otherfile"])
+
+    with pytest.raises(errors.FilesetConflict) as raised:
+        prime_set.combine(stage_set)
+    assert raised.value.conflicting_files == {"otherfile"}
 
 
 def test_fileset_only_includes():


### PR DESCRIPTION
The scenario where the stage filter is unspecified and the prime file
excludes all files must not fail with a wildcard symbol conflict.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1188