### PR TITLE
executor: separate environment setup from build script

### DIFF
--- a/craft_parts/executor/environment.py
+++ b/craft_parts/executor/environment.py
@@ -54,9 +54,6 @@ def generate_step_environment(
 
     # Create the script.
     with io.StringIO() as run_environment:
-        print("#!/bin/bash", file=run_environment)
-        print("set -euo pipefail", file=run_environment)
-
         print("# Environment", file=run_environment)
 
         print("## Application environment", file=run_environment)

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -95,8 +95,6 @@ def test_generate_step_environment_build(new_dir):
 
     assert env == textwrap.dedent(
         f"""\
-        #!/bin/bash
-        set -euo pipefail
         # Environment
         ## Application environment
         export APP_GLOBAL_ENVVAR="from_app"
@@ -148,8 +146,6 @@ def test_generate_step_environment_no_project_name(new_dir):
 
     assert env == textwrap.dedent(
         f"""\
-        #!/bin/bash
-        set -euo pipefail
         # Environment
         ## Application environment
         ## Part environment
@@ -201,8 +197,6 @@ def test_generate_step_environment_no_build(new_dir, step):
 
     assert env == textwrap.dedent(
         f"""\
-        #!/bin/bash
-        set -euo pipefail
         # Environment
         ## Application environment
         ## Part environment
@@ -253,8 +247,6 @@ def test_generate_step_environment_no_user_env(new_dir):
 
     assert env == textwrap.dedent(
         f"""\
-        #!/bin/bash
-        set -euo pipefail
         # Environment
         ## Application environment
         ## Part environment

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -25,7 +25,13 @@ from craft_parts import plugins, sources
 from craft_parts.dirs import ProjectDirs
 from craft_parts.executor.environment import generate_step_environment
 from craft_parts.executor.step_handler import StepContents, StepHandler
-from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
+from craft_parts.infos import (
+    _ARCH_TRANSLATIONS,
+    PartInfo,
+    ProjectInfo,
+    StepInfo,
+    _get_host_architecture,
+)
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
@@ -104,18 +110,17 @@ class TestStepHandlerBuiltins:
         result = sh.run_builtin()
         build_script_path = Path(new_dir / "parts/p1/run/build.sh")
         environment_script_path = Path(new_dir / "parts/p1/run/environment.sh")
+        host_arch = _ARCH_TRANSLATIONS[_get_host_architecture()]
 
         assert get_mode(environment_script_path) == 0o644
         with open(environment_script_path, "r") as file:
             assert file.read() == dedent(
                 f"""\
-                #!/bin/bash
-                set -euo pipefail
                 # Environment
                 ## Application environment
                 ## Part environment
-                export CRAFT_ARCH_TRIPLET="x86_64-linux-gnu"
-                export CRAFT_TARGET_ARCH="amd64"
+                export CRAFT_ARCH_TRIPLET="{host_arch['triplet']}"
+                export CRAFT_TARGET_ARCH="{host_arch['deb']}"
                 export CRAFT_PARALLEL_BUILD_COUNT="1"
                 export CRAFT_PROJECT_DIR="{new_dir}"
                 export CRAFT_OVERLAY="{new_dir}/overlay/overlay"


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Separate environment setup from the build script.  Used by https://github.com/snapcore/snapcraft/pull/3951.

~TODO - add unit tests~

(CRAFT-1411)