### PR TITLE
fix: parts: check for out of source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_parts
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access,consider-using-with
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,duplicate-code,protected-access,consider-using-with
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -251,7 +251,7 @@ class Executor:
             logger.debug("verify plugin environment for part %r", part.name)
 
             part_info = PartInfo(self._project_info, part)
-            plugin_class = plugins.get_plugin_class(part.plugin)
+            plugin_class = plugins.get_plugin_class(part.plugin_name)
             plugin = plugin_class(
                 properties=part.plugin_properties,
                 part_info=part_info,

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -275,7 +275,7 @@ class PartHandler:
         self._unpack_stage_packages()
         self._unpack_stage_snaps()
 
-        if not update and not self._plugin.out_of_source_build:
+        if not update and not self._plugin.get_out_of_source_build():
             _remove(self._part.part_build_dir)
 
             # Copy source from the part source dir to the part build dir
@@ -591,7 +591,7 @@ class PartHandler:
 
         :param step_info: The step information.
         """
-        if not self._plugin.out_of_source_build:
+        if not self._plugin.get_out_of_source_build():
             # Use the local source to update. It's important to use
             # file_utils.copy instead of link_or_copy, as the build process
             # may modify these files

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError, validator
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
+from craft_parts.plugins import get_plugin_class
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
 
@@ -165,7 +166,7 @@ class Part:
         plugin_name: str = data.get("plugin", "")
 
         self.name = name
-        self.plugin = plugin_name
+        self.plugin_name = plugin_name
         self.plugin_properties = plugin_properties
         self._dirs = project_dirs
         self._part_dir = project_dirs.parts_dir / name
@@ -205,8 +206,16 @@ class Part:
 
     @property
     def part_build_subdir(self) -> Path:
-        """Return the subdirectory in build containing the source subtree (if any)."""
-        if self.spec.source_subdir:
+        """Return the subdirectory in build containing the source subtree (if any).
+
+        Parts that have a source subdirectory and do not support out-of-source builds
+        will have a build subdirectory.
+        """
+        if (
+            self.plugin_name != ""
+            and self.spec.source_subdir
+            and not get_plugin_class(self.plugin_name).get_out_of_source_build()
+        ):
             return self.part_build_dir / self.spec.source_subdir
         return self.part_build_dir
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -63,6 +63,11 @@ class Plugin(abc.ABC):
     @property
     def out_of_source_build(self) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
+        return self.get_out_of_source_build()
+
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
+        """Return whether the plugin performs out-of-source-tree builds."""
         return False
 
     @abc.abstractmethod

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -98,7 +98,7 @@ class CMakePlugin(Plugin):
 
         cmake_command = [
             "cmake",
-            f'"{self._part_info.part_src_dir}"',
+            f'"{self._part_info.part_src_subdir}"',
             "-G",
             f'"{options.cmake_generator}"',
         ] + options.cmake_parameters
@@ -112,7 +112,7 @@ class CMakePlugin(Plugin):
             ),
         ]
 
-    @property
-    def out_of_source_build(self) -> bool:
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -93,8 +93,8 @@ class MesonPlugin(Plugin):
     properties_class = MesonPluginProperties
     validator_class = MesonPluginEnvironmentValidator
 
-    @property
-    def out_of_source_build(self) -> bool:
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True
 
@@ -114,7 +114,7 @@ class MesonPlugin(Plugin):
         """Return a list of commands to run during the build step."""
         options = cast(MesonPluginProperties, self._options)
 
-        meson_cmd = ["meson", str(self._part_info.part_src_dir)]
+        meson_cmd = ["meson", str(self._part_info.part_src_subdir)]
         if options.meson_parameters:
             meson_cmd.extend(shlex.quote(p) for p in options.meson_parameters)
 

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -73,7 +73,7 @@ def get_plugin(
 
     :return: The plugin instance.
     """
-    plugin_name = part.plugin if part.plugin else part.name
+    plugin_name = part.plugin_name if part.plugin_name else part.name
     plugin_class = get_plugin_class(plugin_name)
 
     return plugin_class(properties=properties, part_info=part_info)

--- a/tests/integration/plugins/test_cmake.py
+++ b/tests/integration/plugins/test_cmake.py
@@ -78,3 +78,56 @@ def test_cmake_plugin(new_dir):
 
     output = subprocess.check_output([str(binary)], text=True)
     assert output == "hello world\n"
+
+
+def test_cmake_plugin_subdir(new_dir):
+    """Verify cmake builds with a source subdirectory."""
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: cmake
+            source: .
+            source-subdir: test-subdir
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    source_subdir = Path("test-subdir")
+    source_subdir.mkdir(parents=True)
+
+    (source_subdir / "hello.c").write_text(
+        textwrap.dedent(
+            """\
+            #include <stdio.h>
+
+            int main()
+            {
+                printf(\"hello world\\n\");
+                return 0;
+            }
+            """
+        )
+    )
+
+    (source_subdir / "CMakeLists.txt").write_text(
+        textwrap.dedent(
+            """\
+            cmake_minimum_required(VERSION 2.6)
+            project(cmake-hello C)
+            add_executable(cmake-hello hello.c)
+            install(TARGETS cmake-hello RUNTIME DESTINATION bin)
+            """
+        )
+    )
+
+    lf = LifecycleManager(parts, application_name="test_cmake", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    binary = Path(lf.project_info.prime_dir, "usr/local/bin", "cmake-hello")
+
+    output = subprocess.check_output([str(binary)], text=True)
+    assert output == "hello world\n"

--- a/tests/integration/plugins/test_meson.py
+++ b/tests/integration/plugins/test_meson.py
@@ -80,3 +80,58 @@ def test_meson_plugin(new_dir):
 
     output = subprocess.check_output([str(binary)], text=True)
     assert output == "hello world\n"
+
+
+@pytest.mark.usefixtures("mocker")
+@pytest.mark.usefixtures("meson")
+def test_meson_plugin_with_subdir(new_dir):
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: meson
+            source: .
+            source-subdir: test-subdir
+            meson-parameters:
+              - --prefix=/
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    source_subdir = Path("test-subdir")
+    source_subdir.mkdir(parents=True)
+
+    (source_subdir / "meson.build").write_text(
+        textwrap.dedent(
+            """\
+            project('meson-hello', 'c')
+            executable('hello', 'hello.c', install : true)
+            """
+        )
+    )
+
+    (source_subdir / "hello.c").write_text(
+        textwrap.dedent(
+            """\
+            #include <stdio.h>
+
+            int main()
+            {
+                printf(\"hello world\\n\");
+                return 0;
+            }
+            """
+        )
+    )
+
+    # ninja is installed in the ci test setup
+    lf = LifecycleManager(parts, application_name="test_go", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    binary = Path(lf.project_info.prime_dir, "bin", "hello")
+
+    output = subprocess.check_output([str(binary)], text=True)
+    assert output == "hello world\n"

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -187,9 +187,8 @@ class TestPartHandling:
         mocker.patch("subprocess.check_output", return_value=b"os-info")
 
         mocker.patch(
-            "craft_parts.plugins.plugins.NilPlugin.out_of_source_build",
+            "craft_parts.plugins.base.Plugin.get_out_of_source_build",
             return_value=out_of_source,
-            new_callable=mocker.PropertyMock,
         )
 
         self._part_info.part_src_dir.mkdir(parents=True)

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -70,6 +70,7 @@ def test_plugin(new_dir):
     assert plugin.get_build_packages() == {"build_package"}
     assert plugin.get_build_environment() == {"ENV": "value"}
     assert plugin.out_of_source_build is False
+    assert plugin.get_out_of_source_build() is False
     assert plugin.get_build_commands() == ["hello", "world"]
 
 

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -147,3 +147,8 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir)
 
         assert plugin.out_of_source_build is True
+
+    def test_get_out_of_source_build(self, setup_method_fixture, new_dir):
+        plugin = setup_method_fixture(new_dir)
+
+        assert plugin.get_out_of_source_build() is True

--- a/tests/unit/plugins/test_dump_plugin.py
+++ b/tests/unit/plugins/test_dump_plugin.py
@@ -59,3 +59,6 @@ class TestPluginDump:
 
     def test_out_of_source_build(self):
         assert self._plugin.out_of_source_build is False
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -161,6 +161,13 @@ def test_out_of_source_build(part_info):
     assert plugin.out_of_source_build is True
 
 
+def test_get_out_of_source_build(part_info):
+    properties = MesonPlugin.properties_class.unmarshal({"source": "."})
+    plugin = MesonPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_out_of_source_build() is True
+
+
 def test_get_build_snaps(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)

--- a/tests/unit/plugins/test_nil_plugin.py
+++ b/tests/unit/plugins/test_nil_plugin.py
@@ -48,3 +48,6 @@ class TestPluginNil:
 
     def test_out_of_source_build(self):
         assert self._plugin.out_of_source_build is False
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -107,7 +107,7 @@ class TestLifecycleManager:
 
         part = lf._part_list[0]
         assert part.name == "foo"
-        assert part.plugin == "nil"
+        assert part.plugin_name == "nil"
         assert isinstance(part.plugin_properties, nil_plugin.NilPluginProperties)
 
         mock_seq.assert_called_once_with(

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -24,6 +24,8 @@ from craft_parts.dirs import ProjectDirs
 from craft_parts.parts import Part, PartSpec
 from craft_parts.steps import Step
 
+# pylint: disable=too-many-public-methods
+
 
 class TestPartSpecs:
     """Test part specification creation."""
@@ -113,8 +115,42 @@ class TestPartData:
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 
-    def test_part_subdirs(self, new_dir):
+    def test_part_subdirs_default(self, new_dir):
+        """Verify subdirectories for a part with no plugin."""
         p = Part("foo", {"source-subdir": "foobar"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_out_of_source_and_source_subdir(self, new_dir):
+        """
+        Verify subdirectories for a plugin that supports out-of-source builds
+        and has a source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "cmake", "source-subdir": "foobar"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_out_of_source(self, new_dir):
+        """
+        Verify subdirectories for a plugin that supports out-of-source builds
+        and no source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "cmake"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_source_subdir(self, new_dir):
+        """
+        Verify subdirectories for a plugin that does not support out-of-source builds
+        and has a source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "dump", "source-subdir": "foobar"})
         assert p.part_src_dir == new_dir / "parts/foo/src"
         assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
         assert p.part_build_dir == new_dir / "parts/foo/build"


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Plugins that supported out-of-source building were not working with the `source-subdir` parameter.

There were two minor issues:

- A missing check for out-of-source plugins when determining the build directory
- cmake and meson plugins not choosing the right source directory

Unfortunately, accessing the `out_of_source_build` property prior to instantiating the plugin was a challenge.  I've made some comments below.

(CRAFT-1185)