### PR TITLE
plugins: support "go generate" in go parts

### DIFF
--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -90,6 +90,9 @@ class GoPlugin(Plugin):
     or to have it installed or built in a different part. In this case, the
     name of the part supplying the go compiler must be "go".
 
+    The plugin will call "go generate" during build to support go projects
+    that generate code.
+
     The go plugin uses the common plugin keywords as well as those for "sources".
     Additionally, the following plugin-specific keywords can be used:
 
@@ -126,5 +129,6 @@ class GoPlugin(Plugin):
 
         return [
             "go mod download",
+            "go generate ./...",
             f'go install -p "{self._part_info.parallel_build_count}" {tags} ./...',
         ]

--- a/tests/integration/plugins/test_go/gen/generator.go
+++ b/tests/integration/plugins/test_go/gen/generator.go
@@ -1,0 +1,39 @@
+// generator.go: Go program called by "go generate" to create the "main.go" file
+// in the parent directory.
+
+//go:generate go run generator.go
+
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	filename := "../main.go"
+
+	f, err := os.Create(filename)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer f.Close()
+
+	template := `
+package main;
+
+import "fmt"
+
+func main() {
+    fmt.Println("This is a generated line")
+}
+`
+
+	_, err2 := f.WriteString(template)
+
+	if err2 != nil {
+		log.Fatal(err2)
+	}
+}

--- a/tests/integration/plugins/test_go/go.mod
+++ b/tests/integration/plugins/test_go/go.mod
@@ -1,0 +1,3 @@
+module example/generate
+
+go 1.13

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -139,6 +139,7 @@ def test_get_build_commands(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
+        "go generate ./...",
         'go install -p "1"  ./...',
     ]
 
@@ -151,6 +152,7 @@ def test_get_build_commands_with_buildtags(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
+        "go generate ./...",
         'go install -p "1" -tags=dev,debug ./...',
     ]
 


### PR DESCRIPTION
plugins: support "go generate" in go parts
    
GoPlugin's build step will now call "go generate" before the actual
build/install to support code generation. This shouldn't affect existing
uses of the plugin because the call is harmless if there's no code to
generate.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-----

CRAFT-1316
