### PR TITLE
parts: add part validator

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -25,7 +25,7 @@ from .errors import PartsError
 from .executor.environment import expand_environment
 from .infos import PartInfo, ProjectInfo, StepInfo
 from .lifecycle_manager import LifecycleManager
-from .parts import Part
+from .parts import Part, validate_part
 from .steps import Step
 
 __all__ = [
@@ -41,4 +41,5 @@ __all__ = [
     "Step",
     "plugins",
     "expand_environment",
+    "validate_part",
 ]


### PR DESCRIPTION
Add a part validation helper that validates part data against the part and plugin models. Currently all craft tools validate part data, so do it in the library instead of implementing a validator in each application.

Fixes #176.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
