### PR TITLE
Add ubuntu-22.04 to CI runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,6 +54,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.10"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,8 +55,10 @@ jobs:
         os: [ubuntu-20.04]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
+          - adjective: focal
           - os: ubuntu-22.04
             python-version: "3.10"
+            adjective: jammy
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,9 +103,9 @@ jobs:
           make test-integrations
       - name: Run overlay smoke test
         run: |
-          wget -q https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.squashfs
+          wget -q https://cloud-images.ubuntu.com/${{ matrix.adjective }}/current/${{ matrix.adjective }}-server-cloudimg-amd64.squashfs
           mkdir base
-          sudo mount -t squashfs focal-server-cloudimg-amd64.squashfs base/
+          sudo mount -t squashfs ${{ matrix.adjective }}-server-cloudimg-amd64.squashfs base/
           cat <<-EOF > parts.yaml
           parts:
             foo:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,7 @@ jobs:
         run: |
           make test-integrations
       - name: Run overlay smoke test
+        if: ${{ matrix.adjective == 'focal' }} #TODO: fix this smoke test for jammy
         run: |
           wget -q https://cloud-images.ubuntu.com/${{ matrix.adjective }}/current/${{ matrix.adjective }}-server-cloudimg-amd64.squashfs
           mkdir base

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -134,7 +134,7 @@ class GoPlugin(Plugin):
             generate_cmds.append(f"go generate {cmd}")
 
         return (
-            ["go mod download"]
+            ["go mod download all"]
             + generate_cmds
             + [
                 f'go install -p "{self._part_info.parallel_build_count}" {tags} ./...',

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -138,7 +138,7 @@ def test_get_build_commands(part_info):
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_commands() == [
-        "go mod download",
+        "go mod download all",
         'go install -p "1"  ./...',
     ]
 
@@ -150,7 +150,7 @@ def test_get_build_commands_with_buildtags(part_info):
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_commands() == [
-        "go mod download",
+        "go mod download all",
         'go install -p "1" -tags=dev,debug ./...',
     ]
 
@@ -187,7 +187,7 @@ def test_get_build_commands_go_generate(part_info):
     plugin = GoPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_commands() == [
-        "go mod download",
+        "go mod download all",
         "go generate -v a",
         "go generate -x b",
         'go install -p "1"  ./...',


### PR DESCRIPTION
This is needed for a proper Chisel integration test, and it's also healthy to run the tests on the latest LTS. I did uncover an issue with the `GoPlugin` (`go mod download` semantics changed) and discovered that the overlay smoke test doesn't work (at least, not out-of-the-box). It's a TODO for now because it'll take some investigating but we should look into it soon
