### PR TITLE
test: xfail a git submodule test

### DIFF
--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -815,6 +815,10 @@ class TestGitConflicts(GitBaseTestCase):
 
         assert body == "fake 2"
 
+    @pytest.mark.xfail(
+        reason="Current version of git no longer allows adding local repos as submodules",
+        strict=True,
+    )
     def test_git_submodules(self, new_dir):
         """Test that updates to submodules are pulled"""
         repo = os.path.abspath("submodules.git")


### PR DESCRIPTION
Latest versions of `git` in Ubuntu are patched to disallow adding submodules from local repos (using the 'file' transport).

Refs:

- https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
- http://changelogs.ubuntu.com/changelogs/pool/main/g/git/git_2.34.1-1ubuntu1.5/changelog

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
