### PR TITLE
chroot: fix device nodes in overlay base image

### DIFF
--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -252,18 +252,18 @@ def mount_overlayfs(mountpoint: str, *args) -> None:
 _UMOUNT_RETRIES = 5
 
 
-def umount(mountpoint: str) -> None:
+def umount(mountpoint: str, *args) -> None:
     """Unmount a filesystem.
 
     :param mountpoint: The mount point or device to unmount.
 
     :raises subprocess.CalledProcessError: on error.
     """
-    logger.debug("umount mountpoint=%r", mountpoint)
+    logger.debug("umount mountpoint=%r, args=%r", mountpoint, args)
     attempt = 0
     while True:  # unmount in Github CI fails randomly and needs a retry
         try:
-            subprocess.check_call(["/bin/umount", mountpoint])
+            subprocess.check_call(["/bin/umount", *args, mountpoint])
             break
         except subprocess.CalledProcessError as err:
             attempt += 1

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -77,12 +77,10 @@ class TestChroot:
             call("/etc/resolv.conf", f"{new_root}/etc/resolv.conf", "--bind"),
             call("proc", f"{new_root}/proc", "-tproc"),
             call("sysfs", f"{new_root}/sys", "-tsysfs"),
-            call("/dev", f"{new_root}/dev", "--bind"),
-            call("tmpfs", f"{new_root}/dev/shm", "-ttmpfs"),
+            call("/dev", f"{new_root}/dev", "--rbind"),
         ]
         assert mock_umount.mock_calls == [
-            call(f"{new_root}/dev/shm"),
-            call(f"{new_root}/dev"),
+            call(f"{new_root}/dev", "--recursive", "--lazy"),
             call(f"{new_root}/sys"),
             call(f"{new_root}/proc"),
             call(f"{new_root}/etc/resolv.conf"),

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -411,8 +411,10 @@ class TestMount:
 
     def test_umount(self, mocker):
         mock_call = mocker.patch("subprocess.check_call")
-        os_utils.umount("/mountpoint")
-        mock_call.assert_called_once_with(["/bin/umount", "/mountpoint"])
+        os_utils.umount("/mountpoint", "some", "args")
+        mock_call.assert_called_once_with(
+            ["/bin/umount", "some", "args", "/mountpoint"]
+        )
 
     def test_umount_retry(self, mocker):
         gen = itertools.count()


### PR DESCRIPTION
Device nodes won't appear correctly in a regular bind mount inside a container, so use rbind instead.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1416