### PR TITLE
lint: specify a single ruff version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ test_requires = [
     "pytest",
     "pytest-mock",
     "requests-mock",
-    "ruff",
+    "ruff==0.0.236",
     "tox",
     "types-PyYAML",
     "types-requests",


### PR DESCRIPTION
Ensure that ruff only gets updated by renovate or explicitly in PRs. This will prevent random CI breakages until ruff is stable.

Related: https://github.com/canonical/starbase/pull/21

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
