### PR TITLE
fix: rename plugin to plugin_name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint craft_parts
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,no-self-use,duplicate-code,protected-access,consider-using-with
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,duplicate-code,protected-access,consider-using-with
 
 .PHONY: test-pyright
 test-pyright:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -251,7 +251,7 @@ class Executor:
             logger.debug("verify plugin environment for part %r", part.name)
 
             part_info = PartInfo(self._project_info, part)
-            plugin_class = plugins.get_plugin_class(part.plugin)
+            plugin_class = plugins.get_plugin_class(part.plugin_name)
             plugin = plugin_class(
                 properties=part.plugin_properties,
                 part_info=part_info,

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -165,7 +165,7 @@ class Part:
         plugin_name: str = data.get("plugin", "")
 
         self.name = name
-        self.plugin = plugin_name
+        self.plugin_name = plugin_name
         self.plugin_properties = plugin_properties
         self._dirs = project_dirs
         self._part_dir = project_dirs.parts_dir / name

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -73,7 +73,7 @@ def get_plugin(
 
     :return: The plugin instance.
     """
-    plugin_name = part.plugin if part.plugin else part.name
+    plugin_name = part.plugin_name if part.plugin_name else part.name
     plugin_class = get_plugin_class(plugin_name)
 
     return plugin_class(properties=properties, part_info=part_info)

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -107,7 +107,7 @@ class TestLifecycleManager:
 
         part = lf._part_list[0]
         assert part.name == "foo"
-        assert part.plugin == "nil"
+        assert part.plugin_name == "nil"
         assert isinstance(part.plugin_properties, nil_plugin.NilPluginProperties)
 
         mock_seq.assert_called_once_with(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Change `plugin` to `plugin_name`, because it is a string, not a `Plugin` object.

I would like to land this prior to https://github.com/canonical/craft-parts/pull/250#pullrequestreview-1042330556. 