### PR TITLE
linters: add PLR2004 to ruff ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ ignore = [
     "C405", "C408", "C414",
     "Q000", # 2 single-quoted strings - probably accidental
     "RET504", "RET506",  # Return value related.
+    "PLR2004", # Magic value used in comparison
 
 ]
 #show-source = true


### PR DESCRIPTION
PLR2004 is "Magic value used in comparison, consider using a constant". This is triggering for things like expected messages in tests, so there were over 600 instances in craft-parts.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
