### PR TITLE
executor: fix formatting of log message for missing snaps in container

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -234,14 +234,12 @@ class Executor:
 
         if os_utils.is_inside_container():
             logger.warning(
-                (
-                    "The following snaps are required but not installed as the "
-                    "application is running inside docker or podman container: %s.\n"
-                    "Please ensure the environment is properly setup before "
-                    "continuing.\nIgnore this message if the appropriate measures "
-                    "have already been taken.",
-                    ", ".join(build_snaps),
-                )
+                "The following snaps are required but not installed as the "
+                "application is running inside docker or podman container: %s.\n"
+                "Please ensure the environment is properly setup before "
+                "continuing.\nIgnore this message if the appropriate measures "
+                "have already been taken.",
+                ", ".join(build_snaps),
             )
         else:
             packages.snaps.install_snaps(build_snaps)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
An extra set of parenthesis were misformatting a log message:

## Before
```
2022-11-22 16:58:02.517 ('The following snaps are required but not installed as the application is running inside docker or podman container: %s.\nPlease ensure the environment is properly setup before continuing.\nIgnore this message if the appropriate measures have already been taken.', 'core22')
```

## After
```
2022-11-22 17:01:16.204 The following snaps are required but not installed as the application is running inside docker or podman container: core22.
Please ensure the environment is properly setup before continuing.
Ignore this message if the appropriate measures have already been taken.
```
