### PR TITLE
sources: support "deb" sources

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -538,3 +538,16 @@ class OverlayPermissionError(PartsError):
         brief = "Using the overlay step requires superuser privileges."
 
         super().__init__(brief=brief)
+
+
+class DebError(PartsError):
+    """A "deb"-related command failed."""
+
+    def __init__(self, deb_path, command, exit_code):
+        brief = (
+            f"Failed when handling {deb_path}: "
+            f"command {command!r} exited with code {exit_code}."
+        )
+        resolution = "Make sure the deb file is correctly specified."
+
+        super().__init__(brief=brief, resolution=resolution)

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -28,7 +28,7 @@ import tempfile
 from pathlib import Path
 from typing import Dict, List, Sequence, Set, Tuple
 
-from craft_parts.utils import file_utils, os_utils
+from craft_parts.utils import deb_utils, file_utils, os_utils
 
 from . import errors
 from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
@@ -615,7 +615,7 @@ class Ubuntu(BaseRepository):
                 suffix="deb-extract", dir=install_path.parent
             ) as extract_dir:
                 # Extract deb package.
-                cls._extract_deb(pkg_path, extract_dir)
+                deb_utils.extract_deb(pkg_path, Path(extract_dir), logger.debug)
                 # Mark source of files.
                 marked_name = cls._extract_deb_name_version(pkg_path)
                 mark_origin_stage_package(extract_dir, marked_name)
@@ -652,14 +652,6 @@ class Ubuntu(BaseRepository):
             raise errors.UnpackError(str(deb_path)) from err
 
         return output.decode().strip()
-
-    @classmethod
-    def _extract_deb(cls, deb_path: pathlib.Path, extract_dir: str) -> None:
-        """Extract deb and return `<package-name>=<version>`."""
-        try:
-            process_run(["dpkg-deb", "--extract", str(deb_path), extract_dir])
-        except subprocess.CalledProcessError as err:
-            raise errors.UnpackError(str(deb_path)) from err
 
 
 def get_cache_dirs(cache_dir: Path):

--- a/craft_parts/sources/deb_source.py
+++ b/craft_parts/sources/deb_source.py
@@ -1,0 +1,95 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The deb source handler."""
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from craft_parts.dirs import ProjectDirs
+from craft_parts.utils import deb_utils
+
+from . import errors
+from .base import FileSourceHandler
+
+logger = logging.getLogger(__name__)
+
+
+class DebSource(FileSourceHandler):
+    """The "deb" file source handler."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        source: str,
+        part_src_dir: Path,
+        *,
+        cache_dir: Path,
+        source_tag: Optional[str] = None,
+        source_commit: Optional[str] = None,
+        source_branch: Optional[str] = None,
+        source_checksum: Optional[str] = None,
+        source_submodules: Optional[List[str]] = None,
+        source_depth: Optional[int] = None,
+        project_dirs: Optional[ProjectDirs] = None,
+        ignore_patterns: Optional[List[str]] = None,
+    ):
+        super().__init__(
+            source,
+            part_src_dir,
+            cache_dir=cache_dir,
+            source_tag=source_tag,
+            source_branch=source_branch,
+            source_commit=source_commit,
+            source_checksum=source_checksum,
+            source_submodules=source_submodules,
+            source_depth=source_depth,
+            project_dirs=project_dirs,
+            ignore_patterns=ignore_patterns,
+        )
+
+        if source_tag:
+            raise errors.InvalidSourceOption(source_type="deb", option="source-tag")
+
+        if source_commit:
+            raise errors.InvalidSourceOption(source_type="deb", option="source-commit")
+
+        if source_branch:
+            raise errors.InvalidSourceOption(source_type="deb", option="source-branch")
+
+        if source_depth:
+            raise errors.InvalidSourceOption(source_type="deb", option="source-depth")
+
+    # pylint: enable=too-many-arguments
+
+    def provision(
+        self,
+        dst: Path,
+        keep: bool = False,
+        src: Optional[Path] = None,
+    ):
+        """Extract deb file contents to the part source dir."""
+        if src:
+            deb_file = src
+        else:
+            deb_file = self.part_src_dir / os.path.basename(self.source)
+
+        deb_utils.extract_deb(deb_file, dst, logger.debug)
+
+        if not keep:
+            deb_file.unlink()

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -87,6 +87,7 @@ from craft_parts.dirs import ProjectDirs
 
 from . import errors
 from .base import SourceHandler
+from .deb_source import DebSource
 from .git_source import GitSource
 from .local_source import LocalSource
 from .snap_source import SnapSource
@@ -105,6 +106,7 @@ _source_handler: Dict[str, SourceHandlerType] = {
     "git": GitSource,
     "snap": SnapSource,
     "zip": ZipSource,
+    "deb": DebSource,
 }
 
 

--- a/craft_parts/utils/deb_utils.py
+++ b/craft_parts/utils/deb_utils.py
@@ -1,0 +1,38 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""deb-related utilities used by both `packages` and `sources`."""
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from craft_parts import errors
+from craft_parts.utils import os_utils
+
+
+def extract_deb(
+    deb_path: Path, extract_dir: Path, log_func: Callable[[str], None]
+) -> None:
+    """Extract file `deb_path` into `extract_dir."""
+    command = ["dpkg-deb", "--extract", str(deb_path), str(extract_dir)]
+    try:
+        os_utils.process_run(
+            command=command,
+            log_func=log_func,
+        )
+    except subprocess.CalledProcessError as err:
+        raise errors.DebError(deb_path, command, err.returncode) from err

--- a/tests/integration/sources/test_deb.py
+++ b/tests/integration/sources/test_deb.py
@@ -1,0 +1,91 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts.actions import Action
+from craft_parts.steps import Step
+
+
+@pytest.fixture
+def sample_deb(tmp_path: Path) -> Path:
+    """
+    Create a basic .deb file and return its path.
+    """
+    deb_dir = tmp_path / "sample"
+    deb_dir.mkdir()
+
+    # Add control structure
+    control_dir = deb_dir / "DEBIAN"
+    control_dir.mkdir()
+    control_file = control_dir / "control"
+    control_file.write_text(
+        textwrap.dedent(
+            """
+            Package: sample
+            Version: 1.0.0
+            Maintainer: Your Name <you@example.com>
+            Description: Sample package
+            Homepage: www.example.com
+            Architecture: all
+            """
+        )
+    )
+
+    # Add the single text file to the package
+    etc = deb_dir / "etc"
+    etc.mkdir()
+    sample_file = etc / "sample.txt"
+    sample_file.write_text("Sample contents")
+
+    target_deb = tmp_path / "sample.deb"
+
+    subprocess.check_call(["dpkg", "-b", str(deb_dir), str(target_deb)])
+
+    return target_deb
+
+
+def test_source_deb(sample_deb, tmp_path):
+
+    parts_yaml = textwrap.dedent(
+        f"""\
+        parts:
+          foo:
+            plugin: nil
+            source: {sample_deb}
+        """
+    )
+
+    result_dir = tmp_path / "result"
+    result_dir.mkdir()
+
+    parts = yaml.safe_load(parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_deb", cache_dir=tmp_path, work_dir=result_dir
+    )
+
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.PULL))
+
+    expected_file = result_dir / "parts/foo/src/etc/sample.txt"
+    assert expected_file.read_text() == "Sample contents"

--- a/tests/unit/sources/test_deb_source.py
+++ b/tests/unit/sources/test_deb_source.py
@@ -1,0 +1,48 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+
+from craft_parts.sources import sources
+from craft_parts.utils import os_utils
+
+
+@pytest.fixture
+def mock_process_run(mocker):
+    mock_run = mocker.patch.object(os_utils, "process_run", autospec=True)
+    return mock_run
+
+
+@pytest.mark.http_request_handler("FakeFileHTTPRequestHandler")
+def test_pull_debfile_must_download_and_extract(
+    tmp_path, http_server, mocker, mock_process_run
+):
+    dest_dir = tmp_path / "src"
+    dest_dir.mkdir()
+    deb_file_name = "test.deb"
+    source = (
+        f"http://{http_server.server_address[0]}:"
+        f"{http_server.server_address[1]}/{deb_file_name}"
+    )
+    deb_source = sources.DebSource(source, dest_dir, cache_dir=tmp_path)
+
+    deb_source.pull()
+
+    mock_process_run.assert_called_once_with(
+        command=["dpkg-deb", "--extract", str(dest_dir / deb_file_name), str(dest_dir)],
+        log_func=mocker.ANY,
+    )


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

Unpack deb packages in the same way that the stage-packages DebPackage
does (via dpkg-deb). This motivates a small refactoring to move
"extract_deb()" to a place that both handlers can use.

A lot of the code on this PR comes from a work-in-progress branch by @cmatsuoka . Thanks!

-----
CRAFT-117
