### PR TITLE
executor: take permissions into account for collisions

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -366,10 +366,13 @@ class PartFilesConflict(PartsError):
         self.conflicting_files = conflicting_files
         indented_conflicting_files = (f"    {i}" for i in conflicting_files)
         file_paths = "\n".join(sorted(indented_conflicting_files))
-        brief = "Failed to stage: parts list the same file with different contents."
+        brief = (
+            "Failed to stage: parts list the same file "
+            "with different contents or permissions."
+        )
         details = (
             f"Parts {part_name!r} and {other_part_name!r} list the following "
-            f"files, but with different contents:\n"
+            f"files, but with different contents or permissions:\n"
             f"{file_paths}"
         )
 

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -24,7 +24,7 @@ from craft_parts import errors, permissions
 from craft_parts.executor import filesets
 from craft_parts.executor.filesets import Fileset
 from craft_parts.parts import Part
-from craft_parts.permissions import Permissions
+from craft_parts.permissions import Permissions, permissions_are_compatible
 
 
 def check_for_stage_collisions(part_list: List[Part]) -> None:
@@ -92,7 +92,8 @@ def paths_collide(
     """Check whether the provided paths conflict to each other.
 
     If both paths have Permissions definitions, they are considered to be conflicting
-    (the Permissions are not compared).
+    if the permissions are incompatible (as defined by
+    ``permissions.permissions_are_compatible()``).
 
     :param permissions_path1: The list of ``Permissions`` that affect ``path1``.
     :param permissions_path2: The list of ``Permissions`` that affect ``path2``.
@@ -123,8 +124,8 @@ def paths_collide(
     if not (path1_is_dir and path2_is_dir) and _file_collides(path1, path2):
         return True
 
-    # Otherwise, paths only conflict if both have permissions defined for them.
-    return all([permissions_path1, permissions_path2])
+    # Otherwise, paths conflict if they have incompatible permissions.
+    return not permissions_are_compatible(permissions_path1, permissions_path2)
 
 
 def _file_collides(file_this: str, file_other: str) -> bool:

--- a/craft_parts/executor/collisions.py
+++ b/craft_parts/executor/collisions.py
@@ -18,12 +18,13 @@
 
 import filecmp
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from craft_parts import errors
+from craft_parts import errors, permissions
 from craft_parts.executor import filesets
 from craft_parts.executor.filesets import Fileset
 from craft_parts.parts import Part
+from craft_parts.permissions import Permissions
 
 
 def check_for_stage_collisions(part_list: List[Part]) -> None:
@@ -56,7 +57,15 @@ def check_for_stage_collisions(part_list: List[Part]) -> None:
                 this = os.path.join(part.part_install_dir, file)
                 other = os.path.join(other_part_files["installdir"], file)
 
-                if paths_collide(this, other):
+                permissions_this = permissions.filter_permissions(
+                    file, part.spec.permissions
+                )
+
+                permissions_other = permissions.filter_permissions(
+                    file, other_part_files["part"].spec.permissions
+                )
+
+                if paths_collide(this, other, permissions_this, permissions_other):
                     conflict_files.append(file)
 
             if conflict_files:
@@ -70,11 +79,25 @@ def check_for_stage_collisions(part_list: List[Part]) -> None:
         all_parts_files[part.name] = {
             "files": part_contents,
             "installdir": part.part_install_dir,
+            "part": part,
         }
 
 
-def paths_collide(path1: str, path2: str) -> bool:
-    """Check whether the provided paths conflict to each other."""
+def paths_collide(
+    path1: str,
+    path2: str,
+    permissions_path1: Optional[List[Permissions]] = None,
+    permissions_path2: Optional[List[Permissions]] = None,
+) -> bool:
+    """Check whether the provided paths conflict to each other.
+
+    If both paths have Permissions definitions, they are considered to be conflicting
+    (the Permissions are not compared).
+
+    :param permissions_path1: The list of ``Permissions`` that affect ``path1``.
+    :param permissions_path2: The list of ``Permissions`` that affect ``path2``.
+
+    """
     if not (os.path.lexists(path1) and os.path.lexists(path2)):
         return False
 
@@ -100,8 +123,8 @@ def paths_collide(path1: str, path2: str) -> bool:
     if not (path1_is_dir and path2_is_dir) and _file_collides(path1, path2):
         return True
 
-    # Otherwise, paths do not conflict.
-    return False
+    # Otherwise, paths only conflict if both have permissions defined for them.
+    return all([permissions_path1, permissions_path2])
 
 
 def _file_collides(file_this: str, file_other: str) -> bool:

--- a/tests/unit/executor/test_collisions.py
+++ b/tests/unit/executor/test_collisions.py
@@ -13,6 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from pathlib import Path
+from typing import List
 
 import pytest
 
@@ -20,6 +22,7 @@ from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
 from craft_parts.executor.collisions import check_for_stage_collisions
 from craft_parts.parts import Part
+from craft_parts.permissions import Permissions
 
 
 @pytest.fixture
@@ -164,3 +167,37 @@ class TestCollisions:
 
         # a part not built doesn't have the stage file in the installdir.
         check_for_stage_collisions([part_built, part_not_built])
+
+    def create_part_with_permissions(
+        self, part_name: str, permissions: List[Permissions], tmpdir: Path
+    ) -> Part:
+        part = Part(
+            part_name,
+            {"permissions": permissions},
+            project_dirs=ProjectDirs(work_dir=tmpdir),
+        )
+        p = part.part_install_dir
+        p.mkdir(parents=True)
+        (p / "1").write_text("1")
+        (p / "2").write_text("2")
+
+        return part
+
+    def test_collision_with_permissions(self, tmpdir):
+        """Test that Parts' Permissions are taken into account in collision verification"""
+
+        # Create two parts with identical contents (files "1" and "2"). One part has permissions
+        # to set all files to 0o644, and the other part has permissions to set file "2" to 0o755.
+        part1_permissions = [Permissions(mode="644")]
+        part2_permissions = [Permissions(path="2", mode="755")]
+        p1 = self.create_part_with_permissions("part1", part1_permissions, tmpdir)
+        p2 = self.create_part_with_permissions("part2", part2_permissions, tmpdir)
+
+        with pytest.raises(errors.PartFilesConflict) as raised:
+            check_for_stage_collisions([p1, p2])
+
+        # Permissions only collide if both parts define them for a given path, so only "2"
+        # should collide.
+        assert raised.value.other_part_name == "part1"
+        assert raised.value.part_name == "part2"
+        assert raised.value.conflicting_files == ["2"]

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -233,10 +233,11 @@ def test_part_files_conflict():
     assert err.other_part_name == "bar"
     assert err.conflicting_files == ["file1", "file2"]
     assert err.brief == (
-        "Failed to stage: parts list the same file with different contents."
+        "Failed to stage: parts list the same file with different contents or permissions."
     )
     assert err.details == (
-        "Parts 'foo' and 'bar' list the following files, but with different contents:\n"
+        "Parts 'foo' and 'bar' list the following files, "
+        "but with different contents or permissions:\n"
         "    file1\n"
         "    file2"
     )

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -19,7 +19,12 @@ import os
 import pydantic
 import pytest
 
-from craft_parts.permissions import Permissions, apply_permissions, filter_permissions
+from craft_parts.permissions import (
+    Permissions,
+    apply_permissions,
+    filter_permissions,
+    permissions_are_compatible,
+)
 
 
 def get_mode(path) -> int:
@@ -107,3 +112,18 @@ def test_apply_permissions(tmp_path, mock_chown):
     chown_call = mock_chown[target]
     assert chown_call.owner == 3333
     assert chown_call.group == 4444
+
+
+def test_permissions_are_compatible():
+    perm1 = [Permissions(mode="755"), Permissions(owner=1111, group=2222)]
+    perm2 = [Permissions(mode="0o755", owner=1111, group=2222)]
+    perm3 = [Permissions(owner=1111, group=2222)]
+    perm4 = None
+    perm5 = []
+
+    assert permissions_are_compatible(perm1, perm2)
+    assert not permissions_are_compatible(perm1, perm3)
+    assert not permissions_are_compatible(perm2, perm3)
+    assert permissions_are_compatible(perm1, perm4)
+    assert permissions_are_compatible(perm1, perm5)
+    assert permissions_are_compatible(perm4, perm5)


### PR DESCRIPTION
Two paths are considered to be colliding if they both have permissions definitions. The definitions are not "evaluated" to see if they possibly match (that is, if both sets of definitions would generate the same result) for simplicity, but this can be improved in the future.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
