### PR TITLE
features: introduce craft-parts features

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,12 +23,14 @@ from .actions import Action, ActionProperties, ActionType
 from .dirs import ProjectDirs
 from .errors import PartsError
 from .executor.environment import expand_environment
+from .features import Features
 from .infos import PartInfo, ProjectInfo, StepInfo
 from .lifecycle_manager import LifecycleManager
 from .parts import Part, validate_part
 from .steps import Step
 
 __all__ = [
+    "Features",
     "Action",
     "ActionProperties",
     "ActionType",

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -46,6 +46,17 @@ class PartsError(Exception):
             components.append(self.resolution)
 
         return "\n".join(components)
+
+
+class FeatureDisabled(PartsError):
+    """The requested feature is not enabled."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        brief = message
+        resolution = "This operation cannot be executed."
+
+        super().__init__(brief=brief, resolution=resolution)
 
 
 class PartDependencyCycle(PartsError):

--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -1,0 +1,39 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Global features to be configured by the application."""
+
+import contextlib
+import dataclasses
+import logging
+
+from craft_parts.utils import Singleton
+
+logger = logging.getLogger()
+
+
+@dataclasses.dataclass(frozen=True)
+class Features(metaclass=Singleton):
+    """Configurable craft-parts features."""
+
+    enable_overlay: bool = True
+
+    @classmethod
+    def reset(cls):
+        """Delete stored class instance."""
+        logger.warning("deleting current features configuration")
+        with contextlib.suppress(KeyError):
+            del cls._instances[cls]

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,7 @@ from pydantic import ValidationError
 from craft_parts import errors, executor, packages, plugins, sequencer
 from craft_parts.actions import Action
 from craft_parts.dirs import ProjectDirs
+from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo
 from craft_parts.overlays import LayerHash
 from craft_parts.parts import Part, part_by_name
@@ -255,6 +256,9 @@ class LifecycleManager:
 
 def _ensure_overlay_supported() -> None:
     """Overlay is only supported in Linux and requires superuser privileges."""
+    if not Features().enable_overlay:
+        raise errors.FeatureDisabled("Overlays are not supported.")
+
     if sys.platform != "linux":
         raise errors.OverlayPlatformError()
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError, root_validator, validato
 
 from craft_parts import errors, plugins
 from craft_parts.dirs import ProjectDirs
+from craft_parts.features import Features
 from craft_parts.packages import platform
 from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
@@ -78,6 +79,12 @@ class PartSpec(BaseModel):
         assert (
             item[0] != "/"
         ), f"{item!r} must be a relative path (cannot start with '/')"
+        return item
+
+    @validator("overlay_packages", "overlay_files", "overlay_script")
+    def validate_overlay_feature(cls, item):
+        """Check if overlay attributes specified when feature is disabled."""
+        assert Features().enable_overlay, "overlays not supported"
         return item
 
     @root_validator(pre=True)

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, cast
 
 from craft_parts import parts, sources, steps
+from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo, ProjectVar
 from craft_parts.parts import Part
 from craft_parts.sources import SourceHandler
@@ -254,7 +255,13 @@ class StateManager:
 
         previous_steps = step.previous_steps()
         if previous_steps:
-            return self.should_step_run(part, previous_steps[-1])
+            prev_step = previous_steps[-1]
+
+            # Skip testing overlay state if overlays are disabled
+            if not Features().enable_overlay and prev_step == Step.OVERLAY:
+                prev_step = previous_steps[-2]
+
+            return self.should_step_run(part, prev_step)
 
         return False
 

--- a/craft_parts/utils/__init__.py
+++ b/craft_parts/utils/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,27 @@
 
 """Utilities and helpers."""
 
+from typing import Dict
+
 
 def package_name() -> str:
     """Return the topmost package name."""
     return __name__.split(".", maxsplit=1)[0]
+
+
+class Singleton(type):
+    """Singleton metaclass."""
+
+    _instances: Dict = {}
+
+    def __call__(cls, *args, **kwargs):
+        """Return an existing instance, or create a new instance."""
+        if cls not in cls._instances:
+            instance = super().__call__(*args, **kwargs)
+            cls._instances[cls] = instance
+            return instance
+
+        if args or kwargs:
+            raise RuntimeError("parameters can only be set once")
+
+        return cls._instances[cls]

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -51,6 +51,14 @@ def test_part_dependency_cycle():
     assert err.brief == "A circular dependency chain was detected."
     assert err.details is None
     assert err.resolution == "Review the parts definition to remove dependency cycles."
+
+
+def test_feature_disabled():
+    err = errors.FeatureDisabled("bummer")
+    assert err.message == "bummer"
+    assert err.brief == "bummer"
+    assert err.details is None
+    assert err.resolution == "This operation cannot be executed."
 
 
 def test_invalid_application_name():

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import Features
+
+
+@pytest.fixture(autouse=True)
+def setup_features():
+    Features.reset()
+    yield
+    Features.reset()
+
+
+def test_features():
+    features = Features()
+    assert features.enable_overlay is True
+
+
+def test_features_set():
+    features = Features(enable_overlay=False)
+    assert features.enable_overlay is False
+
+    # A different instance should have the previously set value
+    f2 = Features()
+    assert f2.enable_overlay is False
+
+
+def test_features_set_twice():
+    Features(enable_overlay=False)
+
+    with pytest.raises(RuntimeError) as raised:
+        Features(enable_overlay=False)
+
+    assert str(raised.value) == "parameters can only be set once"


### PR DESCRIPTION
Craft-parts can now specify features that can be enabled or disabled to change its behavior in certain scenarios. This change also includes a minimally intrusive implementation of the overlay feature, which inhibits the generation of overlay actions when this feature is disabled by the application.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1531