### PR TITLE
tests: re-enable git submodule test

### DIFF
--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -815,10 +815,6 @@ class TestGitConflicts(GitBaseTestCase):
 
         assert body == "fake 2"
 
-    @pytest.mark.xfail(
-        reason="Current version of git no longer allows adding local repos as submodules",
-        strict=True,
-    )
     def test_git_submodules(self, new_dir):
         """Test that updates to submodules are pulled"""
         repo = os.path.abspath("submodules.git")
@@ -845,7 +841,7 @@ class TestGitConflicts(GitBaseTestCase):
         _call(["git", "init", "--bare"])
 
         self.clone_repo(repo, working_tree)
-        _call(["git", "submodule", "add", sub_repo])
+        _call(["git", "-c", "protocol.file.allow=always", "submodule", "add", sub_repo])
         _call(["git", "commit", "-am", "added submodule"])
         _call(["git", "push", repo])
 
@@ -871,7 +867,18 @@ class TestGitConflicts(GitBaseTestCase):
 
         # update the submodule
         self.clone_repo(repo, working_tree_two)
-        _call(["git", "submodule", "update", "--init", "--recursive", "--remote"])
+        _call(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "--remote",
+            ]
+        )
         _call(["git", "add", "subrepo"])
         _call(["git", "commit", "-am", "updated submodule"])
         _call(["git", "push"])


### PR DESCRIPTION
Adding "-c protocol.file.allow=always" on the test is fine because we're manipulating repos created by the test itself (so no security issue).

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
