### PR TITLE
linters: fix new ruff issues

### DIFF
--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -53,20 +53,20 @@ class LayerHash:
         :returns: The validation hash computed for the layer corresponding
             to the given part.
         """
-        hasher = hashlib.sha1()
+        hasher = hashlib.sha1()  # noqa: S324
         if previous_layer_hash:
             hasher.update(previous_layer_hash.digest)
         for entry in part.spec.overlay_packages:
             hasher.update(entry.encode())
         digest = hasher.digest()
 
-        hasher = hashlib.sha1()
+        hasher = hashlib.sha1()  # noqa: S324
         hasher.update(digest)
         for entry in part.spec.overlay_files:
             hasher.update(entry.encode())
         digest = hasher.digest()
 
-        hasher = hashlib.sha1()
+        hasher = hashlib.sha1()  # noqa: S324
         hasher.update(digest)
         if part.spec.overlay_script:
             hasher.update(part.spec.overlay_script.encode())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ ignore = [
     "ANN", # Ignore type annotations in tests
     "S101",  # Yeah of course we assert in tests
     "B009",  # Allow calling `getattr` in tests since it can be used to make the test clearer.
+    "S103", # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
+    "S108", # Allow Probable insecure usage of temporary file or directory
 ]
 "__init__.py" = ["I001"]  # Imports in __init__ filesare allowed to be out of order
 


### PR DESCRIPTION
ruff is a newish tool and it's getting a lot of new releases; we don't currently pin it and the latest versions need two fixes: be more permissive with temporary dirs in tests, and mark that hashlib.sha1() is not being used for security.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
