### PR TITLE
packages: drop release from chisel command line

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -697,10 +697,7 @@ class Ubuntu(BaseRepository):
         :param install_path: The destination directory.
         """
         # Note that we must hardcode the release here because Chisel this one.
-        process_run(
-            ["chisel", "cut", "--root", str(install_path), "--release", "ubuntu-22.04"]
-            + stage_packages
-        )
+        process_run(["chisel", "cut", "--root", str(install_path)] + stage_packages)
 
     @classmethod
     @_apt_cache_wrapper

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -71,8 +71,6 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
             "cut",
             "--root",
             str(install_dir),
-            "--release",
-            "ubuntu-22.04",
             "package1_slice1",
             "package2_slice2",
         ]
@@ -109,8 +107,6 @@ def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):
             "cut",
             "--root",
             str(install_dir),
-            "--release",
-            "ubuntu-22.04",
             "package1_slice1",
             "package2_slice2",
         ]


### PR DESCRIPTION
Chisel only works in some Ubuntu versions (currently 22.04 and 22.10),
and instead of trying to block invalid calls let's just let the tool's
error propagate up the call stack. This way we can be a bit 'future
proof' for when new Ubuntu versions are supported.

(CRAFT-1407)

