### PR TITLE
migration: filter out unnecessary whiteout files

### DIFF
--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -27,6 +27,7 @@ import logging
 import subprocess
 import sys
 from functools import partial
+from pathlib import Path
 
 import yaml
 from xdg import BaseDirectory  # type: ignore
@@ -87,8 +88,10 @@ def _process_parts(options: argparse.Namespace) -> None:
         # to the base for simplicity, but applications can (and probably should)
         # use a real digest.
         base_layer_hash = options.overlay_base.encode()
+        overlay_base = Path(options.overlay_base)
     else:
         base_layer_hash = b""
+        overlay_base = None
 
     lcm = craft_parts.LifecycleManager(
         part_data,
@@ -96,7 +99,7 @@ def _process_parts(options: argparse.Namespace) -> None:
         work_dir=options.work_dir,
         cache_dir=cache_dir,
         base=options.base,
-        base_layer_dir=options.overlay_base,
+        base_layer_dir=overlay_base,
         base_layer_hash=base_layer_hash,
     )
 

--- a/craft_parts/overlays/__init__.py
+++ b/craft_parts/overlays/__init__.py
@@ -26,5 +26,6 @@ from .overlay_manager import PackageCacheMount  # noqa: F401
 from .overlays import is_oci_opaque_dir  # noqa: F401
 from .overlays import is_oci_whiteout_file  # noqa: F401
 from .overlays import oci_opaque_dir  # noqa: F401
+from .overlays import oci_whited_out_file  # noqa: F401
 from .overlays import oci_whiteout  # noqa: F401
 from .overlays import visible_in_layer  # noqa: F401

--- a/craft_parts/overlays/overlay_manager.py
+++ b/craft_parts/overlays/overlay_manager.py
@@ -54,6 +54,11 @@ class OverlayManager:
         self._overlay_fs: Optional[OverlayFS] = None
         self._base_layer_dir = base_layer_dir
 
+    @property
+    def base_layer_dir(self) -> Optional[Path]:
+        """Return the path to the base layer, if any."""
+        return self._base_layer_dir
+
     def mount_layer(self, part: Part, *, pkg_cache: bool = False) -> None:
         """Mount the overlay step layer stack up to the given part.
 

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -131,6 +131,19 @@ def oci_whiteout(path: Path) -> Path:
     return path.parent / (".wh." + path.name)
 
 
+def oci_whited_out_file(whiteout_file: Path) -> Path:
+    """Find the whited out file corresponding to a whiteout file.
+
+    :param whiteout_file: The whiteout file to process.
+
+    :returns: The file that was whited out.
+    """
+    if not whiteout_file.name.startswith(".wh."):
+        raise ValueError("argument is not an OCI whiteout file")
+
+    return whiteout_file.parent / whiteout_file.name[4:]
+
+
 def oci_opaque_dir(path: Path) -> Path:
     """Return the OCI opaque directory marker.
 

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -55,6 +55,17 @@ class TestHelpers:
         assert overlays.oci_whiteout(Path(name)) == Path(oci_name)
 
     @pytest.mark.parametrize(
+        "name,oci_name", [("whatever", ".wh.whatever"), ("/path/foo", "/path/.wh.foo")]
+    )
+    def test_oci_whited_out_file(self, name, oci_name):
+        assert overlays.oci_whited_out_file(Path(oci_name)) == Path(name)
+
+    def test_oci_whited_out_file_error(self):
+        with pytest.raises(ValueError) as raised:
+            overlays.oci_whited_out_file(Path("whatever"))
+        assert str(raised.value) == "argument is not an OCI whiteout file"
+
+    @pytest.mark.parametrize(
         "name,oci_name",
         [("foo", "foo/.wh..wh..opq"), ("/path/foo", "/path/foo/.wh..wh..opq")],
     )


### PR DESCRIPTION
Remove whiteout files (or opaque directory markers) from the prime
directory if they don't have a corresponding entry in the base layer
to be whited out.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1264