### PR TITLE
plugins: fix cmake plugin prefix

### DIFF
--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -89,7 +89,8 @@ class CMakePlugin(Plugin):
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
-            "CMAKE_PREFIX_PATH": "{self._part_info.stage_dir}",
+            # Also look for staged headers and libraries.
+            "CMAKE_PREFIX_PATH": str(self._part_info.stage_dir)
         }
 
     def get_build_commands(self) -> List[str]:
@@ -101,6 +102,11 @@ class CMakePlugin(Plugin):
             f'"{self._part_info.part_src_subdir}"',
             "-G",
             f'"{options.cmake_generator}"',
+            # Install on a location we search when building using staged files
+            # (e.g. CMAKE_PREFIX_PATH/lib, CMAKE_PREFIX_PATH/lib/<arch> for libs,
+            # see https://cmake.org/cmake/help/latest/command/find_library.html).
+            # This can be overridden by the user using cmake-parameters.
+            "-DCMAKE_INSTALL_PREFIX=",
         ] + options.cmake_parameters
 
         return [

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -80,14 +80,17 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir)
 
         assert plugin.get_build_environment() == {
-            "CMAKE_PREFIX_PATH": "{self._part_info.stage_dir}",
+            "CMAKE_PREFIX_PATH": f"{str(new_dir)}/stage"
         }
 
     def test_get_build_commands_default(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(new_dir)
 
         assert plugin.get_build_commands() == [
-            (f'cmake "{plugin._part_info.part_src_dir}"' ' -G "Unix Makefiles"'),
+            (
+                f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
+                "-DCMAKE_INSTALL_PREFIX="
+            ),
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -99,7 +102,10 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir, properties={"cmake-generator": "Ninja"})
 
         assert plugin.get_build_commands() == [
-            (f'cmake "{plugin._part_info.part_src_dir}"' ' -G "Ninja"'),
+            (
+                f'cmake "{plugin._part_info.part_src_dir}" -G "Ninja" '
+                "-DCMAKE_INSTALL_PREFIX="
+            ),
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -113,7 +119,10 @@ class TestPluginCMakePlugin:
         )
 
         assert plugin.get_build_commands() == [
-            (f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles"'),
+            (
+                f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
+                "-DCMAKE_INSTALL_PREFIX="
+            ),
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -133,8 +142,8 @@ class TestPluginCMakePlugin:
 
         assert plugin.get_build_commands() == [
             (
-                f'cmake "{plugin._part_info.part_src_dir}"'
-                f' -G "Unix Makefiles" {" ".join(cmake_parameters)}'
+                f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
+                f'-DCMAKE_INSTALL_PREFIX= {" ".join(cmake_parameters)}'
             ),
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (


### PR DESCRIPTION
Properly format the cmake prefix path string, and set the installation
prefix to match v1 plugins.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1154