### PR TITLE
plugins: implement strict/offline plugins

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -266,6 +266,22 @@ class InvalidPlugin(PartsError):
         super().__init__(brief=brief, resolution=resolution)
 
 
+class PluginNotStrict(PartsError):
+    """A request was made to use a plugin that's not strict.
+
+    :param plugin_name: The plugin name.
+    :param part_name: The name of the part defining the plugin.
+    """
+
+    def __init__(self, plugin_name: str, *, part_name: str):
+        self.plugin_name = plugin_name
+        self.part_name = part_name
+        brief = f"Plugin {plugin_name!r} in part {part_name!r} cannot be used."
+        details = "Only plugins that are capable of building offline are allowed."
+
+        super().__init__(brief=brief, details=details)
+
+
 class OsReleaseIdError(PartsError):
     """Failed to determine the host operating system identification string."""
 
@@ -418,6 +434,19 @@ class PluginEnvironmentValidationError(PartsError):
         super().__init__(brief=brief)
 
 
+class PluginPullError(PartsError):
+    """Plugin pull script failed at runtime.
+
+    :param part_name: The name of the part being processed.
+    """
+
+    def __init__(self, *, part_name: str):
+        self.part_name = part_name
+        brief = f"Failed to run the pull script for part {part_name!r}."
+
+        super().__init__(brief=brief)
+
+
 class PluginBuildError(PartsError):
     """Plugin build script failed at runtime.
 
@@ -427,6 +456,19 @@ class PluginBuildError(PartsError):
     def __init__(self, *, part_name: str):
         self.part_name = part_name
         brief = f"Failed to run the build script for part {part_name!r}."
+
+        super().__init__(brief=brief)
+
+
+class PluginCleanError(PartsError):
+    """Script to clean strict build preparation failed at runtime.
+
+    :param part_name: The name of the part being processed.
+    """
+
+    def __init__(self, *, part_name: str):
+        self.part_name = part_name
+        brief = f"Failed to run the clean script for part {part_name!r}."
 
         super().__init__(brief=brief)
 

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -277,7 +277,9 @@ class PluginNotStrict(PartsError):
         self.plugin_name = plugin_name
         self.part_name = part_name
         brief = f"Plugin {plugin_name!r} in part {part_name!r} cannot be used."
-        details = "Only plugins that are capable of building offline are allowed."
+        details = (
+            "Only plugins that are capable of building in strict mode are allowed."
+        )
 
         super().__init__(brief=brief, details=details)
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -26,7 +26,7 @@ import tempfile
 import textwrap
 import time
 from pathlib import Path
-from typing import List, Optional, Set, TextIO, Union, cast
+from typing import List, Optional, Set, TextIO, Union
 
 from craft_parts import errors, packages
 from craft_parts.infos import StepInfo
@@ -36,7 +36,6 @@ from craft_parts.sources import SourceHandler
 from craft_parts.steps import Step
 from craft_parts.utils import file_utils
 
-from ..plugins.base import StrictPlugin
 from . import filesets
 from .filesets import Fileset
 from .migration import migrate_files
@@ -110,15 +109,12 @@ class StepHandler:
         if self._source_handler:
             self._source_handler.pull()
 
-        # Plugin prepare commands.
-        if self._step_info.offline_build:
-            # If offline build is enabled we're using only strict plugins
-            plugin = cast(StrictPlugin, self._plugin)
-            pull_prepare_commands = plugin.get_pull_prepare_commands()
+        pull_commands = self._plugin.get_pull_commands()
 
+        if pull_commands:
             try:
                 _create_and_run_script(
-                    pull_prepare_commands,
+                    pull_commands,
                     script_path=self._part.part_run_dir.absolute() / "pull.sh",
                     cwd=self._part.part_src_subdir,
                     stdout=self._stdout,

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -59,6 +59,7 @@ class ProjectInfo:
         architecture.
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
+    :param offline_build: Only allow plugins capable of offline building.
     :param project_dirs: The project work directories.
     :param project_name: The name of the project.
     :param project_vars_part_name: Project variables can be set only if
@@ -76,6 +77,7 @@ class ProjectInfo:
         arch: str = "",
         base: str = "",
         parallel_build_count: int = 1,
+        offline_build: bool = False,
         project_dirs: Optional[ProjectDirs] = None,
         project_name: Optional[str] = None,
         project_vars_part_name: Optional[str] = None,
@@ -92,6 +94,7 @@ class ProjectInfo:
         self._set_machine(arch)
         self._base = base  # TODO: infer base if not specified
         self._parallel_build_count = parallel_build_count
+        self._offline_build = offline_build
         self._dirs = project_dirs
         self._project_name = project_name
         self._project_vars_part_name = project_vars_part_name
@@ -139,6 +142,11 @@ class ProjectInfo:
     def parallel_build_count(self) -> int:
         """Return the maximum allowable number of concurrent build jobs."""
         return self._parallel_build_count
+
+    @property
+    def offline_build(self) -> bool:
+        """Return whether it must be possible to build the project offline."""
+        return self._offline_build
 
     @property
     def host_arch(self) -> str:
@@ -300,6 +308,7 @@ class PartInfo:
         self._part_build_subdir = part.part_build_subdir
         self._part_install_dir = part.part_install_dir
         self._part_state_dir = part.part_state_dir
+        self._part_cache_dir = part.part_cache_dir
         self.build_attributes = part.spec.build_attributes.copy()
 
     def __getattr__(self, name: str) -> Any:
@@ -349,6 +358,11 @@ class PartInfo:
     def part_state_dir(self) -> Path:
         """Return the subdirectory containing this part's lifecycle state."""
         return self._part_state_dir
+
+    @property
+    def part_cache_dir(self) -> Path:
+        """Return the subdirectory containing this part's cache directory."""
+        return self._part_cache_dir
 
     def set_project_var(
         self, name: str, value: str, *, raw_write: bool = False

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -59,7 +59,7 @@ class ProjectInfo:
         architecture.
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
-    :param offline_build: Only allow plugins capable of offline building.
+    :param strict_mode: Only allow plugins capable of building in strict mode.
     :param project_dirs: The project work directories.
     :param project_name: The name of the project.
     :param project_vars_part_name: Project variables can be set only if
@@ -77,7 +77,7 @@ class ProjectInfo:
         arch: str = "",
         base: str = "",
         parallel_build_count: int = 1,
-        offline_build: bool = False,
+        strict_mode: bool = False,
         project_dirs: Optional[ProjectDirs] = None,
         project_name: Optional[str] = None,
         project_vars_part_name: Optional[str] = None,
@@ -94,7 +94,7 @@ class ProjectInfo:
         self._set_machine(arch)
         self._base = base  # TODO: infer base if not specified
         self._parallel_build_count = parallel_build_count
-        self._offline_build = offline_build
+        self._strict_mode = strict_mode
         self._dirs = project_dirs
         self._project_name = project_name
         self._project_vars_part_name = project_vars_part_name
@@ -144,9 +144,9 @@ class ProjectInfo:
         return self._parallel_build_count
 
     @property
-    def offline_build(self) -> bool:
-        """Return whether it must be possible to build the project offline."""
-        return self._offline_build
+    def strict_mode(self) -> bool:
+        """Return whether this project must be built in 'strict' mode."""
+        return self._strict_mode
 
     @property
     def host_arch(self) -> str:

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -65,7 +65,7 @@ class LifecycleManager:
     :param extra_build_packages: A list of additional build packages to install.
     :param extra_build_snaps: A list of additional build snaps to install.
     :param track_stage_packages: Add primed stage packages to the prime state.
-    :param offline_build: Only allow plugins capable of offline building.
+    :param strict_mode: Only allow plugins capable of building in strict mode.
     :param base_layer_dir: The path to the overlay base layer, if using overlays.
     :param base_layer_hash: The validation hash of the overlay base image, if using
         overlays. The validation hash should be constant for a given image, and should
@@ -93,7 +93,7 @@ class LifecycleManager:
         extra_build_packages: Optional[List[str]] = None,
         extra_build_snaps: Optional[List[str]] = None,
         track_stage_packages: bool = False,
-        offline_build: bool = False,
+        strict_mode: bool = False,
         base_layer_dir: Optional[Path] = None,
         base_layer_hash: Optional[bytes] = None,
         project_vars_part_name: Optional[str] = None,
@@ -124,7 +124,7 @@ class LifecycleManager:
             arch=arch,
             base=base,
             parallel_build_count=parallel_build_count,
-            offline_build=offline_build,
+            strict_mode=strict_mode,
             project_name=project_name,
             project_dirs=project_dirs,
             project_vars_part_name=project_vars_part_name,
@@ -138,7 +138,7 @@ class LifecycleManager:
 
         part_list = []
         for name, spec in parts_data.items():
-            part_list.append(_build_part(name, spec, project_dirs, offline_build))
+            part_list.append(_build_part(name, spec, project_dirs, strict_mode))
 
         self._has_overlay = any(p.has_overlay for p in part_list)
 
@@ -299,7 +299,7 @@ def _build_part(
             raise errors.UndefinedPlugin(part_name=name) from err
         raise errors.InvalidPlugin(plugin_name, part_name=name) from err
 
-    if strict_plugins and not plugin_class.offline:
+    if strict_plugins and not plugin_class.supports_strict_mode:
         raise errors.PluginNotStrict(plugin_name, part_name=name)
 
     # validate and unmarshal plugin properties

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -65,6 +65,7 @@ class LifecycleManager:
     :param extra_build_packages: A list of additional build packages to install.
     :param extra_build_snaps: A list of additional build snaps to install.
     :param track_stage_packages: Add primed stage packages to the prime state.
+    :param offline_build: Only allow plugins capable of offline building.
     :param base_layer_dir: The path to the overlay base layer, if using overlays.
     :param base_layer_hash: The validation hash of the overlay base image, if using
         overlays. The validation hash should be constant for a given image, and should
@@ -92,6 +93,7 @@ class LifecycleManager:
         extra_build_packages: Optional[List[str]] = None,
         extra_build_snaps: Optional[List[str]] = None,
         track_stage_packages: bool = False,
+        offline_build: bool = False,
         base_layer_dir: Optional[Path] = None,
         base_layer_hash: Optional[bytes] = None,
         project_vars_part_name: Optional[str] = None,
@@ -122,6 +124,7 @@ class LifecycleManager:
             arch=arch,
             base=base,
             parallel_build_count=parallel_build_count,
+            offline_build=offline_build,
             project_name=project_name,
             project_dirs=project_dirs,
             project_vars_part_name=project_vars_part_name,
@@ -135,7 +138,7 @@ class LifecycleManager:
 
         part_list = []
         for name, spec in parts_data.items():
-            part_list.append(_build_part(name, spec, project_dirs))
+            part_list.append(_build_part(name, spec, project_dirs, offline_build))
 
         self._has_overlay = any(p.has_overlay for p in part_list)
 
@@ -265,7 +268,9 @@ def _ensure_overlay_supported() -> None:
         raise errors.OverlayPermissionError()
 
 
-def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> Part:
+def _build_part(
+    name: str, spec: Dict[str, Any], project_dirs: ProjectDirs, strict_plugins: bool
+) -> Part:
     """Create and populate a :class:`Part` object based on part specification data.
 
     :param spec: A dictionary containing the part specification.
@@ -293,6 +298,9 @@ def _build_part(name: str, spec: Dict[str, Any], project_dirs: ProjectDirs) -> P
             # that part name is an invalid plugin.
             raise errors.UndefinedPlugin(part_name=name) from err
         raise errors.InvalidPlugin(plugin_name, part_name=name) from err
+
+    if strict_plugins and not plugin_class.offline:
+        raise errors.PluginNotStrict(plugin_name, part_name=name)
 
     # validate and unmarshal plugin properties
     try:

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -98,6 +98,7 @@ def _process_parts(options: argparse.Namespace) -> None:
         application_name=options.application_name,
         work_dir=options.work_dir,
         cache_dir=cache_dir,
+        offline_build=options.strict,
         base=options.base,
         base_layer_dir=overlay_base,
         base_layer_hash=base_layer_hash,
@@ -238,6 +239,11 @@ def _parse_arguments() -> argparse.Namespace:
         "--show-skipped",
         action="store_true",
         help="Also display skipped actions.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Enable offline builds.",
     )
     parser.add_argument(
         "--work-dir",

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -98,7 +98,7 @@ def _process_parts(options: argparse.Namespace) -> None:
         application_name=options.application_name,
         work_dir=options.work_dir,
         cache_dir=cache_dir,
-        offline_build=options.strict,
+        strict_mode=options.strict,
         base=options.base,
         base_layer_dir=overlay_base,
         base_layer_hash=base_layer_hash,
@@ -243,7 +243,7 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Enable offline builds.",
+        help="Enable strict builds.",
     )
     parser.add_argument(
         "--work-dir",

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -253,6 +253,11 @@ class Part:
         return self._part_dir / "state"
 
     @property
+    def part_cache_dir(self) -> Path:
+        """Return the subdirectory containing the part cache directory."""
+        return self._part_dir / "cache"
+
+    @property
     def part_packages_dir(self) -> Path:
         """Return the subdirectory containing the part stage packages directory."""
         return self._part_dir / "stage_packages"

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -16,9 +16,8 @@
 
 """Craft Parts plugins subsystem."""
 
-from .base import PluginModel, extract_plugin_properties
+from .base import Plugin, PluginModel, StrictPlugin, extract_plugin_properties
 from .plugins import (
-    Plugin,
     PluginProperties,
     extract_part_properties,
     get_plugin,
@@ -34,6 +33,7 @@ __all__ = [
     "PluginEnvironmentValidator",
     "PluginModel",
     "PluginProperties",
+    "StrictPlugin",
     "extract_part_properties",
     "extract_plugin_properties",
     "get_plugin",

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft Parts plugins subsystem."""
 
-from .base import Plugin, PluginModel, StrictPlugin, extract_plugin_properties
+from .base import Plugin, PluginModel, extract_plugin_properties
 from .plugins import (
     PluginProperties,
     extract_part_properties,
@@ -33,7 +33,6 @@ __all__ = [
     "PluginEnvironmentValidator",
     "PluginModel",
     "PluginProperties",
-    "StrictPlugin",
     "extract_part_properties",
     "extract_plugin_properties",
     "get_plugin",

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -44,6 +44,7 @@ class Plugin(abc.ABC):
 
     properties_class: Type[PluginProperties]
     validator_class = PluginEnvironmentValidator
+    offline = False
 
     def __init__(
         self, *, properties: PluginProperties, part_info: "infos.PartInfo"
@@ -79,6 +80,20 @@ class Plugin(abc.ABC):
         :param action_properties: The properties to store.
         """
         self._action_properties = deepcopy(action_properties)
+
+
+class StrictPlugin(Plugin):
+    """Base class for strict plugins.
+
+    Strict plugins will retrieve all dependencies from remote locations during
+    the pull step, allowing the build step to run offline.
+    """
+
+    offline = True
+
+    @abc.abstractmethod
+    def get_pull_prepare_commands(self) -> List[str]:
+        """Return a list commands to retrieve dependencies during the pull step."""
 
 
 class JavaPlugin(Plugin):

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -44,7 +44,9 @@ class Plugin(abc.ABC):
 
     properties_class: Type[PluginProperties]
     validator_class = PluginEnvironmentValidator
-    offline = False
+
+    supports_strict_mode = False
+    """Plugins that can run in 'strict' mode must set this classvar to True."""
 
     def __init__(
         self, *, properties: PluginProperties, part_info: "infos.PartInfo"
@@ -52,6 +54,10 @@ class Plugin(abc.ABC):
         self._options = properties
         self._part_info = part_info
         self._action_properties: ActionProperties
+
+    def get_pull_commands(self) -> List[str]:
+        """Return the commands to retrieve dependencies during the pull step."""
+        return []
 
     @abc.abstractmethod
     def get_build_snaps(self) -> Set[str]:
@@ -80,20 +86,6 @@ class Plugin(abc.ABC):
         :param action_properties: The properties to store.
         """
         self._action_properties = deepcopy(action_properties)
-
-
-class StrictPlugin(Plugin):
-    """Base class for strict plugins.
-
-    Strict plugins will retrieve all dependencies from remote locations during
-    the pull step, allowing the build step to run offline.
-    """
-
-    offline = True
-
-    @abc.abstractmethod
-    def get_pull_prepare_commands(self) -> List[str]:
-        """Return a list commands to retrieve dependencies during the pull step."""
 
 
 class JavaPlugin(Plugin):

--- a/craft_parts/plugins/dump_plugin.py
+++ b/craft_parts/plugins/dump_plugin.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Set
 
 from overrides import override
 
-from .base import Plugin
+from .base import StrictPlugin
 from .properties import PluginProperties
 
 
@@ -48,7 +48,7 @@ class DumpPluginProperties(PluginProperties):
         return cls()
 
 
-class DumpPlugin(Plugin):
+class DumpPlugin(StrictPlugin):
     """Copy the content from the part source."""
 
     properties_class = DumpPluginProperties
@@ -57,6 +57,11 @@ class DumpPlugin(Plugin):
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
         return set()
+
+    @override
+    def get_pull_prepare_commands(self) -> List[str]:
+        """Return a list commands to retrieve dependencies during the pull step."""
+        return []
 
     @override
     def get_build_packages(self) -> Set[str]:

--- a/craft_parts/plugins/dump_plugin.py
+++ b/craft_parts/plugins/dump_plugin.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Set
 
 from overrides import override
 
-from .base import StrictPlugin
+from .base import Plugin
 from .properties import PluginProperties
 
 
@@ -48,10 +48,12 @@ class DumpPluginProperties(PluginProperties):
         return cls()
 
 
-class DumpPlugin(StrictPlugin):
+class DumpPlugin(Plugin):
     """Copy the content from the part source."""
 
     properties_class = DumpPluginProperties
+
+    supports_strict_mode = True
 
     @override
     def get_build_snaps(self) -> Set[str]:
@@ -59,7 +61,7 @@ class DumpPlugin(StrictPlugin):
         return set()
 
     @override
-    def get_pull_prepare_commands(self) -> List[str]:
+    def get_pull_commands(self) -> List[str]:
         """Return a list commands to retrieve dependencies during the pull step."""
         return []
 

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Set
 
 from overrides import override
 
-from .base import Plugin
+from .base import StrictPlugin
 from .properties import PluginProperties
 
 
@@ -43,7 +43,7 @@ class NilPluginProperties(PluginProperties):
         return cls()
 
 
-class NilPlugin(Plugin):
+class NilPlugin(StrictPlugin):
     """A plugin that defines no build commands.
 
     The nil plugin is useful in two contexts:
@@ -77,6 +77,11 @@ class NilPlugin(Plugin):
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
         return {}
+
+    @override
+    def get_pull_prepare_commands(self) -> List[str]:
+        """Return a list commands to retrieve dependencies during the pull step."""
+        return []
 
     @override
     def get_build_commands(self) -> List[str]:

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Set
 
 from overrides import override
 
-from .base import StrictPlugin
+from .base import Plugin
 from .properties import PluginProperties
 
 
@@ -43,7 +43,7 @@ class NilPluginProperties(PluginProperties):
         return cls()
 
 
-class NilPlugin(StrictPlugin):
+class NilPlugin(Plugin):
     """A plugin that defines no build commands.
 
     The nil plugin is useful in two contexts:
@@ -63,6 +63,8 @@ class NilPlugin(StrictPlugin):
 
     properties_class = NilPluginProperties
 
+    supports_strict_mode = True
+
     @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
@@ -79,7 +81,7 @@ class NilPlugin(StrictPlugin):
         return {}
 
     @override
-    def get_pull_prepare_commands(self) -> List[str]:
+    def get_pull_commands(self) -> List[str]:
         """Return a list commands to retrieve dependencies during the pull step."""
         return []
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ test_requires = [
     "codespell",
     "coverage",
     "isort",
-    "mypy",
+    "mypy==0.991",
     "pydocstyle",
     "pylint",
     "pylint-fixme-info",

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -648,3 +648,23 @@ def test_main_import(mocker, capfd):
     out, err = capfd.readouterr()
     assert out == f"craft-parts {craft_parts.__version__}\n"
     assert err == ""
+
+
+def test_main_strict(mocker):
+    """Test passing "--strict" on the command line."""
+    Path("parts.yaml").write_text(parts_yaml)
+    mocker.patch.object(sys, "argv", ["cmd", "--strict"])
+
+    spied_lcm = mocker.spy(craft_parts.LifecycleManager, name="__init__")
+    main.main()
+
+    kwargs = spied_lcm.call_args[1]
+    assert kwargs == {
+        "application_name": "craft_parts",
+        "base": "",
+        "base_layer_dir": None,
+        "base_layer_hash": b"",
+        "cache_dir": mocker.ANY,
+        "offline_build": True,
+        "work_dir": ".",
+    }

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -665,6 +665,6 @@ def test_main_strict(mocker):
         "base_layer_dir": None,
         "base_layer_hash": b"",
         "cache_dir": mocker.ANY,
-        "offline_build": True,
+        "strict_mode": True,
         "work_dir": ".",
     }

--- a/tests/unit/common_plugins.py
+++ b/tests/unit/common_plugins.py
@@ -1,0 +1,58 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Plugins used in unit tests."""
+from typing import Dict, List, Set
+
+from craft_parts.plugins import Plugin, PluginProperties, StrictPlugin
+
+
+class StrictTestPlugin(StrictPlugin):
+    """Test plugin that is strict (works in offline builds)."""
+
+    properties_class = PluginProperties
+
+    def get_pull_prepare_commands(self) -> List[str]:
+        return ["echo StrictTestPlugin.get_pull_prepare_commands()"]
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+class NonStrictTestPlugin(Plugin):
+    """Test plugin that is *not* strict (does *not* work in offline builds)."""
+
+    properties_class = PluginProperties
+
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> List[str]:
+        return []

--- a/tests/unit/common_plugins.py
+++ b/tests/unit/common_plugins.py
@@ -16,16 +16,18 @@
 """Plugins used in unit tests."""
 from typing import Dict, List, Set
 
-from craft_parts.plugins import Plugin, PluginProperties, StrictPlugin
+from craft_parts.plugins import Plugin, PluginProperties
 
 
-class StrictTestPlugin(StrictPlugin):
+class StrictTestPlugin(Plugin):
     """Test plugin that is strict (works in offline builds)."""
 
     properties_class = PluginProperties
 
-    def get_pull_prepare_commands(self) -> List[str]:
-        return ["echo StrictTestPlugin.get_pull_prepare_commands()"]
+    supports_strict_mode = True
+
+    def get_pull_commands(self) -> List[str]:
+        return [f"strict mode: {self._part_info.strict_mode}"]
 
     def get_build_snaps(self) -> Set[str]:
         return set()

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -56,7 +56,7 @@ class FooPlugin(plugins.Plugin):
 
 
 def _step_handler_for_step(
-    step: Step, cache_dir: Path, offline_build: bool = False, plugin_class=None
+    step: Step, cache_dir: Path, strict_mode: bool = False, plugin_class=None
 ) -> StepHandler:
     p1 = Part("p1", {"source": "."})
     dirs = ProjectDirs()
@@ -64,7 +64,7 @@ def _step_handler_for_step(
         project_dirs=dirs,
         application_name="test",
         cache_dir=cache_dir,
-        offline_build=offline_build,
+        strict_mode=strict_mode,
     )
     part_info = PartInfo(project_info=info, part=p1)
     step_info = StepInfo(part_info=part_info, step=step)
@@ -203,24 +203,24 @@ class TestStepHandlerBuiltins:
         )
 
     def test_run_builtin_pull_strict(self, new_dir, mocker):
-        """Test the Pull step in offline build calls get_pull_prepare_commands()"""
+        """Test the Pull step in strict mode calls get_pull_commands()"""
         Path("parts/p1/run").mkdir(parents=True)
         mock_run = mocker.patch("subprocess.run")
         sh = _step_handler_for_step(
             Step.PULL,
             cache_dir=new_dir,
-            offline_build=True,
+            strict_mode=True,
             plugin_class=StrictTestPlugin,
         )
 
         sh.run_builtin()
 
-        # Check that the contents of StrictTestPlugin.get_pull_prepare_commands()
-        # are in the script ran during the pull step.
+        # Check that when StrictTestPlugin.get_pull_commands() is called
+        # 'strict mode' is correctly enabled.
         assert mock_run.called
         run_args = mock_run.call_args[0][0]
         script_path = run_args[0]
-        assert "StrictTestPlugin.get_pull_prepare_commands()" in script_path.read_text()
+        assert "strict mode: True" in script_path.read_text()
 
 
 class TestStepHandlerRunScriptlet:

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -34,6 +34,7 @@ from craft_parts.infos import (
 )
 from craft_parts.parts import Part
 from craft_parts.steps import Step
+from tests.unit.common_plugins import StrictTestPlugin
 
 
 class FooPlugin(plugins.Plugin):
@@ -54,14 +55,24 @@ class FooPlugin(plugins.Plugin):
         return ["hello"]
 
 
-def _step_handler_for_step(step: Step, cache_dir: Path) -> StepHandler:
+def _step_handler_for_step(
+    step: Step, cache_dir: Path, offline_build: bool = False, plugin_class=None
+) -> StepHandler:
     p1 = Part("p1", {"source": "."})
     dirs = ProjectDirs()
-    info = ProjectInfo(project_dirs=dirs, application_name="test", cache_dir=cache_dir)
+    info = ProjectInfo(
+        project_dirs=dirs,
+        application_name="test",
+        cache_dir=cache_dir,
+        offline_build=offline_build,
+    )
     part_info = PartInfo(project_info=info, part=p1)
     step_info = StepInfo(part_info=part_info, step=step)
     props = plugins.PluginProperties()
-    plugin = FooPlugin(properties=props, part_info=part_info)
+    if plugin_class:
+        plugin = plugin_class(properties=props, part_info=part_info)
+    else:
+        plugin = FooPlugin(properties=props, part_info=part_info)
     source_handler = sources.get_source_handler(
         cache_dir=cache_dir,
         part=p1,
@@ -151,7 +162,7 @@ class TestStepHandlerBuiltins:
             )
 
         mock_run.assert_called_once_with(
-            [str(build_script_path)],
+            [build_script_path],
             cwd=Path(new_dir / "parts/p1/build"),
             check=True,
             stdout=None,
@@ -190,6 +201,26 @@ class TestStepHandlerBuiltins:
         assert str(raised.value) == (
             "Request to run the built-in handler for an invalid step."
         )
+
+    def test_run_builtin_pull_strict(self, new_dir, mocker):
+        """Test the Pull step in offline build calls get_pull_prepare_commands()"""
+        Path("parts/p1/run").mkdir(parents=True)
+        mock_run = mocker.patch("subprocess.run")
+        sh = _step_handler_for_step(
+            Step.PULL,
+            cache_dir=new_dir,
+            offline_build=True,
+            plugin_class=StrictTestPlugin,
+        )
+
+        sh.run_builtin()
+
+        # Check that the contents of StrictTestPlugin.get_pull_prepare_commands()
+        # are in the script ran during the pull step.
+        assert mock_run.called
+        run_args = mock_run.call_args[0][0]
+        script_path = run_args[0]
+        assert "StrictTestPlugin.get_pull_prepare_commands()" in script_path.read_text()
 
 
 class TestStepHandlerRunScriptlet:

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -220,22 +220,22 @@ class TestLifecycleManager:
         assert lf.get_pull_assets(part_name="foo") is None
 
     def test_strict_plugins(self, new_dir, mock_available_plugins):
-        """Test using a strict plugin in offline mode."""
+        """Test using a strict plugin in strict mode."""
         data = create_data("p1", "strict")
         lf = LifecycleManager(
-            data, application_name="test_manager", cache_dir=new_dir, offline_build=True
+            data, application_name="test_manager", cache_dir=new_dir, strict_mode=True
         )
         assert lf.get_pull_assets(part_name="p1") is None
 
     def test_strict_plugins_error(self, new_dir, mock_available_plugins):
-        """Test that using a non-strict plugin in offline mode is an error."""
+        """Test that using a non-strict plugin in strict mode is an error."""
         data = create_data("p1", "nonstrict")
         with pytest.raises(errors.PluginNotStrict) as exc:
             LifecycleManager(
                 data,
                 application_name="test_manager",
                 cache_dir=new_dir,
-                offline_build=True,
+                strict_mode=True,
             )
         assert "p1" in str(exc.value)
 

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -25,10 +25,22 @@ from unittest.mock import ANY, call
 import pytest
 import yaml
 
+import craft_parts
 from craft_parts import errors
 from craft_parts.lifecycle_manager import LifecycleManager
 from craft_parts.plugins import nil_plugin
 from craft_parts.state_manager import states
+from tests.unit.common_plugins import NonStrictTestPlugin, StrictTestPlugin
+
+
+@pytest.fixture
+def mock_available_plugins(monkeypatch):
+    available = {"strict": StrictTestPlugin, "nonstrict": NonStrictTestPlugin}
+    monkeypatch.setattr(craft_parts.plugins.plugins, "_PLUGINS", available)
+
+
+def create_data(part_name: str, plugin_name: str) -> Dict[str, Any]:
+    return {"parts": {part_name: {"plugin": plugin_name}}}
 
 
 class TestLifecycleManager:
@@ -206,6 +218,26 @@ class TestLifecycleManager:
             cache_dir=new_dir,
         )
         assert lf.get_pull_assets(part_name="foo") is None
+
+    def test_strict_plugins(self, new_dir, mock_available_plugins):
+        """Test using a strict plugin in offline mode."""
+        data = create_data("p1", "strict")
+        lf = LifecycleManager(
+            data, application_name="test_manager", cache_dir=new_dir, offline_build=True
+        )
+        assert lf.get_pull_assets(part_name="p1") is None
+
+    def test_strict_plugins_error(self, new_dir, mock_available_plugins):
+        """Test that using a non-strict plugin in offline mode is an error."""
+        data = create_data("p1", "nonstrict")
+        with pytest.raises(errors.PluginNotStrict) as exc:
+            LifecycleManager(
+                data,
+                application_name="test_manager",
+                cache_dir=new_dir,
+                offline_build=True,
+            )
+        assert "p1" in str(exc.value)
 
 
 class TestOverlaySupport:

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -123,6 +123,7 @@ class TestPartData:
         assert p.part_snaps_dir == new_dir / "parts/foo/stage_snaps"
         assert p.part_run_dir == new_dir / "parts/foo/run"
         assert p.part_layer_dir == new_dir / "parts/foo/layer"
+        assert p.part_cache_dir == new_dir / "parts/foo/cache"
         assert p.overlay_dir == new_dir / "overlay"
         assert p.stage_dir == new_dir / "stage"
         assert p.prime_dir == new_dir / "prime"


### PR DESCRIPTION
The first commit has @cmatsuoka 's original code with some minor linting by me. The second commit has the tests I added.
One thing we should maybe discuss is this `strict`/`offline` "duality". Really what a "strict" plugin currently means is that it does offline builds, but is that definition something that we envision changing in the future? Should we use "strict" throughout the codebase?

(CRAFT-1587)