### PR TITLE
tests: Ensure maven test sets environment

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Fixtures for all plugin tests to use."""
+
+import pytest
+from craft_parts.packages import deb
+
+@pytest.fixture(autouse=True)
+def clear_function_cache_after_run():
+    yield
+    deb.Ubuntu.refresh_packages_list.cache_clear()
+    deb._run_dpkg_query_list_files.cache_clear()
+    deb._run_dpkg_query_search.cache_clear()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -14,7 +14,9 @@
 """Fixtures for all plugin tests to use."""
 
 import pytest
+
 from craft_parts.packages import deb
+
 
 @pytest.fixture(autouse=True)
 def clear_function_cache_after_run():

--- a/tests/integration/plugins/test_maven.py
+++ b/tests/integration/plugins/test_maven.py
@@ -24,6 +24,7 @@ from craft_parts import LifecycleManager, Step
 
 
 def test_maven_plugin(new_dir, monkeypatch):
+    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
     source_location = Path(__file__).parent / "test_maven"
 
     parts_yaml = textwrap.dedent(


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

I came across this while running the integration tests. As is, the maven test succeeds when running all tests in order, but fails when run without running the ant test. The change in `test_maven.py` fixes the test so it can run independently, and the change in `__init__.py` ensures that cached functions get their caches cleared after each integration test, keeping them more independent.