### PR TITLE
plugins: drop cmake install prefix argument

### DIFF
--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -57,7 +57,16 @@ class CMakePlugin(Plugin):
     For more information check the 'plugins' topic for the former and the
     'sources' topic for the latter.
 
-    Additionally, this plugin uses the following plugin-specific keywords:
+    This implementation follows the syntax and behavior used in the
+    Snapcraft cmake plugin for core20. Unlike the cmake plugin used for
+    core18, ``CMAKE_INSTALL_PREFIX`` is not automatically set. To retain
+    compatibility with the Snapcraft core18 plugin, define the cmake
+    parameter ``-DCMAKE_INSTALL_PREFIX=`` in your project.  This also
+    allows libraries built using the cmake plugin and staged by a different
+    part to be automatically recognized without defining additional
+    parameters such as ``CMAKE_INCLUDE_PATH`` or ``CMAKE_INSTALL_PATH``.
+
+    This plugin uses the following plugin-specific keywords:
 
         - cmake-parameters
           (list of strings)
@@ -102,11 +111,6 @@ class CMakePlugin(Plugin):
             f'"{self._part_info.part_src_subdir}"',
             "-G",
             f'"{options.cmake_generator}"',
-            # Install on a location we search when building using staged files
-            # (e.g. CMAKE_PREFIX_PATH/lib, CMAKE_PREFIX_PATH/lib/<arch> for libs,
-            # see https://cmake.org/cmake/help/latest/command/find_library.html).
-            # This can be overridden by the user using cmake-parameters.
-            "-DCMAKE_INSTALL_PREFIX=",
         ] + options.cmake_parameters
 
         return [

--- a/tests/integration/plugins/test_cmake.py
+++ b/tests/integration/plugins/test_cmake.py
@@ -27,8 +27,10 @@ from craft_parts import LifecycleManager, Step
 @pytest.mark.parametrize(
     "prefix,install_path",
     [
-        (None, "bin"),
+        (None, "usr/local/bin"),
+        ("", "bin"),
         ("/usr/local", "usr/local/bin"),
+        ("/something/else", "something/else/bin"),
     ],
 )
 def test_cmake_plugin(new_dir, prefix, install_path):
@@ -40,7 +42,7 @@ def test_cmake_plugin(new_dir, prefix, install_path):
             source: .
         """
     )
-    if prefix:
+    if prefix is not None:
         parts_yaml += f"    cmake-parameters: [-DCMAKE_INSTALL_PREFIX={prefix}]"
 
     parts = yaml.safe_load(parts_yaml)
@@ -94,8 +96,10 @@ def test_cmake_plugin(new_dir, prefix, install_path):
 @pytest.mark.parametrize(
     "prefix,install_path",
     [
-        (None, "bin"),
+        (None, "usr/local/bin"),
+        ("", "bin"),
         ("/usr/local", "usr/local/bin"),
+        ("/something/else", "something/else/bin"),
     ],
 )
 def test_cmake_plugin_subdir(new_dir, prefix, install_path):
@@ -109,7 +113,7 @@ def test_cmake_plugin_subdir(new_dir, prefix, install_path):
             source-subdir: test-subdir
         """
     )
-    if prefix:
+    if prefix is not None:
         parts_yaml += f"    cmake-parameters: [-DCMAKE_INSTALL_PREFIX={prefix}]"
 
     parts = yaml.safe_load(parts_yaml)

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -87,10 +87,7 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir)
 
         assert plugin.get_build_commands() == [
-            (
-                f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
-                "-DCMAKE_INSTALL_PREFIX="
-            ),
+            f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles"',
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -102,10 +99,7 @@ class TestPluginCMakePlugin:
         plugin = setup_method_fixture(new_dir, properties={"cmake-generator": "Ninja"})
 
         assert plugin.get_build_commands() == [
-            (
-                f'cmake "{plugin._part_info.part_src_dir}" -G "Ninja" '
-                "-DCMAKE_INSTALL_PREFIX="
-            ),
+            f'cmake "{plugin._part_info.part_src_dir}" -G "Ninja"',
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -119,10 +113,7 @@ class TestPluginCMakePlugin:
         )
 
         assert plugin.get_build_commands() == [
-            (
-                f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
-                "-DCMAKE_INSTALL_PREFIX="
-            ),
+            f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles"',
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (
                 f'DESTDIR="{plugin._part_info.part_install_dir}" '
@@ -143,7 +134,7 @@ class TestPluginCMakePlugin:
         assert plugin.get_build_commands() == [
             (
                 f'cmake "{plugin._part_info.part_src_dir}" -G "Unix Makefiles" '
-                f'-DCMAKE_INSTALL_PREFIX= {" ".join(cmake_parameters)}'
+                f'{" ".join(cmake_parameters)}'
             ),
             f"cmake --build . -- -j{plugin._part_info.parallel_build_count}",
             (


### PR DESCRIPTION
Setting `CMAKE_INSTALL_PREFIX` by default makes the cmake plugin
compatible with the Snapcraft cmake plugin for core18 and solves
usability issues, but it also breaks compatibility with existing
core22 snaps that expect binaries to be installed in `usr/local/bin`
by default.

To keep compatibility with existing core22 snaps, the prefix path
will not be defined by default, and snap authors are encouraged
to define `-DCMAKE_INSTALL_PREFIX=` in cmake parameters to be
compatible with the core18 cmake plugin, so that libraries
built with cmake and staged by a different part can be correctly
detected without the need to define additional parameters such as
`CMAKE_INCLUDE_PATH` and `CMAKE_LIBRARY_PATH`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
