### PR TITLE
plugins: verify plugin method override

### DIFF
--- a/craft_parts/plugins/ant_plugin.py
+++ b/craft_parts/plugins/ant_plugin.py
@@ -19,6 +19,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
+
 from craft_parts import errors
 
 from . import validator
@@ -38,6 +40,7 @@ class AntPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "AntPluginProperties":
         """Populate make properties from the part specification.
 
@@ -60,6 +63,7 @@ class AntPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -125,18 +129,22 @@ class AntPlugin(JavaPlugin):
     properties_class = AntPluginProperties
     validator_class = AntPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(AntPluginProperties, self._options)

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Set, cast
 
+from overrides import override
+
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
 
@@ -31,6 +33,7 @@ class AutotoolsPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "AutotoolsPluginProperties":
         """Populate autotools properties from the part specification.
 
@@ -70,14 +73,17 @@ class AutotoolsPlugin(Plugin):
 
     properties_class = AutotoolsPluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return {"autoconf", "automake", "autopoint", "gcc", "libtool"}
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
@@ -89,6 +95,7 @@ class AutotoolsPlugin(Plugin):
 
     # pylint: disable=line-too-long
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         return [

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Set, cast
 
+from overrides import override
+
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
 
@@ -32,6 +34,7 @@ class CMakePluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "CMakePluginProperties":
         """Populate class attributes from the part specification.
 
@@ -80,10 +83,12 @@ class CMakePlugin(Plugin):
 
     properties_class = CMakePluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         build_packages = {"gcc", "cmake"}
@@ -95,6 +100,7 @@ class CMakePlugin(Plugin):
 
         return build_packages
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
@@ -102,6 +108,7 @@ class CMakePlugin(Plugin):
             "CMAKE_PREFIX_PATH": str(self._part_info.stage_dir)
         }
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(CMakePluginProperties, self._options)
@@ -123,6 +130,7 @@ class CMakePlugin(Plugin):
         ]
 
     @classmethod
+    @override
     def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True

--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -19,6 +19,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
+
 from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
@@ -36,6 +38,7 @@ class DotnetPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "DotnetPluginProperties":
         """Populate make properties from the part specification.
 
@@ -58,6 +61,7 @@ class DotPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -95,18 +99,22 @@ class DotnetPlugin(Plugin):
     properties_class = DotnetPluginProperties
     validator_class = DotPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(DotnetPluginProperties, self._options)

--- a/craft_parts/plugins/dump_plugin.py
+++ b/craft_parts/plugins/dump_plugin.py
@@ -21,6 +21,8 @@ This plugin just dumps the content from a specified part source.
 
 from typing import Any, Dict, List, Set
 
+from overrides import override
+
 from .base import Plugin
 from .properties import PluginProperties
 
@@ -29,6 +31,7 @@ class DumpPluginProperties(PluginProperties):
     """The part properties used by the dump plugin."""
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "DumpPluginProperties":
         """Populate dump properties from the part specification.
 
@@ -50,18 +53,22 @@ class DumpPlugin(Plugin):
 
     properties_class = DumpPluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         install_dir = self._part_info.part_install_dir

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -19,6 +19,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
+
 from craft_parts import errors
 
 from . import validator
@@ -38,6 +40,7 @@ class GoPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "GoPluginProperties":
         """Populate make properties from the part specification.
 
@@ -60,6 +63,7 @@ class GoPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -108,20 +112,24 @@ class GoPlugin(Plugin):
     properties_class = GoPluginProperties
     validator_class = GoPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
             "GOBIN": f"{self._part_info.part_install_dir}/bin",
         }
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(GoPluginProperties, self._options)

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Set, cast
 
+from overrides import override
+
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
 
@@ -31,6 +33,7 @@ class MakePluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "MakePluginProperties":
         """Populate make properties from the part specification.
 
@@ -68,14 +71,17 @@ class MakePlugin(Plugin):
 
     properties_class = MakePluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return {"gcc", "make"}
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
@@ -91,6 +97,7 @@ class MakePlugin(Plugin):
 
         return " ".join(cmd)
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         return [

--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -23,6 +23,8 @@ from typing import Any, Dict, List, Optional, Set, cast
 from urllib.parse import urlparse
 from xml.etree import ElementTree
 
+from overrides import override
+
 from craft_parts import errors
 
 from . import validator
@@ -39,6 +41,7 @@ class MavenPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "MavenPluginProperties":
         """Populate class attributes from the part specification.
 
@@ -61,6 +64,7 @@ class MavenPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -105,18 +109,22 @@ class MavenPlugin(JavaPlugin):
     properties_class = MavenPluginProperties
     validator_class = MavenPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(MavenPluginProperties, self._options)

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -21,6 +21,8 @@ import logging
 import shlex
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
+
 from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
@@ -37,6 +39,7 @@ class MesonPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "MesonPluginProperties":
         """Populate make properties from the part specification.
 
@@ -59,6 +62,7 @@ class MesonPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -96,22 +100,27 @@ class MesonPlugin(Plugin):
     validator_class = MesonPluginEnvironmentValidator
 
     @classmethod
+    @override
     def get_out_of_source_build(cls) -> bool:
         """Return whether the plugin performs out-of-source-tree builds."""
         return True
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(MesonPluginProperties, self._options)

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -22,6 +22,8 @@ automatically included, e.g. stage-packages.
 
 from typing import Any, Dict, List, Set
 
+from overrides import override
+
 from .base import Plugin
 from .properties import PluginProperties
 
@@ -30,6 +32,7 @@ class NilPluginProperties(PluginProperties):
     """The part properties used by the nil plugin."""
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "NilPluginProperties":
         """Populate class attributes from the part specification.
 
@@ -60,18 +63,22 @@ class NilPlugin(Plugin):
 
     properties_class = NilPluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         return []

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -22,6 +22,7 @@ import platform
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
 from pydantic import root_validator
 
 from craft_parts.errors import InvalidArchitecture
@@ -60,6 +61,7 @@ class NpmPluginProperties(PluginProperties, PluginModel):
         return values
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "NpmPluginProperties":
         """Populate class attributes from the part specification.
 
@@ -82,6 +84,7 @@ class NpmPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -147,22 +150,26 @@ class NpmPlugin(Plugin):
 
         return node_arch
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         if cast(NpmPluginProperties, self._options).npm_include_node:
             return {"curl", "gcc"}
         return {"gcc"}
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         if cast(NpmPluginProperties, self._options).npm_include_node:
             return dict(PATH="${CRAFT_PART_INSTALL}/bin:${PATH}")
         return {}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(NpmPluginProperties, self._options)

--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -20,6 +20,8 @@ import shlex
 from textwrap import dedent
 from typing import Any, Dict, List, Set, cast
 
+from overrides import override
+
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
 
@@ -35,6 +37,7 @@ class PythonPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "PythonPluginProperties":
         """Populate make properties from the part specification.
 
@@ -97,14 +100,17 @@ class PythonPlugin(Plugin):
 
     properties_class = PythonPluginProperties
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return {"findutils", "python3-dev", "python3-venv"}
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
@@ -118,6 +124,7 @@ class PythonPlugin(Plugin):
 
     # pylint: disable=line-too-long
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         build_commands = [

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -19,6 +19,7 @@
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, cast
 
+from overrides import override
 from pydantic import conlist
 
 from . import validator
@@ -44,6 +45,7 @@ class RustPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "RustPluginProperties":
         """Populate class attributes from the part specification.
 
@@ -66,6 +68,7 @@ class RustPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -100,18 +103,22 @@ class RustPlugin(Plugin):
     properties_class = RustPluginProperties
     validator_class = RustPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return {"gcc", "git"}
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {"PATH": "${HOME}/.cargo/bin:${PATH}"}
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(RustPluginProperties, self._options)

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Optional, Set, cast
 
+from overrides import override
+
 from .. import errors
 from . import validator
 from .base import Plugin, PluginModel, extract_plugin_properties
@@ -33,6 +35,7 @@ class SConsPluginProperties(PluginProperties, PluginModel):
     source: str
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "SConsPluginProperties":
         """Populate make properties from the part specification.
 
@@ -55,6 +58,7 @@ class SConsPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
     :param env: A string containing the build step environment setup.
     """
 
+    @override
     def validate_environment(
         self, *, part_dependencies: Optional[List[str]] = None
     ) -> None:
@@ -109,20 +113,24 @@ class SConsPlugin(Plugin):
     properties_class = SConsPluginProperties
     validator_class = SConsPluginEnvironmentValidator
 
+    @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
 
+    @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
         return set()
 
+    @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {
             "DESTDIR": f"{self._part_info.part_install_dir}",
         }
 
+    @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(SConsPluginProperties, self._options)


### PR DESCRIPTION
Use the `@override` decorator to ensure plugin methods correctly overrode an inherited method.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
