### PR TITLE
executor: fix directory cleaning

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -16,7 +16,6 @@
 
 """Definitions and helpers for the action executor."""
 
-import contextlib
 import logging
 import shutil
 from pathlib import Path
@@ -149,12 +148,14 @@ class Executor:
 
         if not part_names:
             # also remove toplevel directories if part names are not specified
-            with contextlib.suppress(FileNotFoundError):
+            if self._project_info.prime_dir.exists():
                 shutil.rmtree(self._project_info.prime_dir)
-                if initial_step <= Step.STAGE:
-                    shutil.rmtree(self._project_info.stage_dir)
-                if initial_step <= Step.PULL:
-                    shutil.rmtree(self._project_info.parts_dir)
+
+            if initial_step <= Step.STAGE and self._project_info.stage_dir.exists():
+                shutil.rmtree(self._project_info.stage_dir)
+
+            if initial_step <= Step.PULL and self._project_info.parts_dir.exists():
+                shutil.rmtree(self._project_info.parts_dir)
 
     def _run_action(
         self,

--- a/tests/unit/executor/test_executor.py
+++ b/tests/unit/executor/test_executor.py
@@ -41,8 +41,14 @@ class TestExecutor:
         file2.parent.mkdir(parents=True)
         file2.touch()
 
+        stage_dir = Path("stage")
+        stage_dir.mkdir()
+        file3 = Path("stage/foobar.txt")
+        file3.touch()
+
         assert file1.exists()
         assert file2.exists()
+        assert file3.exists()
 
         info = ProjectInfo(application_name="test", cache_dir=new_dir)
         e = Executor(project_info=info, part_list=[p1, p2])
@@ -50,6 +56,8 @@ class TestExecutor:
 
         assert file1.exists() is False
         assert file2.exists() is False
+        assert file3.exists() is False
+        assert stage_dir.exists() is False
 
     def test_clean_part(self, new_dir):
         p1 = Part("p1", {"plugin": "nil"})


### PR DESCRIPTION
Fix bad logic in the executor cleaning that could lead to lifecycle directories that should be cleaned unexpectedly remaining after clean is issued. Thanks to Facundo Batista for spotting this bug, fixes #329.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
