### PR TITLE
sources: allow plus symbol in git url scheme

### DIFF
--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -287,7 +287,7 @@ class GitSource(SourceHandler):
         Local sources are formatted as file:///absolute/path/to/local/source
         This is done because `git clone --depth=1 path/to/local/source` is invalid
         """
-        protocol_pattern = re.compile(r"^[\w\-.@]+:")
+        protocol_pattern = re.compile(r"^[\w\-.@+]+:")
 
         if protocol_pattern.search(self.source):
             return self.source

--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -290,6 +290,7 @@ class TestGitSource(GitBaseTestCase):
         "repository",
         [
             "ssh://user@host.xz:123/path/to/repo.git",
+            "git+ssh://user@host.xz:123/path/to/repo.git",
             "user@host.xz:path/to/repo.git",
             "https://host.xz/path/to/repo.git",
             "user@host.xz:/~[user]/path/to/repo.git",


### PR DESCRIPTION
Add the plus symbol to valid git protocol scheme to allow entries using `git+ssh://`. This is allowed in Snapcraft 6 and displayed in Launchpad for git repos.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
