### PR TITLE
parts: check for out of source builds

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -275,7 +275,7 @@ class PartHandler:
         self._unpack_stage_packages()
         self._unpack_stage_snaps()
 
-        if not update and not self._plugin.out_of_source_build:
+        if not update and not self._plugin.get_out_of_source_build():
             _remove(self._part.part_build_dir)
 
             # Copy source from the part source dir to the part build dir
@@ -591,7 +591,7 @@ class PartHandler:
 
         :param step_info: The step information.
         """
-        if not self._plugin.out_of_source_build:
+        if not self._plugin.get_out_of_source_build():
             # Use the local source to update. It's important to use
             # file_utils.copy instead of link_or_copy, as the build process
             # may modify these files

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError, validator
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
+from craft_parts.plugins import get_plugin_class
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
 
@@ -205,8 +206,16 @@ class Part:
 
     @property
     def part_build_subdir(self) -> Path:
-        """Return the subdirectory in build containing the source subtree (if any)."""
-        if self.spec.source_subdir:
+        """Return the subdirectory in build containing the source subtree (if any).
+
+        Parts that have a source subdirectory and do not support out-of-source builds
+        will have a build subdirectory.
+        """
+        if (
+            self.plugin_name != ""
+            and self.spec.source_subdir
+            and not get_plugin_class(self.plugin_name).get_out_of_source_build()
+        ):
             return self.part_build_dir / self.spec.source_subdir
         return self.part_build_dir
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -63,6 +63,11 @@ class Plugin(abc.ABC):
     @property
     def out_of_source_build(self) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
+        return self.get_out_of_source_build()
+
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
+        """Return whether the plugin performs out-of-source-tree builds."""
         return False
 
     @abc.abstractmethod

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -60,11 +60,6 @@ class Plugin(abc.ABC):
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
 
-    @property
-    def out_of_source_build(self) -> bool:
-        """Return whether the plugin performs out-of-source-tree builds."""
-        return self.get_out_of_source_build()
-
     @classmethod
     def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -98,7 +98,7 @@ class CMakePlugin(Plugin):
 
         cmake_command = [
             "cmake",
-            f'"{self._part_info.part_src_dir}"',
+            f'"{self._part_info.part_src_subdir}"',
             "-G",
             f'"{options.cmake_generator}"',
         ] + options.cmake_parameters
@@ -112,7 +112,7 @@ class CMakePlugin(Plugin):
             ),
         ]
 
-    @property
-    def out_of_source_build(self) -> bool:
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -93,8 +93,8 @@ class MesonPlugin(Plugin):
     properties_class = MesonPluginProperties
     validator_class = MesonPluginEnvironmentValidator
 
-    @property
-    def out_of_source_build(self) -> bool:
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True
 
@@ -114,7 +114,7 @@ class MesonPlugin(Plugin):
         """Return a list of commands to run during the build step."""
         options = cast(MesonPluginProperties, self._options)
 
-        meson_cmd = ["meson", str(self._part_info.part_src_dir)]
+        meson_cmd = ["meson", str(self._part_info.part_src_subdir)]
         if options.meson_parameters:
             meson_cmd.extend(shlex.quote(p) for p in options.meson_parameters)
 

--- a/tests/integration/plugins/test_cmake.py
+++ b/tests/integration/plugins/test_cmake.py
@@ -78,3 +78,56 @@ def test_cmake_plugin(new_dir):
 
     output = subprocess.check_output([str(binary)], text=True)
     assert output == "hello world\n"
+
+
+def test_cmake_plugin_subdir(new_dir):
+    """Verify cmake builds with a source subdirectory."""
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: cmake
+            source: .
+            source-subdir: test-subdir
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    source_subdir = Path("test-subdir")
+    source_subdir.mkdir(parents=True)
+
+    (source_subdir / "hello.c").write_text(
+        textwrap.dedent(
+            """\
+            #include <stdio.h>
+
+            int main()
+            {
+                printf(\"hello world\\n\");
+                return 0;
+            }
+            """
+        )
+    )
+
+    (source_subdir / "CMakeLists.txt").write_text(
+        textwrap.dedent(
+            """\
+            cmake_minimum_required(VERSION 2.6)
+            project(cmake-hello C)
+            add_executable(cmake-hello hello.c)
+            install(TARGETS cmake-hello RUNTIME DESTINATION bin)
+            """
+        )
+    )
+
+    lf = LifecycleManager(parts, application_name="test_cmake", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    binary = Path(lf.project_info.prime_dir, "usr/local/bin", "cmake-hello")
+
+    output = subprocess.check_output([str(binary)], text=True)
+    assert output == "hello world\n"

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -187,9 +187,8 @@ class TestPartHandling:
         mocker.patch("subprocess.check_output", return_value=b"os-info")
 
         mocker.patch(
-            "craft_parts.plugins.plugins.NilPlugin.out_of_source_build",
+            "craft_parts.plugins.base.Plugin.get_out_of_source_build",
             return_value=out_of_source,
-            new_callable=mocker.PropertyMock,
         )
 
         self._part_info.part_src_dir.mkdir(parents=True)

--- a/tests/unit/plugins/test_autotools_plugin.py
+++ b/tests/unit/plugins/test_autotools_plugin.py
@@ -109,3 +109,6 @@ class TestPluginAutotools:
         assert len(err) == 1
         assert err[0]["loc"] == ("source",)
         assert err[0]["type"] == "value_error.missing"
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -70,6 +70,7 @@ def test_plugin(new_dir):
     assert plugin.get_build_packages() == {"build_package"}
     assert plugin.get_build_environment() == {"ENV": "value"}
     assert plugin.out_of_source_build is False
+    assert plugin.get_out_of_source_build() is False
     assert plugin.get_build_commands() == ["hello", "world"]
 
 

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -69,7 +69,6 @@ def test_plugin(new_dir):
     assert plugin.get_build_snaps() == {"build_snap"}
     assert plugin.get_build_packages() == {"build_package"}
     assert plugin.get_build_environment() == {"ENV": "value"}
-    assert plugin.out_of_source_build is False
     assert plugin.get_out_of_source_build() is False
     assert plugin.get_build_commands() == ["hello", "world"]
 

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -143,11 +143,6 @@ class TestPluginCMakePlugin:
             ),
         ]
 
-    def test_out_of_source_build(self, setup_method_fixture, new_dir):
-        plugin = setup_method_fixture(new_dir)
-
-        assert plugin.out_of_source_build is True
-
     def test_get_out_of_source_build(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(new_dir)
 

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -147,3 +147,8 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir)
 
         assert plugin.out_of_source_build is True
+
+    def test_get_out_of_source_build(self, setup_method_fixture, new_dir):
+        plugin = setup_method_fixture(new_dir)
+
+        assert plugin.get_out_of_source_build() is True

--- a/tests/unit/plugins/test_dotnet_plugin.py
+++ b/tests/unit/plugins/test_dotnet_plugin.py
@@ -156,3 +156,10 @@ def test_missing_parameters():
     assert len(err) == 1
     assert err[0]["loc"] == ("source",)
     assert err[0]["type"] == "value_error.missing"
+
+
+def test_get_out_of_source_build(new_dir, part_info):
+    properties = DotnetPlugin.properties_class.unmarshal({"source": "."})
+    plugin = DotnetPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_dump_plugin.py
+++ b/tests/unit/plugins/test_dump_plugin.py
@@ -59,3 +59,6 @@ class TestPluginDump:
 
     def test_out_of_source_build(self):
         assert self._plugin.out_of_source_build is False
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_dump_plugin.py
+++ b/tests/unit/plugins/test_dump_plugin.py
@@ -57,8 +57,5 @@ class TestPluginDump:
             'cp --archive --link --no-dereference . "install/dir"'
         ]
 
-    def test_out_of_source_build(self):
-        assert self._plugin.out_of_source_build is False
-
     def test_get_out_of_source_build(self):
         assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -171,3 +171,10 @@ def test_missing_parameters():
     assert len(err) == 1
     assert err[0]["loc"] == ("source",)
     assert err[0]["type"] == "value_error.missing"
+
+
+def test_get_out_of_source_build(part_info):
+    properties = GoPlugin.properties_class.unmarshal({"source": "."})
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_make_plugin.py
+++ b/tests/unit/plugins/test_make_plugin.py
@@ -92,3 +92,6 @@ class TestPluginMake:
         assert len(err) == 1
         assert err[0]["loc"] == ("source",)
         assert err[0]["type"] == "value_error.missing"
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -154,13 +154,6 @@ def test_validate_environment_without_ninja_part(part_info):
     )
 
 
-def test_out_of_source_build(part_info):
-    properties = MesonPlugin.properties_class.unmarshal({"source": "."})
-    plugin = MesonPlugin(properties=properties, part_info=part_info)
-
-    assert plugin.out_of_source_build is True
-
-
 def test_get_out_of_source_build(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)

--- a/tests/unit/plugins/test_meson_plugin.py
+++ b/tests/unit/plugins/test_meson_plugin.py
@@ -161,6 +161,13 @@ def test_out_of_source_build(part_info):
     assert plugin.out_of_source_build is True
 
 
+def test_get_out_of_source_build(part_info):
+    properties = MesonPlugin.properties_class.unmarshal({"source": "."})
+    plugin = MesonPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_out_of_source_build() is True
+
+
 def test_get_build_snaps(part_info):
     properties = MesonPlugin.properties_class.unmarshal({"source": "."})
     plugin = MesonPlugin(properties=properties, part_info=part_info)

--- a/tests/unit/plugins/test_nil_plugin.py
+++ b/tests/unit/plugins/test_nil_plugin.py
@@ -48,3 +48,6 @@ class TestPluginNil:
 
     def test_out_of_source_build(self):
         assert self._plugin.out_of_source_build is False
+
+    def test_get_out_of_source_build(self):
+        assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_nil_plugin.py
+++ b/tests/unit/plugins/test_nil_plugin.py
@@ -46,8 +46,5 @@ class TestPluginNil:
     def test_get_build_commands(self):
         assert self._plugin.get_build_commands() == []
 
-    def test_out_of_source_build(self):
-        assert self._plugin.out_of_source_build is False
-
     def test_get_out_of_source_build(self):
         assert self._plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -24,6 +24,8 @@ from craft_parts.infos import PartInfo, ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.plugins.npm_plugin import NpmPlugin
 
+# pylint: disable=too-many-public-methods
+
 
 @pytest.fixture()
 def part_info(new_dir):
@@ -328,3 +330,9 @@ class TestPluginNpmPlugin:
             raised.value.brief
             == """Architecture "System/360 ('32bit', 'OS/360')" is not supported."""
         )
+
+    def test_get_out_of_source_build(self, part_info, new_dir):
+        properties = NpmPlugin.properties_class.unmarshal({"source": "."})
+        plugin = NpmPlugin(properties=properties, part_info=part_info)
+
+        assert plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -25,8 +25,11 @@ from craft_parts.plugins import nil_plugin
 from craft_parts.plugins.plugins import (
     AutotoolsPlugin,
     CMakePlugin,
+    DotnetPlugin,
     DumpPlugin,
+    GoPlugin,
     MakePlugin,
+    MesonPlugin,
     NilPlugin,
     NpmPlugin,
     PythonPlugin,
@@ -46,8 +49,11 @@ class TestGetPlugin:
         [
             ("autotools", AutotoolsPlugin, {"source": "."}),
             ("cmake", CMakePlugin, {"source": "."}),
+            ("dotnet", DotnetPlugin, {"source": "."}),
             ("dump", DumpPlugin, {"source": "."}),
+            ("go", GoPlugin, {"source": "."}),
             ("make", MakePlugin, {"source": "."}),
+            ("meson", MesonPlugin, {"source": "."}),
             ("nil", NilPlugin, {}),
             ("npm", NpmPlugin, {"source": "."}),
             ("python", PythonPlugin, {"source": "."}),

--- a/tests/unit/plugins/test_python_plugin.py
+++ b/tests/unit/plugins/test_python_plugin.py
@@ -135,3 +135,7 @@ def test_missing_properties():
     assert len(err) == 1
     assert err[0]["loc"] == ("source",)
     assert err[0]["type"] == "value_error.missing"
+
+
+def test_get_out_of_source_build(plugin):
+    assert plugin.get_out_of_source_build() is False

--- a/tests/unit/plugins/test_rust_plugin.py
+++ b/tests/unit/plugins/test_rust_plugin.py
@@ -232,3 +232,9 @@ class TestPluginRustPlugin:
             RustPlugin.properties_class.unmarshal(
                 {"source": ".", "rust-path": rust_path}
             )
+
+    def test_get_out_of_source_build(self, part_info):
+        properties = RustPlugin.properties_class.unmarshal({"source": "."})
+        plugin = RustPlugin(properties=properties, part_info=part_info)
+
+        assert plugin.get_out_of_source_build() is False

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -24,6 +24,8 @@ from craft_parts.dirs import ProjectDirs
 from craft_parts.parts import Part, PartSpec
 from craft_parts.steps import Step
 
+# pylint: disable=too-many-public-methods
+
 
 class TestPartSpecs:
     """Test part specification creation."""
@@ -113,8 +115,42 @@ class TestPartData:
         assert p.stage_dir == new_dir / "foobar/stage"
         assert p.prime_dir == new_dir / "foobar/prime"
 
-    def test_part_subdirs(self, new_dir):
+    def test_part_subdirs_default(self, new_dir):
+        """Verify subdirectories for a part with no plugin."""
         p = Part("foo", {"source-subdir": "foobar"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_out_of_source_and_source_subdir(self, new_dir):
+        """
+        Verify subdirectories for a plugin that supports out-of-source builds
+        and has a source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "cmake", "source-subdir": "foobar"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_out_of_source(self, new_dir):
+        """
+        Verify subdirectories for a plugin that supports out-of-source builds
+        and no source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "cmake"})
+        assert p.part_src_dir == new_dir / "parts/foo/src"
+        assert p.part_src_subdir == new_dir / "parts/foo/src"
+        assert p.part_build_dir == new_dir / "parts/foo/build"
+        assert p.part_build_subdir == new_dir / "parts/foo/build"
+
+    def test_part_subdirs_source_subdir(self, new_dir):
+        """
+        Verify subdirectories for a plugin that does not support out-of-source builds
+        and has a source subdirectory defined.
+        """
+        p = Part("foo", {"plugin": "dump", "source-subdir": "foobar"})
         assert p.part_src_dir == new_dir / "parts/foo/src"
         assert p.part_src_subdir == new_dir / "parts/foo/src/foobar"
         assert p.part_build_dir == new_dir / "parts/foo/build"


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Plugins that supported out-of-source building were not working with the source-subdir parameter.

There were two minor issues:

1. A missing check for out-of-source plugins when determining the build directory
2. `cmake` and `meson` plugins not choosing the right source directory

Unfortunately, accessing the out_of_source_build property prior to instantiating the plugin was a challenge. I've made some comments below.

(CRAFT-1185)