### PR TITLE
unpack chisel slices

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,7 +79,17 @@ jobs:
           pip install -e .
       - name: Install additional test dependencies
         run: |
-          sudo apt install -y golang ninja-build cmake
+          sudo apt install -y ninja-build cmake
+          # Build Chisel: needs a version of go than is available in Ubuntu 20.04 
+          sudo snap install --classic --channel=latest/stable go
+          git clone https://github.com/canonical/chisel.git chisel-tmp
+          cd chisel-tmp && git checkout f0bff5a30dfdcb400b # known "good" commit until Chisel has versions
+          go mod download
+          sudo go build -o /usr/bin ./...
+          chisel --help
+          # Remove newer go and install regular version for 20.04
+          sudo snap remove go
+          sudo apt install -y golang
       - name: Run unit tests
         run: |
           make test-units

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -22,7 +22,7 @@ import os.path
 import shutil
 from glob import iglob
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, cast
 
 from typing_extensions import Protocol
 
@@ -902,9 +902,17 @@ class PartHandler:
 
     def _unpack_stage_packages(self):
         """Extract stage packages contents to the part's install directory."""
+        pulled_packages = None
+
+        pull_state = states.load_step_state(self._part, Step.PULL)
+        if pull_state is not None:
+            pull_state = cast(states.PullState, pull_state)
+            pulled_packages = pull_state.assets.get("stage-packages")
+
         packages.Repository.unpack_stage_packages(
             stage_packages_path=self._part.part_packages_dir,
             install_path=Path(self._part.part_install_dir),
+            stage_packages=pulled_packages,
         )
 
     def _unpack_stage_snaps(self):

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -153,13 +153,19 @@ class BaseRepository(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def unpack_stage_packages(
-        cls, *, stage_packages_path: Path, install_path: Path
+        cls,
+        *,
+        stage_packages_path: Path,
+        install_path: Path,
+        stage_packages: Optional[List[str]] = None,
     ) -> None:
         """Unpack stage packages.
 
         :param stage_packages_path: The path to the directory containing the
             stage packages to unpack.
         :param install_path: The path stage packages will be unpacked to.
+        :param stage_packages: An optional list of the packages that were previously
+            pulled.
         """
 
 
@@ -222,7 +228,11 @@ class DummyRepository(BaseRepository):
 
     @classmethod
     def unpack_stage_packages(
-        cls, *, stage_packages_path: Path, install_path: Path
+        cls,
+        *,
+        stage_packages_path: Path,
+        install_path: Path,
+        stage_packages: Optional[List[str]] = None,
     ) -> None:
         """Unpack stage packages to install_path."""
 

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -1,0 +1,56 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Step
+
+IS_CI: bool = os.getenv("CI") == "true"
+
+
+@pytest.mark.skipif(not IS_CI, reason="This test needs 'chisel' and only runs on CI.")
+def test_chisel_lifecycle(new_dir):
+    """Integrated test for Chisel support.
+
+    Note that since this test needs the "chisel" binary, it currently only runs on CI.
+    """
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            stage-packages: [ca-certificates_data]
+        """
+    )
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_slice", cache_dir=new_dir, work_dir=new_dir
+    )
+
+    actions = lf.plan(Step.PRIME)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    root = Path(new_dir)
+    assert (root / "prime/etc/ssl/certs/ca-certificates.crt").is_file()
+    assert (root / "prime/usr/share/ca-certificates").is_dir()

--- a/tests/unit/packages/conftest.py
+++ b/tests/unit/packages/conftest.py
@@ -1,0 +1,44 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+
+@pytest.fixture
+def fake_apt_cache(mocker):
+    def get_installed_version(package_name, resolve_virtual_packages=False):
+        if "installed" in package_name:
+            return "1.0"
+        if "new-version" in package_name:
+            return "3.0"
+        if "resolved-virtual-package" in package_name:
+            return "1.0"
+        if package_name == "versioned-package":
+            return "2.0"
+        if package_name.endswith("package"):
+            return "1.0"
+        return None
+
+    fake = mocker.patch("craft_parts.packages.deb.AptCache")
+    fake.return_value.__enter__.return_value.get_installed_version.side_effect = (
+        get_installed_version
+    )
+    return fake
+
+
+@pytest.fixture
+def fake_deb_run(mocker):
+    return mocker.patch("craft_parts.packages.deb.process_run")

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -1,0 +1,117 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import yaml
+
+import craft_parts
+from craft_parts import Step
+from craft_parts.packages import deb
+from craft_parts.packages.deb import _is_list_of_slices
+
+
+def test_is_list_of_slices():
+    assert _is_list_of_slices(["package1_slice1", "package1_slice2", "package2_slice2"])
+    assert not _is_list_of_slices(["package1", "package2"])
+    assert not _is_list_of_slices([])
+
+
+def test_fetch_stage_slices(tmp_path, fake_apt_cache):
+    stage_dir = tmp_path / "stage"
+    stage_dir.mkdir()
+
+    slices = ["package1_slice1", "package2_slice2"]
+    fetched_slices = deb.Ubuntu.fetch_stage_packages(
+        cache_dir=Path(),
+        package_names=slices,
+        stage_packages_path=stage_dir,
+        base="unused",
+        arch="unused",
+        list_only=False,
+    )
+
+    assert fetched_slices == slices
+    # Sanity check: the chisel support doesn't include downloading the packages and slices yet.
+    assert list(stage_dir.iterdir()) == []
+
+    # Make sure the standard codepath for .deb packages was not followed.
+    assert not fake_apt_cache.called
+
+
+def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
+    stage_dir = tmp_path / "stage"
+    stage_dir.mkdir()
+
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    slices = ["package1_slice1", "package2_slice2"]
+    deb.Ubuntu.unpack_stage_packages(
+        stage_packages_path=stage_dir, install_path=install_dir, stage_packages=slices
+    )
+
+    fake_deb_run.assert_called_once_with(
+        [
+            "chisel",
+            "cut",
+            "--root",
+            str(install_dir),
+            "--release",
+            "ubuntu-22.04",
+            "package1_slice1",
+            "package2_slice2",
+        ]
+    )
+
+
+def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):
+    """Test the combination of 'pulling' and 'building' chisel slices."""
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            stage-packages: [package1_slice1, package2_slice2]
+        """
+    )
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_slice", cache_dir=new_dir, work_dir=new_dir
+    )
+
+    actions = lf.plan(Step.BUILD)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    install_dir = lf.project_info.parts_dir / "foo/install"
+
+    fake_deb_run.assert_called_once_with(
+        [
+            "chisel",
+            "cut",
+            "--root",
+            str(install_dir),
+            "--release",
+            "ubuntu-22.04",
+            "package1_slice1",
+            "package2_slice2",
+        ]
+    )


### PR DESCRIPTION
This is done by using the `PullState` to "transmit" the list of slices from the pull step (that currently doesn't do anything for slices) to the build step (that does the actual cutting).

The integration test needs the "chisel" binary, so it's set to run on CI only. This required updating the workflow to use a newer version of "go" to build chisel. I then needed to revert back to the default Ubuntu 20.04 version because other tests need an older version (might be worth looking into).

In addition to the tests I also built a local `rockcraft` snap using this code, and used it to build an image containing "sliced" files.
