### PR TITLE
tests: make integration tests use datadir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ test_requires = [
     "pylint-fixme-info",
     "pylint-pytest",
     "pytest",
+    "pytest-datadir",
     "pytest-mock",
     "requests-mock",
     "tox",

--- a/tests/integration/plugins/test_rust.py
+++ b/tests/integration/plugins/test_rust.py
@@ -23,38 +23,16 @@ import yaml
 from craft_parts import LifecycleManager, Step
 
 
-def test_rust_plugin(new_dir):
+def test_rust_plugin(new_dir, datadir):
     parts_yaml = textwrap.dedent(
         """\
         parts:
           foo:
             plugin: rust
-            source: .
+            source: test_rust/simple
         """
     )
     parts = yaml.safe_load(parts_yaml)
-
-    Path("Cargo.toml").write_text(
-        textwrap.dedent(
-            """\
-            [package]
-            name = "rust-hello"
-            version = "1.0.0"
-            edition = "2021"
-            """
-        )
-    )
-
-    Path("src").mkdir()
-    Path("src/main.rs").write_text(
-        textwrap.dedent(
-            """\
-            fn main() {
-                println!("hello world");
-            }
-            """
-        )
-    )
 
     lifecycle = LifecycleManager(
         parts, application_name="test_rust_plugin", cache_dir=new_dir
@@ -70,48 +48,17 @@ def test_rust_plugin(new_dir):
     assert output == "hello world\n"
 
 
-def test_rust_plugin_features(new_dir):
+def test_rust_plugin_features(new_dir, datadir):
     parts_yaml = textwrap.dedent(
         """\
         parts:
           foo:
             plugin: rust
-            source: .
+            source: test_rust/features
             rust-features: [conditional-feature-present]
         """
     )
     parts = yaml.safe_load(parts_yaml)
-
-    Path("Cargo.toml").write_text(
-        textwrap.dedent(
-            """\
-            [package]
-            name = "rust-hello-features"
-            version = "1.0.0"
-            edition = "2021"
-
-            [features]
-            conditional-feature-present = []
-            conditional-feature-missing = []
-
-            [dependencies]
-            log = "*"
-            """
-        )
-    )
-
-    Path("src").mkdir()
-    Path("src/main.rs").write_text(
-        textwrap.dedent(
-            """\
-            extern crate log;
-            fn main() {
-                #[cfg(feature="conditional-feature-present")]
-                println!("hello world");
-            }
-            """
-        )
-    )
 
     lifecycle = LifecycleManager(
         parts, application_name="test_rust_plugin_features", cache_dir=new_dir
@@ -127,79 +74,17 @@ def test_rust_plugin_features(new_dir):
     assert output == "hello world\n"
 
 
-def test_rust_plugin_workspace(new_dir):
+def test_rust_plugin_workspace(new_dir, datadir):
     parts_yaml = textwrap.dedent(
         """\
         parts:
           foo:
             plugin: rust
-            source: .
+            source: test_rust/workspace
             rust-path: ["hello"]
         """
     )
     parts = yaml.safe_load(parts_yaml)
-
-    Path("Cargo.toml").write_text(
-        textwrap.dedent(
-            """\
-            [workspace]
-            members = [
-                "hello",
-                "say",
-            ]
-            """
-        )
-    )
-
-    Path("hello").mkdir()
-    Path("hello/Cargo.toml").write_text(
-        textwrap.dedent(
-            """\
-            [package]
-            name = "rust-hello-workspace"
-            version = "1.0.0"
-            edition = "2021"
-
-            [dependencies]
-            say = { path = "../say" }
-            """
-        )
-    )
-
-    Path("hello/src").mkdir()
-    Path("hello/src/main.rs").write_text(
-        textwrap.dedent(
-            """\
-            use say;
-            fn main() {
-                say::hello();
-            }
-            """
-        )
-    )
-
-    Path("say").mkdir()
-    Path("say/Cargo.toml").write_text(
-        textwrap.dedent(
-            """\
-            [package]
-            name = "say"
-            version = "0.1.0"
-            edition = "2021"
-            """
-        )
-    )
-
-    Path("say/src").mkdir()
-    Path("say/src/lib.rs").write_text(
-        textwrap.dedent(
-            """\
-            pub fn hello() {
-                println!("hello world");
-            }
-            """
-        )
-    )
 
     lifecycle = LifecycleManager(
         parts, application_name="test_rust_hello_workspace", cache_dir=new_dir

--- a/tests/integration/plugins/test_rust/features/Cargo.toml
+++ b/tests/integration/plugins/test_rust/features/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust-hello-features"
+version = "1.0.0"
+edition = "2021"
+
+[features]
+conditional-feature-present = []
+conditional-feature-missing = []
+
+[dependencies]
+log = "*"

--- a/tests/integration/plugins/test_rust/features/src/main.rs
+++ b/tests/integration/plugins/test_rust/features/src/main.rs
@@ -1,0 +1,5 @@
+extern crate log;
+fn main() {
+    #[cfg(feature="conditional-feature-present")]
+    println!("hello world");
+}

--- a/tests/integration/plugins/test_rust/simple/Cargo.toml
+++ b/tests/integration/plugins/test_rust/simple/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "rust-hello"
+version = "1.0.0"
+edition = "2021"

--- a/tests/integration/plugins/test_rust/simple/src/main.rs
+++ b/tests/integration/plugins/test_rust/simple/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello world");
+}

--- a/tests/integration/plugins/test_rust/workspace/Cargo.toml
+++ b/tests/integration/plugins/test_rust/workspace/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "hello",
+    "say",
+]

--- a/tests/integration/plugins/test_rust/workspace/hello/Cargo.toml
+++ b/tests/integration/plugins/test_rust/workspace/hello/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust-hello-workspace"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+say = { path = "../say" }

--- a/tests/integration/plugins/test_rust/workspace/hello/src/main.rs
+++ b/tests/integration/plugins/test_rust/workspace/hello/src/main.rs
@@ -1,0 +1,4 @@
+use say;
+fn main() {
+    say::hello();
+}

--- a/tests/integration/plugins/test_rust/workspace/say/Cargo.toml
+++ b/tests/integration/plugins/test_rust/workspace/say/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "say"
+version = "0.1.0"
+edition = "2021"

--- a/tests/integration/plugins/test_rust/workspace/say/src/lib.rs
+++ b/tests/integration/plugins/test_rust/workspace/say/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn hello() {
+    println!("hello world");
+}


### PR DESCRIPTION
The `pytest-datadir` plugin enable per-test-module data, that is exposed
to tests via the `datadir` fixture. This proof-of-concept commit
refactors the existing integration tests for the rust plugin to use this
scheme.

The main change is that `test_rust.py` is simplified because all the
runtime rust code generation is moved to data diles in the `test_rust/`
dir; this is useful because these rust files are static, and their
generation is not what's being tested.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
