### PR TITLE
repo: fix_pkg_config removes prefixes from staged snap's .pc files.

### DIFF
--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -154,7 +154,7 @@ class StepHandler:
             if not file_path.endswith(".pc"):
                 return
             packages.fix_pkg_config(
-                root=self._part.stage_dir,
+                prefix_prepend=self._part.stage_dir,
                 pkg_config_file=file_path,
                 prefix_trim=self._part.part_install_dir,
             )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
When normalizing pkg-config (.pc) files from staged snaps, directories previously prepended to the prefix parameter will be removed:

- `/build/<snap-name>/stage` from snaps built via launchpad
-  `/root/stage` from snaps built via a provider

An almost duplicate of https://github.com/snapcore/snapcraft/pull/3848.

LP: #[1916281](https://bugs.launchpad.net/snapcraft/+bug/1916281)
(CRAFT-1215)