### PR TITLE
plugins: add SConsPlugin

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,7 +84,7 @@ jobs:
           pip install -e .
       - name: Install additional test dependencies
         run: |
-          sudo apt install -y ninja-build cmake
+          sudo apt install -y ninja-build cmake scons
           # Build Chisel: needs a version of go than is available in Ubuntu 20.04 
           sudo snap install --classic --channel=latest/stable go
           git clone https://github.com/canonical/chisel.git chisel-tmp

--- a/craft_parts/plugins/plugins.py
+++ b/craft_parts/plugins/plugins.py
@@ -32,6 +32,7 @@ from .npm_plugin import NpmPlugin
 from .properties import PluginProperties
 from .python_plugin import PythonPlugin
 from .rust_plugin import RustPlugin
+from .scons_plugin import SConsPlugin
 
 if TYPE_CHECKING:
     # import module to avoid circular imports in sphinx doc generation
@@ -54,6 +55,7 @@ _BUILTIN_PLUGINS: Dict[str, PluginType] = {
     "npm": NpmPlugin,
     "python": PythonPlugin,
     "rust": RustPlugin,
+    "scons": SConsPlugin,
 }
 
 _PLUGINS = copy.deepcopy(_BUILTIN_PLUGINS)

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -27,7 +27,7 @@ from .properties import PluginProperties
 class SConsPluginProperties(PluginProperties, PluginModel):
     """The part properties used by the SCons plugin."""
 
-    scons_options: List[str] = []
+    scons_parameters: List[str] = []
 
     # part properties required by the plugin
     source: str
@@ -98,7 +98,7 @@ class SConsPlugin(Plugin):
 
     The plugin supports the following keywords:
 
-    - ``scons-options``
+    - ``scons-parameters``
       (list of strings)
       Additional values to pass to the ``scons`` and ``scons install`` command
       lines.
@@ -126,6 +126,6 @@ class SConsPlugin(Plugin):
         options = cast(SConsPluginProperties, self._options)
 
         return [
-            " ".join(["scons"] + options.scons_options),
-            " ".join(["scons", "install"] + options.scons_options),
+            " ".join(["scons"] + options.scons_parameters),
+            " ".join(["scons", "install"] + options.scons_parameters),
         ]

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -53,8 +53,8 @@ class SConsPlugin(Plugin):
     (C/C++ compiler, Java compiler, etc) must be declared via ``build-packages``.
     Since there is no "official" way of defining the target installation directory
     for SCons-built artifacts, the default build will set the DESTDIR environment
-    variable which the SConstruct file should use to configure its ``Install()``
-    builder target.
+    variable which contains the root which the SConstruct file should use to
+    configure its ``Install()`` builder target.
 
     The plugin supports the following keywords:
 
@@ -77,7 +77,7 @@ class SConsPlugin(Plugin):
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
-            "DESTDIR": f"{self._part_info.part_install_dir}/bin",
+            "DESTDIR": f"{self._part_info.part_install_dir}",
         }
 
     def get_build_commands(self) -> List[str]:

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -1,0 +1,90 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The SCons plugin."""
+
+from typing import Any, Dict, List, Set, cast
+
+from .base import Plugin, PluginModel, extract_plugin_properties
+from .properties import PluginProperties
+
+
+class SConsPluginProperties(PluginProperties, PluginModel):
+    """The part properties used by the SCons plugin."""
+
+    scons_options: List[str] = []
+
+    # part properties required by the plugin
+    source: str
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "SConsPluginProperties":
+        """Populate make properties from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+
+        :raise pydantic.ValidationError: If validation fails.
+        """
+        plugin_data = extract_plugin_properties(
+            data, plugin_name="scons", required=["source"]
+        )
+        return cls(**plugin_data)
+
+
+class SConsPlugin(Plugin):
+    """A plugin for SCons projects.
+
+    The plugin installs the ``scons`` package at build time but other dependencies
+    (C/C++ compiler, Java compiler, etc) must be declared via ``build-packages``.
+    Since there is no "official" way of defining the target installation directory
+    for SCons-built artifacts, the default build will set the DESTDIR environment
+    variable which the SConstruct file should use to configure its ``Install()``
+    builder target.
+
+    The plugin supports the following keywords:
+
+    - ``scons-options``
+      (list of strings)
+      Additional values to pass to the ``scons`` and ``scons install`` command
+      lines.
+    """
+
+    properties_class = SConsPluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        """Return a set of required snaps to install in the build environment."""
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        """Return a set of required packages to install in the build environment."""
+        return {"scons"}
+
+    def get_build_environment(self) -> Dict[str, str]:
+        """Return a dictionary with the environment to use in the build step."""
+        return {
+            "DESTDIR": f"{self._part_info.part_install_dir}/bin",
+        }
+
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        options = cast(SConsPluginProperties, self._options)
+
+        return [
+            " ".join(["scons"] + options.scons_options),
+            " ".join(["scons", "install"] + options.scons_options),
+        ]

--- a/tests/integration/plugins/test_scons.py
+++ b/tests/integration/plugins/test_scons.py
@@ -17,7 +17,7 @@ def test_scons_plugin(new_dir):
           foo:
             plugin: scons
             source: {source_location}
-            scons-options:
+            scons-parameters:
               - greeting=Hello
               - person-name=craft-parts
         """
@@ -35,5 +35,5 @@ def test_scons_plugin(new_dir):
     assert binary.is_file()
 
     output = subprocess.check_output([str(binary)], text=True)
-    # The output "Hello, craft-parts!" verifies that the scons-options were forwarded correctly.
+    # The output "Hello, craft-parts!" verifies that the scons-parameters were forwarded correctly.
     assert output == "Hello, craft-parts!\n"

--- a/tests/integration/plugins/test_scons.py
+++ b/tests/integration/plugins/test_scons.py
@@ -1,0 +1,39 @@
+import subprocess
+import textwrap
+from pathlib import Path
+
+import yaml
+
+from craft_parts import LifecycleManager, Step
+
+
+def test_scons_plugin(new_dir):
+    """Test builds with the scons plugin"""
+    source_location = Path(__file__).parent / "test_scons"
+
+    parts_yaml = textwrap.dedent(
+        f"""
+        parts:
+          foo:
+            plugin: scons
+            source: {source_location}
+            scons-options:
+              - greeting=Hello
+              - person-name=craft-parts
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+    lf = LifecycleManager(
+        parts, application_name="test_scons", cache_dir=new_dir, work_dir=new_dir
+    )
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    binary = Path(lf.project_info.prime_dir, "bin", "hello")
+    assert binary.is_file()
+
+    output = subprocess.check_output([str(binary)], text=True)
+    # The output "Hello, craft-parts!" verifies that the scons-options were forwarded correctly.
+    assert output == "Hello, craft-parts!\n"

--- a/tests/integration/plugins/test_scons/SConstruct
+++ b/tests/integration/plugins/test_scons/SConstruct
@@ -1,7 +1,7 @@
 import os
 import os.path
 
-install_dir = os.environ['DESTDIR']
+install_dir = os.path.join(os.environ['DESTDIR'], "bin")
 
 # "greeting" and "person-name" should come from the "scons" command line; if the program outputs
 # "WRONG PARAMETERS!", then the arguments were not provided correctly.

--- a/tests/integration/plugins/test_scons/SConstruct
+++ b/tests/integration/plugins/test_scons/SConstruct
@@ -1,0 +1,17 @@
+import os
+import os.path
+
+install_dir = os.environ['DESTDIR']
+
+# "greeting" and "person-name" should come from the "scons" command line; if the program outputs
+# "WRONG PARAMETERS!", then the arguments were not provided correctly.
+env = Environment(
+    CPPDEFINES={
+        "GREETING": ARGUMENTS.get("greeting", "WRONG"),
+        "PERSON_NAME": ARGUMENTS.get("person-name", "PARAMETERS"),
+    }
+)
+
+hello = env.Program("hello.c")
+env.Install(install_dir, hello)
+env.Alias('install', install_dir)

--- a/tests/integration/plugins/test_scons/hello.c
+++ b/tests/integration/plugins/test_scons/hello.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+// "Stringify" macros to turns the preprocessor constants GREETING and PERSON_NAME
+// into strings to print
+#define xstr(s) str(s)
+#define str(s) #s
+
+int main()
+{
+    printf("%s, %s!\n", xstr(GREETING), xstr(PERSON_NAME));
+    return 0;
+}

--- a/tests/unit/plugins/test_scons_plugin.py
+++ b/tests/unit/plugins/test_scons_plugin.py
@@ -26,7 +26,7 @@ def test_get_build_environment(part_info):
     plugin = SConsPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_environment() == {
-        "DESTDIR": f"{part_info.part_install_dir}/bin"
+        "DESTDIR": str(part_info.part_install_dir)
     }
 
 

--- a/tests/unit/plugins/test_scons_plugin.py
+++ b/tests/unit/plugins/test_scons_plugin.py
@@ -1,0 +1,55 @@
+import pytest
+from pydantic import ValidationError
+
+from craft_parts import Part, PartInfo, ProjectInfo
+from craft_parts.plugins.scons_plugin import SConsPlugin
+
+
+@pytest.fixture
+def part_info(new_dir):
+    return PartInfo(
+        project_info=ProjectInfo(application_name="test", cache_dir=new_dir),
+        part=Part("my-part", {}),
+    )
+
+
+def test_get_build_snaps_and_packages(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_snaps() == set()
+    assert plugin.get_build_packages() == {"scons"}
+
+
+def test_get_build_environment(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_environment() == {
+        "DESTDIR": f"{part_info.part_install_dir}/bin"
+    }
+
+
+def test_missing_parameters():
+    with pytest.raises(ValidationError) as raised:
+        SConsPlugin.properties_class.unmarshal({})
+    err = raised.value.errors()
+    assert len(err) == 1
+    assert err[0]["loc"] == ("source",)
+    assert err[0]["type"] == "value_error.missing"
+
+
+def test_get_build_commands(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_commands() == ["scons", "scons install"]
+
+
+def test_get_build_commands_with_options(part_info):
+    properties = SConsPlugin.properties_class.unmarshal(
+        {"source": ".", "scons-options": ["a=1", "b=2"]}
+    )
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_commands() == ["scons a=1 b=2", "scons install a=1 b=2"]

--- a/tests/unit/plugins/test_scons_plugin.py
+++ b/tests/unit/plugins/test_scons_plugin.py
@@ -124,9 +124,9 @@ def test_get_build_commands(part_info):
     assert plugin.get_build_commands() == ["scons", "scons install"]
 
 
-def test_get_build_commands_with_options(part_info):
+def test_get_build_commands_with_parameters(part_info):
     properties = SConsPlugin.properties_class.unmarshal(
-        {"source": ".", "scons-options": ["a=1", "b=2"]}
+        {"source": ".", "scons-parameters": ["a=1", "b=2"]}
     )
     plugin = SConsPlugin(properties=properties, part_info=part_info)
 

--- a/tests/unit/plugins/test_scons_plugin.py
+++ b/tests/unit/plugins/test_scons_plugin.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from craft_parts import Part, PartInfo, ProjectInfo
+from craft_parts import Part, PartInfo, ProjectInfo, errors
 from craft_parts.plugins.scons_plugin import SConsPlugin
 
 
@@ -13,12 +13,90 @@ def part_info(new_dir):
     )
 
 
+def test_validate_environment(dependency_fixture, part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+    scons = dependency_fixture("scons", output="SCons by Steven Knight et al.")
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(scons.parent)}", properties=properties
+    )
+    validator.validate_environment()
+
+
+def test_validate_environment_missing_scons(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "'scons' not found"
+
+
+def test_validate_environment_broken_scons(dependency_fixture, part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+    scons = dependency_fixture("scons", broken=True)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(scons.parent)}", properties=properties
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "'scons' failed with error code 33"
+
+
+def test_validate_environment_invalid_scons(dependency_fixture, part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+    scons = dependency_fixture("scons", invalid=True)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env=f"PATH={str(scons.parent)}", properties=properties
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment()
+
+    assert raised.value.reason == "invalid scons compiler version ''"
+
+
+def test_validate_environment_with_scons_part(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
+    validator.validate_environment(part_dependencies=["scons-deps"])
+
+
+def test_validate_environment_without_scons_part(part_info):
+    properties = SConsPlugin.properties_class.unmarshal({"source": "."})
+    plugin = SConsPlugin(properties=properties, part_info=part_info)
+
+    validator = plugin.validator_class(
+        part_name="my-part", env="PATH=/foo", properties=properties
+    )
+    with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
+        validator.validate_environment(part_dependencies=[])
+
+    assert raised.value.reason == (
+        "'scons' not found and part 'my-part' does not depend on a part named "
+        "'scons-deps' that would satisfy the dependency"
+    )
+
+
 def test_get_build_snaps_and_packages(part_info):
     properties = SConsPlugin.properties_class.unmarshal({"source": "."})
     plugin = SConsPlugin(properties=properties, part_info=part_info)
 
     assert plugin.get_build_snaps() == set()
-    assert plugin.get_build_packages() == {"scons"}
+    assert plugin.get_build_packages() == set()
 
 
 def test_get_build_environment(part_info):


### PR DESCRIPTION
This plugin builds SCons projects and is heavily based on Snapcraft's core18 plugin. Remarks:

- The plugin builds artifacts through two commands: "scons" and "scons install". This assumes that "install" is a valid target in the source's SConstruct file.
- Since there is no "official" way to configure the installation dir for SCons-generated artifacts, the plugin assumes the common convention of setting the DESTDIR environment variable to the part's install dir.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

CRAFT-1418
