### PR TITLE
overlay: only refresh overlay packages if necessary

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -91,7 +91,7 @@ class Executor:
 
         # update the overlay environment package list to allow installation of
         # overlay packages.
-        if any(p.has_overlay for p in self._part_list):
+        if any(p.spec.overlay_packages for p in self._part_list):
             with overlays.PackageCacheMount(self._overlay_manager) as ctx:
                 ctx.refresh_packages_list()
 

--- a/tests/integration/lifecycle/test_overlay.py
+++ b/tests/integration/lifecycle/test_overlay.py
@@ -35,7 +35,13 @@ def fake_call(mocker):
 def mock_overlay_support_prerequisites(mocker):
     mocker.patch.object(sys, "platform", "linux")
     mocker.patch("os.geteuid", return_value=0)
-    mocker.patch("craft_parts.overlays.OverlayManager.refresh_packages_list")
+    mock_refresh = mocker.patch(
+        "craft_parts.overlays.OverlayManager.refresh_packages_list"
+    )
+    yield
+    # Make sure that refresh_packages_list() was *not* called, as it's an expensive call that
+    # overlays without packages do not need.
+    assert not mock_refresh.called
 
 
 class TestOverlayLayerOrder:

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from craft_parts import callbacks
+from craft_parts import callbacks, overlays
 from craft_parts.actions import Action
 from craft_parts.executor import ExecutionContext, Executor
 from craft_parts.infos import ProjectInfo
@@ -179,6 +179,17 @@ class TestExecutionContext:
 
         captured = capfd.readouterr()
         assert captured.out == "build\nepilogue custom\n"
+
+    def test_prologue_overlay_packages(self, new_dir, mocker):
+        """Check that the overlay package cache is not touched if the part doesn't have overlay packages"""
+        mock_mount = mocker.patch.object(overlays, "PackageCacheMount")
+
+        p1 = Part("p1", {"plugin": "nil", "overlay-script": "echo overlay"})
+        info = ProjectInfo(application_name="test", cache_dir=new_dir, custom="custom")
+        e = Executor(project_info=info, part_list=[p1])
+
+        with ExecutionContext(executor=e):
+            assert not mock_mount.called
 
     def test_capture_stdout(self, capfd, new_dir):
         def cbf(info):


### PR DESCRIPTION
Only mount & refresh the overlay package cache if the part has overlay-packages; otherwise we're doing extra expensive work needlessly.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
