### PR TITLE
lint: normalize link(), copy(), and link_or_copy() signatures

### DIFF
--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -71,7 +71,9 @@ class NonBlockingRWFifo:
             os.close(self._fd)
 
 
-def link_or_copy(source: str, destination: str, follow_symlinks: bool = False) -> None:
+def link_or_copy(
+    source: str, destination: str, *, follow_symlinks: bool = False
+) -> None:
     """Hard-link source and destination files. Copy if it fails to link.
 
     Hard-linking may fail (e.g. a cross-device link, or permission denied), so
@@ -91,7 +93,7 @@ def link_or_copy(source: str, destination: str, follow_symlinks: bool = False) -
             # os.link will fail if the destination already exists, so let's
             # remove it and try again.
             os.remove(destination)
-            link_or_copy(source, destination, follow_symlinks)
+            link_or_copy(source, destination, follow_symlinks=follow_symlinks)
         else:
             copy(source, destination, follow_symlinks=follow_symlinks)
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Latest Pyright release fixed a bug and found a new error!

Pyright 1.1.264 [changelog](https://github.com/microsoft/pyright/releases/tag/1.1.264):
`Bug Fix: Fixed a bug that resulted in incorrect type inference for unannotated parameters with a default argument value in an __init__ method.`

Source: https://github.com/canonical/craft-parts/blob/7c8140f4c69959674afee30109a36cc8697bb873/craft_parts/sources/local_source.py#L41

Error: 
```
pyright 1.1.264
/home/developer/dev/craft-parts/craft_parts/executor/part_handler.py
  /home/developer/dev/craft-parts/craft_parts/executor/part_handler.py:601:31 - error: Argument of type "(source: str, destination: str, *, follow_symlinks: bool = False) -> None" cannot be assigned to parameter "copy_function" of type "(source: str, destination: str, follow_symlinks: bool = False) -> None" in function "__init__"
    Type "(source: str, destination: str, *, follow_symlinks: bool = False) -> None" cannot be assigned to type "(source: str, destination: str, follow_symlinks: bool = False) -> None"
      Function accepts too many positional parameters; expected 2 but received 3 (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations
```