### PR TITLE
many: make changed file list available to plugins

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -19,7 +19,7 @@
 __version__ = "1.15.1"
 
 from . import plugins
-from .actions import Action, ActionType
+from .actions import Action, ActionProperties, ActionType
 from .dirs import ProjectDirs
 from .errors import PartsError
 from .executor.environment import expand_environment
@@ -30,6 +30,7 @@ from .steps import Step
 
 __all__ = [
     "Action",
+    "ActionProperties",
     "ActionType",
     "ProjectDirs",
     "PartsError",

--- a/craft_parts/actions.py
+++ b/craft_parts/actions.py
@@ -17,8 +17,8 @@
 """Definitions of lifecycle actions and action types."""
 
 import enum
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from craft_parts.steps import Step
 
@@ -54,6 +54,14 @@ class ActionType(enum.IntEnum):
 
 
 @dataclass(frozen=True)
+class ActionProperties:
+    """Properties defined for an action."""
+
+    changed_files: Optional[List[str]] = None
+    changed_dirs: Optional[List[str]] = None
+
+
+@dataclass(frozen=True)
 class Action:
     """The action to be executed for a given part.
 
@@ -75,3 +83,4 @@ class Action:
     action_type: ActionType = ActionType.RUN
     reason: Optional[str] = None
     project_vars: Optional[Dict[str, "ProjectVar"]] = None
+    properties: ActionProperties = field(default=ActionProperties())

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -17,9 +17,12 @@
 """Plugin base class and definitions."""
 
 import abc
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type
 
 from pydantic import BaseModel
+
+from craft_parts.actions import ActionProperties
 
 from .properties import PluginProperties
 from .validator import PluginEnvironmentValidator
@@ -47,6 +50,7 @@ class Plugin(abc.ABC):
     ) -> None:
         self._options = properties
         self._part_info = part_info
+        self._action_properties: ActionProperties
 
     @abc.abstractmethod
     def get_build_snaps(self) -> Set[str]:
@@ -68,6 +72,13 @@ class Plugin(abc.ABC):
     @abc.abstractmethod
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
+
+    def set_action_properties(self, action_properties: ActionProperties) -> None:
+        """Store a copy of the given action properties.
+
+        :param action_properties: The properties to store.
+        """
+        self._action_properties = deepcopy(action_properties)
 
 
 class PluginModel(BaseModel):

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -20,7 +20,7 @@ import logging
 from typing import Dict, List, Optional, Sequence, Set
 
 from craft_parts import parts, steps
-from craft_parts.actions import Action, ActionType
+from craft_parts.actions import Action, ActionProperties, ActionType
 from craft_parts.infos import ProjectInfo, ProjectVar
 from craft_parts.overlays import LayerHash, LayerStateManager
 from craft_parts.parts import Part, part_list_by_name, sort_parts
@@ -160,8 +160,22 @@ class Sequencer:
         if outdated_report:
             logger.debug("%s:%s is outdated", part.name, current_step)
 
+            outdated_files, outdated_dirs = None, None
+            if current_step == Step.PULL:
+                outdated_files = outdated_report.outdated_files
+                outdated_dirs = outdated_report.outdated_dirs
+            elif current_step == Step.BUILD:
+                outdated_files = self._sm.get_outdated_files(part)
+                outdated_dirs = self._sm.get_outdated_dirs(part)
+
             if current_step in (Step.PULL, Step.OVERLAY, Step.BUILD):
-                self._update_step(part, current_step, reason=outdated_report.reason())
+                self._update_step(
+                    part,
+                    current_step,
+                    reason=outdated_report.reason(),
+                    outdated_files=outdated_files,
+                    outdated_dirs=outdated_dirs,
+                )
             else:
                 self._rerun_step(part, current_step, reason=outdated_report.reason())
 
@@ -284,11 +298,37 @@ class Sequencer:
 
         self._run_step(part, step, reason=reason, rerun=True)
 
-    def _update_step(self, part: Part, step: Step, *, reason: Optional[str] = None):
+    def _update_step(
+        self,
+        part: Part,
+        step: Step,
+        *,
+        reason: Optional[str] = None,
+        outdated_files: Optional[List[str]] = None,
+        outdated_dirs: Optional[List[str]] = None,
+    ):
         """Set the step state as reexecuted by updating its timestamp."""
         logger.debug("update step %s:%s", part.name, step)
-        self._add_action(part, step, action_type=ActionType.UPDATE, reason=reason)
+        properties = ActionProperties(
+            changed_files=outdated_files, changed_dirs=outdated_dirs
+        )
+        self._add_action(
+            part,
+            step,
+            action_type=ActionType.UPDATE,
+            reason=reason,
+            properties=properties,
+        )
         self._sm.update_state_timestamp(part, step)
+
+        if step == Step.PULL:
+            state = states.PullState(
+                part_properties=part.spec.marshal(),
+                project_options=self._project_info.project_options,
+                outdated_files=outdated_files,
+                outdated_dirs=outdated_dirs,
+            )
+            self._sm.set_state(part, step, state=state)
 
     def _reapply_layer(
         self, part: Part, layer_hash: LayerHash, *, reason: Optional[str] = None
@@ -308,8 +348,12 @@ class Sequencer:
         action_type: ActionType = ActionType.RUN,
         reason: Optional[str] = None,
         project_vars: Optional[Dict[str, ProjectVar]] = None,
+        properties: Optional[ActionProperties] = None,
     ) -> None:
         logger.debug("add action %s:%s(%s)", part.name, step, action_type)
+        if not properties:
+            properties = ActionProperties()
+
         self._actions.append(
             Action(
                 part.name,
@@ -317,6 +361,7 @@ class Sequencer:
                 action_type=action_type,
                 reason=reason,
                 project_vars=project_vars,
+                properties=properties,
             )
         )
 

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -22,7 +22,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
 import requests
 from overrides import overrides
@@ -84,6 +84,9 @@ class SourceHandler(abc.ABC):
         self._checked = False
         self._ignore_patterns = ignore_patterns.copy()
 
+        self.outdated_files: Optional[List[str]] = None
+        self.outdated_dirs: Optional[List[str]] = None
+
     # pylint: enable=too-many-arguments
 
     @abc.abstractmethod
@@ -99,6 +102,16 @@ class SourceHandler(abc.ABC):
         :param ignore_files: Files excluded from verification.
 
         :return: Whether the sources are outdated.
+
+        :raise errors.SourceUpdateUnsupported: If the source handler can't check if
+            files are outdated.
+        """
+        raise errors.SourceUpdateUnsupported(self.__class__.__name__)
+
+    def get_outdated_files(self) -> Tuple[List[str], List[str]]:
+        """Obtain lists of outdated files and directories.
+
+        :return: The lists of outdated files and directories.
 
         :raise errors.SourceUpdateUnsupported: If the source handler can't check if
             files are outdated.

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -22,7 +22,7 @@ import glob
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from overrides import overrides
 
@@ -130,6 +130,17 @@ class LocalSource(SourceHandler):
         logger.debug("updated directories: %r", self._updated_directories)
 
         return len(self._updated_files) > 0 or len(self._updated_directories) > 0
+
+    @overrides
+    def get_outdated_files(self) -> Tuple[List[str], List[str]]:
+        """Obtain lists of outdated files and directories.
+
+        :return: The lists of outdated files and directories.
+
+        :raise errors.SourceUpdateUnsupported: If the source handler can't check if
+            files are outdated.
+        """
+        return (sorted(self._updated_files), sorted(self._updated_directories))
 
     @overrides
     def update(self):

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -16,7 +16,7 @@
 
 """State definitions for the pull step."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from .step_state import StepState
 
@@ -25,6 +25,8 @@ class PullState(StepState):
     """Context information for the pull step."""
 
     assets: Dict[str, Any] = {}
+    outdated_files: Optional[List[str]] = None
+    outdated_dirs: Optional[List[str]] = None
 
     @classmethod
     def unmarshal(cls, data: Dict[str, Any]) -> "PullState":

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -46,6 +46,8 @@ class OutdatedReport:
         *,
         previous_step_modified: Optional[Step] = None,
         source_modified: bool = False,
+        outdated_files: Optional[List[str]] = None,
+        outdated_dirs: Optional[List[str]] = None,
     ) -> None:
         """Create a new OutdatedReport.
 
@@ -54,6 +56,8 @@ class OutdatedReport:
         """
         self.previous_step_modified = previous_step_modified
         self.source_modified = source_modified
+        self.outdated_files = outdated_files
+        self.outdated_dirs = outdated_dirs
 
     def reason(self) -> str:
         """Get summarized report.

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -20,7 +20,7 @@ import contextlib
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, cast
 
 from craft_parts import parts, sources, steps
 from craft_parts.infos import ProjectInfo, ProjectVar
@@ -29,7 +29,7 @@ from craft_parts.sources import SourceHandler
 from craft_parts.steps import Step
 
 from .reports import Dependency, DirtyReport, OutdatedReport
-from .states import StepState, get_step_state_path, load_step_state
+from .states import PullState, StepState, get_step_state_path, load_step_state
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +313,12 @@ class StateManager:
                 # Not all sources support checking for updates
                 with contextlib.suppress(sources.errors.SourceUpdateUnsupported):
                     if source_handler.check_if_outdated(str(state_file)):
-                        return OutdatedReport(source_modified=True)
+                        files, dirs = source_handler.get_outdated_files()
+                        return OutdatedReport(
+                            source_modified=True,
+                            outdated_files=files,
+                            outdated_dirs=dirs,
+                        )
 
         elif step == Step.BUILD:
             pull_stw = self._state_db.get(part_name=part.name, step=Step.PULL)
@@ -446,6 +451,34 @@ class StateManager:
             return b""
 
         return bytes.fromhex(overlay_hash)
+
+    def get_outdated_files(self, part: Part) -> Optional[List[str]]:
+        """Get the list of outdated files for this part.
+
+        :param part: The part being processed.
+
+        :returns: The list of outdated files from the part's pull step.
+        """
+        stw = self._state_db.get(part_name=part.name, step=Step.PULL)
+        if not stw:
+            return None
+
+        pull_state = cast(PullState, stw.state)
+        return pull_state.outdated_files
+
+    def get_outdated_dirs(self, part: Part) -> Optional[List[str]]:
+        """Get the list of outdated directories for this part.
+
+        :param part: The part being processed.
+
+        :returns: The list of outdated directories from the part's pull step.
+        """
+        stw = self._state_db.get(part_name=part.name, step=Step.PULL)
+        if not stw:
+            return None
+
+        pull_state = cast(PullState, stw.state)
+        return pull_state.outdated_dirs
 
 
 def _sort_steps_by_state_timestamp(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ min-similarity-lines=13
 
 [tool.pylint.format]
 max-line-length = "88"
-max-attributes = 15
+max-attributes = 16
 max-args= 6
 max-locals = 18
 

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -21,7 +21,7 @@ import pytest
 import yaml
 
 import craft_parts
-from craft_parts import Action, ActionType, Step
+from craft_parts import Action, ActionProperties, ActionType, Step
 
 basic_parts_yaml = textwrap.dedent(
     """\
@@ -167,13 +167,15 @@ def test_basic_lifecycle_actions(new_dir, mocker):
     actions = lf.plan(Step.BUILD)
     assert actions == [
         # fmt: off
-        Action("foo", Step.PULL, action_type=ActionType.UPDATE, reason="source changed"),
+        Action("foo", Step.PULL, action_type=ActionType.UPDATE, reason="source changed",
+               properties=ActionProperties(changed_files=['a.tar.gz'], changed_dirs=[])),
         Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", step=Step.OVERLAY, action_type=ActionType.UPDATE, reason="'PULL' step changed"),
         Action("bar", step=Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
         Action("foobar", step=Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
-        Action("foo", Step.BUILD, action_type=ActionType.UPDATE, reason="'PULL' step changed"),
+        Action("foo", Step.BUILD, action_type=ActionType.UPDATE, reason="'PULL' step changed",
+               properties=ActionProperties(changed_files=['a.tar.gz'], changed_dirs=[])),
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),

--- a/tests/integration/lifecycle/test_plugin_changesets.py
+++ b/tests/integration/lifecycle/test_plugin_changesets.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/lifecycle/test_plugin_changesets.py
+++ b/tests/integration/lifecycle/test_plugin_changesets.py
@@ -1,0 +1,235 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+import yaml
+
+import craft_parts
+from craft_parts import Action, ActionProperties, ActionType, Step, plugins
+
+
+def setup_function():
+    plugins.unregister_all()
+
+
+def teardown_module():
+    plugins.unregister_all()
+
+
+class ExamplePluginProperties(plugins.PluginProperties, plugins.PluginModel):
+    """The application-defined plugin properties."""
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]):
+        return cls()
+
+
+class ExamplePlugin(plugins.Plugin):
+    """Our application plugin."""
+
+    properties_class = ExamplePluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        if self._action_properties.changed_files:
+            return [f"echo Changed files: {self._action_properties.changed_files}"]
+
+        return ["echo no files changed"]
+
+
+def test_changesets(new_dir, mocker, capfd):
+    plugins.register({"example": ExamplePlugin})
+
+    Path("dir1").mkdir()
+    Path("dir1/foo").touch()
+
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """\
+            parts:
+              foo:
+                plugin: example
+                source: dir1
+            """
+        )
+    )
+
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+
+    # build parts
+
+    actions = lcm.plan(Step.BUILD)
+    assert actions == [
+        Action("foo", Step.PULL),
+        Action("foo", Step.OVERLAY),
+        Action("foo", Step.BUILD),
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    assert capfd.readouterr().out == "no files changed\n"
+
+    # just repull
+
+    actions = lcm.plan(Step.PULL)
+    assert actions == [
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran")
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    # change the file, and build
+
+    Path("dir1/foo").touch()
+
+    actions = lcm.plan(Step.BUILD)
+    assert actions == [
+        Action(
+            "foo",
+            Step.PULL,
+            action_type=ActionType.UPDATE,
+            reason="source changed",
+            properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
+        ),
+        Action(
+            "foo",
+            Step.OVERLAY,
+            action_type=ActionType.UPDATE,
+            reason="'PULL' step changed",
+            project_vars=None,
+            properties=ActionProperties(changed_files=None, changed_dirs=None),
+        ),
+        Action(
+            "foo",
+            Step.BUILD,
+            action_type=ActionType.UPDATE,
+            reason="'PULL' step changed",
+            project_vars=None,
+            properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
+        ),
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    assert capfd.readouterr().out == "Changed files: [foo]\n"
+
+
+def test_changesets_reload_state(new_dir, mocker, capfd):
+    plugins.register({"example": ExamplePlugin})
+
+    Path("dir1").mkdir()
+    Path("dir1/foo").touch()
+
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """\
+            parts:
+              foo:
+                plugin: example
+                source: dir1
+            """
+        )
+    )
+
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+
+    # build parts
+
+    actions = lcm.plan(Step.BUILD)
+    assert actions == [
+        Action("foo", Step.PULL),
+        Action("foo", Step.OVERLAY),
+        Action("foo", Step.BUILD),
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    assert capfd.readouterr().out == "no files changed\n"
+
+    # change the file, and pull
+
+    Path("dir1/foo").touch()
+
+    actions = lcm.plan(Step.PULL)
+    assert actions == [
+        Action(
+            "foo",
+            Step.PULL,
+            action_type=ActionType.UPDATE,
+            reason="source changed",
+            properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
+        )
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    # run build reloading any existing state
+    # the state of changed files must be preserved
+
+    actions = lcm.plan(Step.BUILD)
+    assert actions == [
+        Action(
+            "foo",
+            Step.PULL,
+            action_type=ActionType.SKIP,
+            reason="already ran",
+        ),
+        Action(
+            "foo",
+            Step.OVERLAY,
+            action_type=ActionType.UPDATE,
+            reason="'PULL' step changed",
+            project_vars=None,
+            properties=ActionProperties(changed_files=None, changed_dirs=None),
+        ),
+        Action(
+            "foo",
+            Step.BUILD,
+            action_type=ActionType.UPDATE,
+            reason="'PULL' step changed",
+            project_vars=None,
+            properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
+        ),
+    ]
+
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    assert capfd.readouterr().out == "Changed files: [foo]\n"

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -33,6 +33,8 @@ class TestPullState:
             "project-options": {},
             "files": set(),
             "directories": set(),
+            "outdated-files": None,
+            "outdated-dirs": None,
         }
 
     def test_marshal_unmarshal(self):
@@ -42,6 +44,8 @@ class TestPullState:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "outdated-files": ["a"],
+            "outdated-dirs": ["b"],
         }
 
         state = PullState.unmarshal(state_data)

--- a/tests/unit/state_manager/test_states.py
+++ b/tests/unit/state_manager/test_states.py
@@ -40,6 +40,8 @@ class TestStepStates:
             "project-options": {"target_arch": "amd64"},
             "files": {"a"},
             "directories": {"b"},
+            "outdated-files": ["a"],
+            "outdated-dirs": ["b"],
         }
         state_file = Path("parts/foo/state/pull")
         state_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -28,10 +28,10 @@ def test_action_type():
 
 def test_action_representation():
     action = Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="is tired")
-    assert (
-        f"{action!r}"
-        == "Action(part_name='foo', step=Step.PULL, action_type=ActionType.SKIP, "
-        "reason='is tired', project_vars=None)"
+    assert f"{action!r}" == (
+        "Action(part_name='foo', step=Step.PULL, action_type=ActionType.SKIP, "
+        "reason='is tired', project_vars=None, properties=ActionProperties("
+        "changed_files=None, changed_dirs=None))"
     )
 
 

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from craft_parts.actions import Action, ActionType
+from craft_parts.actions import Action, ActionProperties, ActionType
 from craft_parts.infos import ProjectInfo
 from craft_parts.overlays import LayerHash
 from craft_parts.parts import Part, PartSpec
@@ -173,7 +173,12 @@ def test_sequencer_update_step(step, state_class, new_dir):
 
     # check if action was created
     assert seq._actions == [
-        Action(part_name="p1", action_type=ActionType.UPDATE, step=step)
+        Action(
+            part_name="p1",
+            action_type=ActionType.UPDATE,
+            step=step,
+            properties=ActionProperties(),
+        )
     ]
 
     # check if serial updated


### PR DESCRIPTION
Part plugins can make better decisions on how to handle part building if they know what has been changed instead of relying solely on the current state of the filesystem and on static plugin properties defined in the project. For example, retrieving plugin-specific dependency packages could be avoided entirely if no changes were made to the files listing these dependencies, resulting in faster execution times and preventing unnecessary network access.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
