### PR TITLE
lint: set a timeout in `requests.get()`

### DIFF
--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -226,7 +226,9 @@ class FileSourceHandler(SourceHandler):
             raise NotImplementedError("ftp download not implemented")
 
         try:
-            request = requests.get(self.source, stream=True, allow_redirects=True)
+            request = requests.get(
+                self.source, stream=True, allow_redirects=True, timeout=3600
+            )
             request.raise_for_status()
         except requests.exceptions.RequestException as err:
             raise errors.NetworkRequestError(

--- a/tests/unit/utils/test_url_utils.py
+++ b/tests/unit/utils/test_url_utils.py
@@ -56,7 +56,7 @@ def test_download_request(requests_mock):
 
     test_file = Path("test_file")
 
-    request = requests.get(source_url, stream=True)
+    request = requests.get(source_url, stream=True, timeout=3600)
     url_utils.download_request(request, "test_file")
 
     assert test_file.is_file()


### PR DESCRIPTION
pylint 2.15 adds a new warning on timeout-less calls to
`requests.get()`, as it's a potentially endless call. The value of 10
seconds is arbitrary and can change if needed.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
