### PR TITLE
packages: fetch stage-packages from host arch's repo

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -846,7 +846,7 @@ class PartHandler:
             fetched_packages = packages.Repository.fetch_stage_packages(
                 cache_dir=step_info.cache_dir,
                 package_names=stage_packages,
-                target_arch=step_info.target_arch,
+                arch=step_info.host_arch,
                 base=step_info.base,
                 stage_packages_path=self._part.part_packages_dir,
             )

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -137,8 +137,13 @@ class ProjectInfo:
         return self._parallel_build_count
 
     @property
+    def host_arch(self) -> str:
+        """Return the host architecture used for debs, snaps and charms."""
+        return self._host_machine["deb"]
+
+    @property
     def target_arch(self) -> str:
-        """Return the architecture used for debs, snaps and charms."""
+        """Return the target architecture used for debs, snaps and charms."""
         return self._machine["deb"]
 
     @property
@@ -247,16 +252,22 @@ class ProjectInfo:
             raise ValueError(f"{name!r} not in project variables")
 
     def _set_machine(self, arch: Optional[str]):
-        """Initialize machine information based on the architecture.
+        """Initialize host and target machine information based on the architecture.
 
         :param arch: The architecture to use. If empty, assume the
             host system architecture.
         """
+        # set host machine and arch
         self._host_arch = _get_host_architecture()
+        host_machine = _ARCH_TRANSLATIONS.get(self._host_arch)
+        if not host_machine:
+            raise errors.InvalidArchitecture(self._host_arch)
+        self._host_machine = host_machine
+
+        # set target machine and arch
         if not arch:
             arch = self._host_arch
             logger.debug("Setting target machine to %s", arch)
-
         machine = _ARCH_TRANSLATIONS.get(arch)
         if not machine:
             raise errors.InvalidArchitecture(arch)

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -133,7 +133,7 @@ class BaseRepository(abc.ABC):
         package_names: List[str],
         stage_packages_path: Path,
         base: str,
-        target_arch: str,
+        arch: str,
         list_only: bool = False,
     ) -> List[str]:
         """Fetch stage packages to stage_packages_path.
@@ -143,7 +143,7 @@ class BaseRepository(abc.ABC):
         :param package_names: A list with the names of the packages to fetch.
         :stage_packages_path: The path stage packages will be fetched to.
         :param base: The base this project will run on.
-        :param target_arch: The architecture of the packages to fetch.
+        :param arch: The architecture of the packages to fetch.
         :param list_only: Whether to obtain a list of packages to be fetched
             instead of actually fetching the packages.
 

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -557,7 +557,7 @@ class Ubuntu(BaseRepository):
         package_names: List[str],
         stage_packages_path: pathlib.Path,
         base: str,
-        target_arch: str,
+        arch: str,
         list_only: bool = False,
     ) -> List[str]:
         """Fetch stage packages to stage_packages_path."""
@@ -582,9 +582,7 @@ class Ubuntu(BaseRepository):
         # Update the package cache
         cls.refresh_packages_list()
 
-        with AptCache(
-            stage_cache=stage_cache_dir, stage_cache_arch=target_arch
-        ) as apt_cache:
+        with AptCache(stage_cache=stage_cache_dir, stage_cache_arch=arch) as apt_cache:
             apt_cache.mark_packages(set(package_names))
             apt_cache.unmark_packages(filtered_names)
 

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -155,7 +155,7 @@ class TestPackages:
             package_names=["fake-package"],
             stage_packages_path=Path(tmpdir),
             base="core",
-            target_arch="amd64",
+            arch="amd64",
         )
 
         fake_run.assert_has_calls([call(["apt-get", "update"])])
@@ -186,7 +186,7 @@ class TestPackages:
             package_names=["virtual-fake-package"],
             stage_packages_path=Path(tmpdir),
             base="core",
-            target_arch="amd64",
+            arch="amd64",
         )
 
         fake_run.assert_has_calls([call(["apt-get", "update"])])
@@ -208,7 +208,7 @@ class TestPackages:
             package_names=["fake-package"],
             stage_packages_path=Path(tmpdir),
             base="core",
-            target_arch="amd64",
+            arch="amd64",
         )
 
         fake_run.assert_has_calls([call(["apt-get", "update"])])
@@ -226,7 +226,7 @@ class TestPackages:
             package_names=[],
             stage_packages_path=Path(tmpdir),
             base="core",
-            target_arch="amd64",
+            arch="amd64",
         )
 
         assert fetched_packages == []
@@ -242,7 +242,7 @@ class TestPackages:
                 package_names=["fake-package"],
                 stage_packages_path=Path(tmpdir),
                 base="core",
-                target_arch="amd64",
+                arch="amd64",
             )
 
         assert raised.value.message == "foo"


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
`stage-packages` are now fetched from the host architecture's repositories instead of the target architecture's repository.
This was causing an error during cross-compiling because the target architecture's repository was not registered.


LP: #[1983009](https://bugs.launchpad.net/snapcraft/+bug/1983009)
(CRAFT-1216)