### PR TITLE
plugins: add 'go-generate' GoPlugin option

### DIFF
--- a/tests/integration/plugins/test_go.py
+++ b/tests/integration/plugins/test_go.py
@@ -88,8 +88,10 @@ def test_go_generate(new_dir):
           foo:
             plugin: go
             source: {source_location}
+            go-generate:
+              - gen/generator.go
             build-environment:
-            - GO111MODULE: "on"
+              - GO111MODULE: "on"
         """
     )
     parts = yaml.safe_load(parts_yaml)
@@ -102,6 +104,7 @@ def test_go_generate(new_dir):
         ctx.execute(actions)
 
     binary = Path(lf.project_info.prime_dir, "bin", "generate")
+    assert binary.is_file()
 
     output = subprocess.check_output([str(binary)], text=True)
     # This is the expected output that "gen/generator.go" sets in "main.go"

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -139,7 +139,6 @@ def test_get_build_commands(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
-        "go generate ./...",
         'go install -p "1"  ./...',
     ]
 
@@ -152,7 +151,6 @@ def test_get_build_commands_with_buildtags(part_info):
 
     assert plugin.get_build_commands() == [
         "go mod download",
-        "go generate ./...",
         'go install -p "1" -tags=dev,debug ./...',
     ]
 
@@ -180,3 +178,17 @@ def test_get_out_of_source_build(part_info):
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_out_of_source_build() is False
+
+
+def test_get_build_commands_go_generate(part_info):
+    properties = GoPlugin.properties_class.unmarshal(
+        {"source": ".", "go-generate": ["-v a", "-x b"]}
+    )
+    plugin = GoPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_commands() == [
+        "go mod download",
+        "go generate -v a",
+        "go generate -x b",
+        'go install -p "1"  ./...',
+    ]


### PR DESCRIPTION
Instead of always calling "go generate ./...", which might fail for Go projects that don't support it, add an explicit "go-generate" option to let users specify how code is generated in their parts.

CRAFT-1406
