### PR TITLE
repo: fix_pkg_config trims prefixes more generically

### DIFF
--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -166,18 +166,22 @@ def fix_pkg_config(
     2. Remove directories commonly added by staged snaps from the prefix.
     3. Prepend `prefix_prepend` to the prefix.
 
-    The prepended directory depends on the source of the pkg-config file:
-    - From snaps built via launchpad: the stage directory
-      `/build/<snap-name>/stage/` is prepended
-    - From snaps built via a provider: the stage directory `/root/stage/` is prepended
-    - Built during the build stage: the install directory may be prepended
+    The prepended stage directory depends on the source of the pkg-config file:
+    - From snaps built via launchpad: `/build/<snap-name>/stage/`
+    - From snaps built via a provider: `/root/stage/`
+    - From snaps built locally: `<local-path-to-project>/stage`
+    - Built during the build stage: the install directory
+
+    To capture these possibilities, all directories prior to and
+    including `stage/` are trimmed.
+    For example, `/root/stage/usr` is trimmed to `/usr`.
 
     :param pkg_config_file: pkg-config (.pc) file to modify
     :param prefix_prepend: directory to prepend to the prefix
     :param prefix_trim: directory to remove from prefix
     """
     # build patterns
-    prefixes_to_trim = [r"/build/[\w\-. ]+/stage", "/root/stage"]
+    prefixes_to_trim = [r"[\w\-. /]*/stage"]
     if prefix_trim:
         prefixes_to_trim.append(prefix_trim.as_posix())
     pattern_trim = re.compile(

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -266,38 +266,24 @@ class TestFixPkgConfig:
     @pytest.mark.parametrize(
         "prefix,fixed_prefix",
         [
+            # typical prefix from a snap built via launchpad
             ("/build/mir-core20/stage", ""),
             ("/build/mir-core20/stage/usr", "/usr"),
-            ("/build/test/test/stage", "/build/test/test/stage"),
-        ],
-    )
-    def test_fix_pkg_config_trim_launchpad_prefix(
-        self,
-        tmpdir,
-        prefix,
-        fixed_prefix,
-        pkg_config_file,
-        expected_pkg_config_content,
-    ):
-        """Verify prefixes from snaps built via launchpad are trimmed."""
-        pc_file = tmpdir / "my-file.pc"
-        pkg_config_file(pc_file, prefix)
-
-        fix_pkg_config(tmpdir, pc_file)
-
-        assert pc_file.read_text(encoding="utf-8") == expected_pkg_config_content(
-            f"{tmpdir}{fixed_prefix}"
-        )
-
-    @pytest.mark.parametrize(
-        "prefix,fixed_prefix",
-        [
+            # typical prefix from a snap built via a provider
             ("/root/stage", ""),
             ("/root/stage/usr", "/usr"),
-            ("/root/test/stage", "/root/test/stage"),
+            # arbitrary prefixes, possibly from a locally built snap
+            ("/test/path/stage", ""),
+            ("/test/path/stage/usr", "/usr"),
+            ("/test/path/stage/usr/lib", "/usr/lib"),
+            # verify "stage" can be used elsewhere in the path name
+            ("/build/stage/stage", ""),
+            ("/build/stage/stage/usr", "/usr"),
+            ("/build/my-stage-snap/stage", ""),
+            ("/build/my-stage-snap/stage/usr", "/usr"),
         ],
     )
-    def test_fix_pkg_config_trim_provider_prefix(
+    def test_fix_pkg_config_trim_prefix_from_snap(
         self,
         tmpdir,
         prefix,
@@ -305,7 +291,7 @@ class TestFixPkgConfig:
         pkg_config_file,
         expected_pkg_config_content,
     ):
-        """Verify prefixes from snaps built via a provider are trimmed."""
+        """Verify prefixes from snaps are trimmed."""
         pc_file = tmpdir / "my-file.pc"
         pkg_config_file(pc_file, prefix)
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Follow up to https://github.com/canonical/craft-parts/pull/251 thanks to an idea from @cmatsuoka.

When normalizing pkg-config (.pc) files from staged snaps, the previously prepended `<path-to-project-path>/stage` will be removed from the `prefix` parameter.

This means all directories prior to and including `stage/` are trimmed.

For example, `/root/stage/usr` is trimmed to `/usr`.

LP: #[1916281](https://bugs.launchpad.net/snapcraft/+bug/1916281)
(CRAFT-1215)