### PR TITLE
Revert "repo: fix_pkg_config trims prefixes more generically"

### DIFF
--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -167,21 +167,17 @@ def fix_pkg_config(
     3. Prepend `prefix_prepend` to the prefix.
 
     The prepended stage directory depends on the source of the pkg-config file:
-    - From snaps built via launchpad: `/build/<snap-name>/stage/`
-    - From snaps built via a provider: `/root/stage/`
+    - From snaps built via launchpad: `/build/<snap-name>/stage`
+    - From snaps built via a provider: `/root/stage`
     - From snaps built locally: `<local-path-to-project>/stage`
     - Built during the build stage: the install directory
-
-    To capture these possibilities, all directories prior to and
-    including `stage/` are trimmed.
-    For example, `/root/stage/usr` is trimmed to `/usr`.
 
     :param pkg_config_file: pkg-config (.pc) file to modify
     :param prefix_prepend: directory to prepend to the prefix
     :param prefix_trim: directory to remove from prefix
     """
     # build patterns
-    prefixes_to_trim = [r"[\w\-. /]*/stage"]
+    prefixes_to_trim = [r"/build/[\w\-. ]+/stage", "/root/stage"]
     if prefix_trim:
         prefixes_to_trim.append(prefix_trim.as_posix())
     pattern_trim = re.compile(

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -266,21 +266,17 @@ class TestFixPkgConfig:
     @pytest.mark.parametrize(
         "prefix,fixed_prefix",
         [
-            # typical prefix from a snap built via launchpad
+            # possible prefixes from snaps built via launchpad
             ("/build/mir-core20/stage", ""),
             ("/build/mir-core20/stage/usr", "/usr"),
-            # typical prefix from a snap built via a provider
+            ("/build/stage/stage", ""),
+            ("/build/stage/stage/usr/stage", "/usr/stage"),
+            ("/build/my-stage-snap/stage", ""),
+            ("/build/my-stage-snap/stage/usr/stage", "/usr/stage"),
+            # possible prefixes from snaps built via a provider
             ("/root/stage", ""),
             ("/root/stage/usr", "/usr"),
-            # arbitrary prefixes, possibly from a locally built snap
-            ("/test/path/stage", ""),
-            ("/test/path/stage/usr", "/usr"),
-            ("/test/path/stage/usr/lib", "/usr/lib"),
-            # verify "stage" can be used elsewhere in the path name
-            ("/build/stage/stage", ""),
-            ("/build/stage/stage/usr", "/usr"),
-            ("/build/my-stage-snap/stage", ""),
-            ("/build/my-stage-snap/stage/usr", "/usr"),
+            ("/root/stage/usr/stage", "/usr/stage"),
         ],
     )
     def test_fix_pkg_config_trim_prefix_from_snap(
@@ -330,7 +326,16 @@ class TestFixPkgConfig:
 
     @pytest.mark.parametrize(
         "prefix",
-        ["", "/", "/usr"],
+        [
+            "",
+            "/",
+            "/usr",
+            "/build/test/test/stage",
+            "/root/test/stage",
+            "/test/path/stage",
+            "/test/path/stage/usr",
+            "/test/path/stage/usr/stage",
+        ],
     )
     def test_fix_pkg_config_no_trim(
         self,


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This reverts commit f6681f0fef39c38c1a4d3a7808d9e66cb884a369.
This commit caused craft-part's behavior to change when `stage` is part of the pwd.