### PR TITLE
docs: update sphinx-autodoc-typehints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,9 +2,9 @@ wheel
 setuptools
 python-distutils-extra @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz
 python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz
-Sphinx==4.2.0
-sphinx-autodoc-typehints==1.12.0
-sphinx-jsonschema==1.16.11
+Sphinx==5.3.0
+sphinx-autodoc-typehints==1.20.0
+sphinx-jsonschema==1.19.1
 sphinx-pydantic==0.1.1
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2


### PR DESCRIPTION
The doc generation from code (via autodoc) is currently broken because sphinx-autodoc-typehints was interacting badly with Pydantic; update sphinx-autodoc-typehints to a newer version to fix this.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
