### PR TITLE
sources: improve missing local source error message

### DIFF
--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -28,6 +28,7 @@ from overrides import overrides
 
 from craft_parts.utils import file_utils
 
+from . import errors
 from .base import SourceHandler
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,9 @@ class LocalSource(SourceHandler):
     @overrides
     def pull(self):
         """Retrieve the local source files."""
+        if not Path(self.source_abspath).exists():
+            raise errors.SourceNotFound(self.source)
+
         file_utils.link_or_copy_tree(
             self.source_abspath,
             str(self.part_src_dir),

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -22,6 +22,7 @@ import pytest
 
 from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
+from craft_parts.sources import errors as sources_errors
 from craft_parts.sources import sources
 from craft_parts.sources.local_source import LocalSource
 
@@ -265,6 +266,18 @@ class TestLocal:
             ignore_patterns=ignore_patterns,
         )
         assert s2._ignore_patterns == ["hello", "work"]
+
+    def test_source_does_not_exist(self, new_dir):
+        dirs = ProjectDirs(work_dir=Path("src/work"))
+        local = LocalSource(
+            "does-not-exist",
+            "destination",
+            cache_dir=new_dir,
+            project_dirs=dirs,
+        )
+
+        with pytest.raises(sources_errors.SourceNotFound):
+            local.pull()
 
 
 class TestLocalUpdate:


### PR DESCRIPTION
When a local source does not exist, display the appropriate "source not found" error message instead of surfacing a file copy error.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
