### PR TITLE
filters: fix stage/prime filter combination

### DIFF
--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -66,27 +66,25 @@ class Fileset:
         :param other: The fileset to combine with.
         """
         to_combine = False
-        # combine if the other fileset has a wildcard
+        # combine if the fileset has a wildcard
         # XXX: should this only be a single wildcard and possibly excludes?
-        if "*" in other.entries:
+        if "*" in self.entries:
             to_combine = True
-            other.remove("*")
+            self.remove("*")
 
-        my_excludes = set(self.excludes)
-        other_includes = set(other.includes)
+        other_excludes = set(other.excludes)
+        my_includes = set(self.includes)
 
-        contradicting_set = set.intersection(my_excludes, other_includes)
+        contradicting_set = set.intersection(other_excludes, my_includes)
         if contradicting_set:
             raise errors.FilesetConflict(contradicting_set)
 
-        # combine if the other fileset is only excludes
-        if {x[0] for x in other.entries} == set("-"):
+        # combine if the fileset is only excludes
+        if {x[0] for x in self.entries} == set("-"):
             to_combine = True
 
         if to_combine:
             self._list = list(set(self._list + other.entries))
-        else:
-            self._list = other.entries
 
 
 def migratable_filesets(fileset: Fileset, srcdir: str) -> Tuple[Set[str], Set[str]]:

--- a/tests/integration/lifecycle/test_filters.py
+++ b/tests/integration/lifecycle/test_filters.py
@@ -1,0 +1,59 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import yaml
+
+import craft_parts
+from craft_parts import Action, Step
+
+
+def test_stage_prime_filtering(new_dir):
+    parts_yaml = textwrap.dedent(
+        """
+        parts:
+          my-part:
+            plugin: nil
+            override-build: |
+              touch ${CRAFT_PART_INSTALL}/testfile
+            stage:
+              - testfile
+            prime:
+              - -*
+        """
+    )
+
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.PRIME)
+    assert actions == [
+        Action("my-part", Step.PULL),
+        Action("my-part", Step.OVERLAY),
+        Action("my-part", Step.BUILD),
+        Action("my-part", Step.STAGE),
+        Action("my-part", Step.PRIME),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # testfile must be in stage but not in prime
+    assert Path("stage/testfile").exists()
+    assert Path("prime/testfile").exists() is False


### PR DESCRIPTION
Filter combination was computed with filters reversed, resulting in unexpected behavior when both stage and prime filters are defined. Fix and add additional test cases matching Snapcraft 6.x tests and results.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1377