### PR TITLE
info: pass build attributes and state to post-step callback

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -165,6 +165,7 @@ class PartHandler:
         state = handler(step_info, stdout=stdout, stderr=stderr)
         state_file = states.get_step_state_path(self._part, action.step)
         state.write(state_file)
+        step_info.state = state
         callbacks.run_post_step(step_info)
 
     def _run_pull(

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -196,7 +196,6 @@ class StepHandler:
             destdir=self._part.prime_dir,
             permissions=self._part.spec.permissions,
         )
-        # TODO: handle elf dependencies
 
         return StepContents(files, dirs)
 

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,7 @@ import logging
 import platform
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from pydantic_yaml import YamlModel
 
@@ -28,6 +28,10 @@ from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
 from craft_parts.parts import Part
 from craft_parts.steps import Step
+
+if TYPE_CHECKING:
+    from craft_parts.state_manager import states
+
 
 logger = logging.getLogger(__name__)
 
@@ -296,6 +300,7 @@ class PartInfo:
         self._part_build_subdir = part.part_build_subdir
         self._part_install_dir = part.part_install_dir
         self._part_state_dir = part.part_state_dir
+        self.build_attributes = part.spec.build_attributes.copy()
 
     def __getattr__(self, name):
         # Use composition and attribute cascading to avoid setting attributes
@@ -397,6 +402,7 @@ class StepInfo:
         self._part_info = part_info
         self.step = step
         self.step_environment: Dict[str, str] = {}
+        self.state: "Optional[states.StepState]" = None
 
     def __getattr__(self, name):
         if hasattr(self._part_info, name):

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -132,12 +132,6 @@ def _my_step_callback(info: StepInfo) -> bool:
     return True
 
 
-def _state_step_callback(info: StepInfo) -> bool:
-    assert info.state is not None
-    assert isinstance(info.state, StepState)
-    return True
-
-
 # Test the update action separately because it's only defined
 # for steps PULL and BUILD.
 
@@ -200,6 +194,14 @@ def test_callback_post(tmpdir, capfd, step, action_type):
 
 @pytest.mark.parametrize("step", list(Step))
 def test_callback_post_state_info(tmpdir, step):
+    callback_called = [False]
+
+    def _state_step_callback(info: StepInfo) -> bool:
+        assert info.state is not None
+        assert isinstance(info.state, StepState)
+        callback_called[0] = True
+        return True
+
     callbacks.register_post_step(_state_step_callback, step_list=[step])
 
     parts = yaml.safe_load(_parts_yaml)
@@ -215,6 +217,8 @@ def test_callback_post_state_info(tmpdir, step):
 
     with lf.action_executor() as ctx:
         ctx.execute(Action("foo", step))
+
+    assert callback_called[0]
 
 
 _update_yaml = textwrap.dedent(

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -271,7 +271,7 @@ def test_part_info(new_dir):
         custom1="foobar",
         custom2=[1, 2],
     )
-    part = Part("foo", {})
+    part = Part("foo", {"build-attributes": ["bar"]})
     x = PartInfo(project_info=info, part=part)
 
     assert x.application_name == "test"
@@ -289,6 +289,7 @@ def test_part_info(new_dir):
     assert x.part_state_dir == new_dir / "parts/foo/state"
     assert x.stage_dir == new_dir / "stage"
     assert x.prime_dir == new_dir / "prime"
+    assert x.build_attributes == ["bar"]
 
     assert x.custom_args == ["custom1", "custom2"]
     assert x.custom1 == "foobar"
@@ -443,6 +444,7 @@ def test_step_info(new_dir):
     assert x.step == Step.BUILD
     assert x.global_environment == {}
     assert x.step_environment == {}
+    assert x.state is None
 
     assert x.custom_args == ["custom1", "custom2"]
     assert x.custom1 == "foobar"


### PR DESCRIPTION
Add build attributes and step execution state to the part information passed to post-step callbacks. This allows further processing of migrated files according to part properties set by the user.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
