### PR TITLE
features: introduce craft-parts features

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,12 +23,14 @@ from .actions import Action, ActionProperties, ActionType
 from .dirs import ProjectDirs
 from .errors import PartsError
 from .executor.environment import expand_environment
+from .features import Features
 from .infos import PartInfo, ProjectInfo, StepInfo
 from .lifecycle_manager import LifecycleManager
 from .parts import Part, validate_part
 from .steps import Step
 
 __all__ = [
+    "Features",
     "Action",
     "ActionProperties",
     "ActionType",

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -46,6 +46,17 @@ class PartsError(Exception):
             components.append(self.resolution)
 
         return "\n".join(components)
+
+
+class FeatureDisabled(PartsError):
+    """The requested feature is not enabled."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        brief = message
+        resolution = "This operation cannot be executed."
+
+        super().__init__(brief=brief, resolution=resolution)
 
 
 class PartDependencyCycle(PartsError):

--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -1,0 +1,39 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Global features to be configured by the application."""
+
+import contextlib
+import dataclasses
+import logging
+
+from craft_parts.utils import Singleton
+
+logger = logging.getLogger()
+
+
+@dataclasses.dataclass(frozen=True)
+class Features(metaclass=Singleton):
+    """Configurable craft-parts features."""
+
+    enable_overlay: bool = True
+
+    @classmethod
+    def reset(cls):
+        """Delete stored class instance."""
+        logger.warning("deleting current features configuration")
+        with contextlib.suppress(KeyError):
+            del cls._instances[cls]

--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -32,7 +32,7 @@ class Features(metaclass=Singleton):
     enable_overlay: bool = False
 
     @classmethod
-    def reset(cls):
+    def reset(cls) -> None:
         """Delete stored class instance."""
         logger.warning("deleting current features configuration")
         with contextlib.suppress(KeyError):

--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -29,7 +29,7 @@ logger = logging.getLogger()
 class Features(metaclass=Singleton):
     """Configurable craft-parts features."""
 
-    enable_overlay: bool = True
+    enable_overlay: bool = False
 
     @classmethod
     def reset(cls):

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,7 @@ from pydantic import ValidationError
 from craft_parts import errors, executor, packages, plugins, sequencer
 from craft_parts.actions import Action
 from craft_parts.dirs import ProjectDirs
+from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo
 from craft_parts.overlays import LayerHash
 from craft_parts.parts import Part, part_by_name
@@ -255,6 +256,9 @@ class LifecycleManager:
 
 def _ensure_overlay_supported() -> None:
     """Overlay is only supported in Linux and requires superuser privileges."""
+    if not Features().enable_overlay:
+        raise errors.FeatureDisabled("Overlays are not supported.")
+
     if sys.platform != "linux":
         raise errors.OverlayPlatformError()
 

--- a/craft_parts/main.py
+++ b/craft_parts/main.py
@@ -52,6 +52,8 @@ def main():
 
     logging.basicConfig(level=log_level)
 
+    craft_parts.Features(enable_overlay=True)
+
     try:
         _process_parts(options)
     except OSError as err:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, ValidationError, root_validator, validato
 
 from craft_parts import errors, plugins
 from craft_parts.dirs import ProjectDirs
+from craft_parts.features import Features
 from craft_parts.packages import platform
 from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
@@ -78,6 +79,12 @@ class PartSpec(BaseModel):
         assert (
             item[0] != "/"
         ), f"{item!r} must be a relative path (cannot start with '/')"
+        return item
+
+    @validator("overlay_packages", "overlay_files", "overlay_script")
+    def validate_overlay_feature(cls, item):
+        """Check if overlay attributes specified when feature is disabled."""
+        assert Features().enable_overlay, "overlays not supported"
         return item
 
     @root_validator(pre=True)

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -82,7 +82,7 @@ class PartSpec(BaseModel):
         return item
 
     @validator("overlay_packages", "overlay_files", "overlay_script")
-    def validate_overlay_feature(cls, item):
+    def validate_overlay_feature(cls, item: Any) -> Any:
         """Check if overlay attributes specified when feature is disabled."""
         assert Features().enable_overlay, "overlays not supported"
         return item

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,8 +19,9 @@
 import logging
 from typing import Dict, List, Optional, Sequence, Set
 
-from craft_parts import parts, steps
+from craft_parts import errors, parts, steps
 from craft_parts.actions import Action, ActionProperties, ActionType
+from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo, ProjectVar
 from craft_parts.overlays import LayerHash, LayerStateManager
 from craft_parts.parts import Part, part_list_by_name, sort_parts
@@ -79,6 +80,9 @@ class Sequencer:
 
         :returns: The list of actions that should be executed.
         """
+        if target_step == Step.OVERLAY and not Features().enable_overlay:
+            raise errors.FeatureDisabled("Overlay step is not supported.")
+
         self._actions = []
         self._add_all_actions(target_step, part_names)
         return self._actions
@@ -120,6 +124,13 @@ class Sequencer:
         reason: Optional[str] = None,
     ) -> None:
         """Verify if this step should be executed."""
+        # if overlays disabled, don't generate overlay actions
+        if not Features().enable_overlay and current_step == Step.OVERLAY:
+            logger.debug(
+                "Overlay feature disabled: skipping generation of overlay action"
+            )
+            return
+
         # check if step already ran, if not then run it
         if not self._sm.has_step_run(part, current_step):
             self._run_step(part, current_step, reason=reason)

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, cast
 
 from craft_parts import parts, sources, steps
+from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo, ProjectVar
 from craft_parts.parts import Part
 from craft_parts.sources import SourceHandler
@@ -254,7 +255,13 @@ class StateManager:
 
         previous_steps = step.previous_steps()
         if previous_steps:
-            return self.should_step_run(part, previous_steps[-1])
+            prev_step = previous_steps[-1]
+
+            # Skip testing overlay state if overlays are disabled
+            if not Features().enable_overlay and prev_step == Step.OVERLAY:
+                prev_step = previous_steps[-2]
+
+            return self.should_step_run(part, prev_step)
 
         return False
 

--- a/craft_parts/utils/__init__.py
+++ b/craft_parts/utils/__init__.py
@@ -16,7 +16,7 @@
 
 """Utilities and helpers."""
 
-from typing import Dict
+from typing import Any, Dict
 
 
 def package_name() -> str:
@@ -29,7 +29,7 @@ class Singleton(type):
 
     _instances: Dict = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         """Return an existing instance, or create a new instance."""
         if cls not in cls._instances:
             instance = super().__call__(*args, **kwargs)

--- a/craft_parts/utils/__init__.py
+++ b/craft_parts/utils/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,27 @@
 
 """Utilities and helpers."""
 
+from typing import Dict
+
 
 def package_name() -> str:
     """Return the topmost package name."""
     return __name__.split(".", maxsplit=1)[0]
+
+
+class Singleton(type):
+    """Singleton metaclass."""
+
+    _instances: Dict = {}
+
+    def __call__(cls, *args, **kwargs):
+        """Return an existing instance, or create a new instance."""
+        if cls not in cls._instances:
+            instance = super().__call__(*args, **kwargs)
+            cls._instances[cls] = instance
+            return instance
+
+        if args or kwargs:
+            raise RuntimeError("parameters can only be set once")
+
+        return cls._instances[cls]

--- a/craft_parts/utils/__init__.py
+++ b/craft_parts/utils/__init__.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/executor/test_callbacks.py
+++ b/tests/integration/executor/test_callbacks.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -33,6 +33,9 @@ from craft_parts.state_manager import StepState
 
 
 def setup_function():
+    craft_parts.Features.reset()
+    craft_parts.Features(enable_overlay=True)
+
     callbacks.unregister_all()
 
 

--- a/tests/integration/executor/test_environment.py
+++ b/tests/integration/executor/test_environment.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -77,6 +77,9 @@ _parts_yaml = textwrap.dedent(
 
 @pytest.mark.parametrize("step", list(Step))
 def test_step_callback(new_dir, mocker, capfd, step):
+    craft_parts.Features.reset()
+    craft_parts.Features(enable_overlay=True)
+
     mocker.patch("platform.machine", return_value="aarch64")
 
     callbacks.register_pre_step(_step_callback, step_list=[step])
@@ -120,6 +123,9 @@ def test_step_callback(new_dir, mocker, capfd, step):
 
 
 def test_prologue_callback(new_dir, capfd, mocker):
+    craft_parts.Features.reset()
+    craft_parts.Features(enable_overlay=True)
+
     mocker.patch("platform.machine", return_value="aarch64")
 
     callbacks.register_prologue(_prologue_callback)

--- a/tests/integration/features/test_lifecycle_no_overlay.py
+++ b/tests/integration/features/test_lifecycle_no_overlay.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -138,13 +138,11 @@ def test_basic_lifecycle_actions(new_dir, mocker):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    print("=== >>>>>>>>>>>>>>>>>>>>>>>>>>")
     # A request to build all parts skips everything
     lf = craft_parts.LifecycleManager(
         parts, application_name="test_demo", cache_dir=new_dir
     )
     actions = lf.plan(Step.BUILD)
-    print("=== <<<<<<<<<<<<<<<<<<<<<<<<<<")
     assert actions == [
         # fmt: off
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),

--- a/tests/integration/features/test_lifecycle_no_overlay.py
+++ b/tests/integration/features/test_lifecycle_no_overlay.py
@@ -1,0 +1,367 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+import craft_parts
+from craft_parts import Action, ActionProperties, ActionType, Features, Step
+
+basic_parts_yaml = textwrap.dedent(
+    """\
+    parts:
+      bar:
+        after: [foo]
+        plugin: nil
+
+      foo:
+        plugin: nil
+        source: a.tar.gz
+
+      foobar:
+        plugin: nil"""
+)
+
+
+@pytest.fixture(autouse=True)
+def _setup_module():
+    Features.reset()
+    Features(enable_overlay=False)
+    yield
+    Features.reset()
+
+
+def test_basic_lifecycle_actions(new_dir, mocker):
+    parts = yaml.safe_load(basic_parts_yaml)
+
+    Path("a.tar.gz").touch()
+
+    # no need to untar the file
+    mocker.patch("craft_parts.sources.tar_source.TarSource.provision")
+
+    # See https://gist.github.com/sergiusens/dcae19c301eb59e091f92ab29d7d03fc
+
+    # first run
+    # command: pull
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.PULL)
+    assert actions == [
+        Action("foo", Step.PULL),
+        Action("bar", Step.PULL),
+        Action("foobar", Step.PULL),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # foobar part depends on nothing
+    # command: prime foobar
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.PRIME, ["foobar"])
+    assert actions == [
+        # fmt: off
+        Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.BUILD),
+        Action("foobar", Step.STAGE),
+        Action("foobar", Step.PRIME),
+        # fmt: on
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # Then running build for bar that depends on foo
+    # command: build bar
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD, ["bar"])
+    assert actions == [
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, reason="required to build 'bar'"),
+        Action("foo", Step.STAGE, reason="required to build 'bar'"),
+        Action("bar", Step.BUILD),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # Building bar again rebuilds it (explicit request)
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD, ["bar"])
+    assert actions == [
+        # fmt: off
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        # fmt: on
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # Modifying foo’s source marks bar as dirty
+    new_yaml = basic_parts_yaml.replace("source: a.tar.gz", "source: .")
+    parts = yaml.safe_load(new_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD, ["bar"])
+    assert actions == [
+        # fmt: off
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.PULL, action_type=ActionType.RERUN, reason="'source' property changed"),
+        Action("foo", Step.BUILD, action_type=ActionType.RUN, reason="required to build 'bar'"),
+        Action("foo", Step.STAGE, action_type=ActionType.RUN, reason="required to build 'bar'"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        # fmt: on
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    print("=== >>>>>>>>>>>>>>>>>>>>>>>>>>")
+    # A request to build all parts skips everything
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD)
+    print("=== <<<<<<<<<<<<<<<<<<<<<<<<<<")
+    assert actions == [
+        # fmt: off
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        # fmt: on
+    ]
+
+    # Touching a source file triggers an update
+    Path("a.tar.gz").touch()
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.BUILD)
+    assert actions == [
+        # fmt: off
+        Action("foo", Step.PULL, action_type=ActionType.UPDATE, reason="source changed",
+               properties=ActionProperties(changed_files=['a.tar.gz'], changed_dirs=[])),
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, action_type=ActionType.UPDATE, reason="'PULL' step changed",
+               properties=ActionProperties(changed_files=['a.tar.gz'], changed_dirs=[])),
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="required to build 'bar'"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
+        Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        # fmt: on
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # A request to build all parts again skips everything
+    actions = lf.plan(Step.BUILD)
+    assert actions == [
+        # fmt: off
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        # fmt: on
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestCleaning:
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, new_dir):
+        # pylint: disable=attribute-defined-outside-init
+        parts_yaml = textwrap.dedent(
+            """
+            parts:
+              foo:
+                plugin: dump
+                source: foo
+              bar:
+                plugin: dump
+                source: bar
+            """
+        )
+        Path("foo").mkdir()
+        Path("foo/foo.txt").touch()
+        Path("bar").mkdir()
+        Path("bar/bar.txt").touch()
+
+        parts = yaml.safe_load(parts_yaml)
+
+        self._lifecycle = craft_parts.LifecycleManager(
+            parts, application_name="test_clean", cache_dir=new_dir
+        )
+
+        # pylint: enable=attribute-defined-outside-init
+
+    @pytest.mark.parametrize(
+        "step,test_dir,state_file",
+        [
+            (Step.PULL, "parts/foo/src", "pull"),
+            (Step.BUILD, "parts/foo/install", "build"),
+            (Step.STAGE, "stage", "stage"),
+            (Step.PRIME, "prime", "prime"),
+        ],
+    )
+    def test_clean_step(self, step, test_dir, state_file):
+        actions = self._lifecycle.plan(step)
+
+        with self._lifecycle.action_executor() as ctx:
+            ctx.execute(actions)
+
+        assert Path(test_dir, "foo.txt").is_file()
+        assert Path("parts/foo/state", state_file).is_file()
+
+        self._lifecycle.clean(step, part_names=["foo"])
+
+        assert Path(test_dir, "foo.txt").is_file() is False
+        assert Path("parts/foo/state", state_file).is_file() is False
+
+    def test_clean_default(self):
+        actions = self._lifecycle.plan(Step.PRIME)
+
+        with self._lifecycle.action_executor() as ctx:
+            ctx.execute(actions)
+
+        assert Path("parts/foo/src/foo.txt").is_file()
+        assert Path("parts/foo/install/foo.txt").is_file()
+        assert Path("stage/foo.txt").is_file()
+        assert Path("prime/foo.txt").is_file()
+
+        state_dir = Path("parts/foo/state")
+
+        assert sorted(state_dir.rglob("*")) == [
+            state_dir / "build",
+            state_dir / "prime",
+            state_dir / "pull",
+            state_dir / "stage",
+        ]
+
+        self._lifecycle.clean()
+
+        assert Path("parts").exists() is False
+        assert Path("stage").exists() is False
+        assert Path("prime").exists() is False
+
+        assert list(state_dir.rglob("*")) == []
+
+    def test_clean_part(self):
+        actions = self._lifecycle.plan(Step.PRIME)
+
+        with self._lifecycle.action_executor() as ctx:
+            ctx.execute(actions)
+
+        foo_state_dir = Path("parts/foo/state")
+        bar_state_dir = Path("parts/bar/state")
+
+        self._lifecycle.clean(part_names=["foo"])
+
+        assert Path("parts/foo/src/foo.txt").is_file() is False
+        assert Path("parts/foo/install/foo.txt").is_file() is False
+        assert Path("stage/foo.txt").is_file() is False
+        assert Path("prime/foo.txt").is_file() is False
+        assert list(foo_state_dir.rglob("*")) == []
+
+        assert Path("parts/bar/src/bar.txt").is_file()
+        assert Path("parts/bar/install/bar.txt").is_file()
+        assert Path("stage/bar.txt").is_file()
+        assert Path("prime/bar.txt").is_file()
+        assert sorted(bar_state_dir.rglob("*")) == [
+            bar_state_dir / "build",
+            bar_state_dir / "prime",
+            bar_state_dir / "pull",
+            bar_state_dir / "stage",
+        ]
+
+    @pytest.mark.parametrize("step", list(Step))
+    def test_clean_all_parts(self, step):
+        # always run all steps
+        actions = self._lifecycle.plan(Step.PRIME)
+
+        with self._lifecycle.action_executor() as ctx:
+            ctx.execute(actions)
+
+        foo_state_dir = Path("parts/foo/state")
+        bar_state_dir = Path("parts/bar/state")
+
+        step_is_overlay_or_later = step >= Step.OVERLAY
+        step_is_stage_or_later = step >= Step.STAGE
+        step_is_prime = step == Step.PRIME
+
+        self._lifecycle.clean(step)
+
+        assert Path("parts").exists() == step_is_overlay_or_later
+        assert Path("parts/foo/src/foo.txt").exists() == step_is_overlay_or_later
+        assert Path("parts/bar/src/bar.txt").exists() == step_is_overlay_or_later
+        assert Path("parts/foo/install/foo.txt").exists() == step_is_stage_or_later
+        assert Path("parts/bar/install/bar.txt").exists() == step_is_stage_or_later
+        assert Path("stage/foo.txt").exists() == step_is_prime
+        assert Path("stage/bar.txt").exists() == step_is_prime
+        assert Path("prime").is_file() is False
+
+        all_states = []
+        if step_is_overlay_or_later:
+            all_states.append(foo_state_dir / "pull")
+            all_states.append(bar_state_dir / "pull")
+        if step_is_stage_or_later:
+            all_states.append(foo_state_dir / "build")
+            all_states.append(bar_state_dir / "build")
+        if step_is_prime:
+            all_states.append(foo_state_dir / "stage")
+            all_states.append(bar_state_dir / "stage")
+
+        assert sorted(Path("parts").rglob("*/state/*")) == sorted(all_states)
+
+
+class TestUpdating:
+    def test_refresh_system_packages_list(self, new_dir, mocker):
+        mock_refresh_packages_list = mocker.patch(
+            "craft_parts.packages.Repository.refresh_packages_list"
+        )
+
+        parts_yaml = textwrap.dedent(
+            """
+            parts:
+              foo:
+                plugin: nil
+            """
+        )
+        parts = yaml.safe_load(parts_yaml)
+
+        lf = craft_parts.LifecycleManager(
+            parts, application_name="test_update", cache_dir=new_dir, arch="aarch64"
+        )
+        lf.refresh_packages_list()
+
+        mock_refresh_packages_list.assert_called_once_with()

--- a/tests/integration/lifecycle/test_craftctl.py
+++ b/tests/integration/lifecycle/test_craftctl.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,9 @@ from tests import TESTS_DIR
 
 @pytest.fixture(autouse=True)
 def setup_fixture(new_dir, mocker):
+    craft_parts.Features.reset()
+    craft_parts.Features(enable_overlay=True)
+
     craftctl = Path("craftctl")
     craftctl.write_text(f"#!{sys.executable}\nfrom craft_parts import ctl\nctl.main()")
     craftctl.chmod(0o755)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -75,7 +75,13 @@ def setup_new_dir(new_dir):  # pylint: disable=unused-argument
     pass
 
 
+def setup_function():
+    craft_parts.Features.reset()
+    craft_parts.Features(enable_overlay=True)
+
+
 def test_main_no_args(mocker, capfd):
+
     Path("parts.yaml").write_text(parts_yaml)
 
     mocker.patch.object(sys, "argv", ["cmd"])

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -81,7 +81,6 @@ def setup_function():
 
 
 def test_main_no_args(mocker, capfd):
-
     Path("parts.yaml").write_text(parts_yaml)
 
     mocker.patch.object(sys, "argv", ["cmd"])

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -77,7 +77,6 @@ def setup_new_dir(new_dir):  # pylint: disable=unused-argument
 
 def setup_function():
     craft_parts.Features.reset()
-    craft_parts.Features(enable_overlay=True)
 
 
 def test_main_no_args(mocker, capfd):
@@ -291,6 +290,7 @@ def test_main_step_dry_run_skip(mocker, capfd):
 
     # run it again on the existing state
     mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "prime"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -312,6 +312,7 @@ def test_main_step_dry_run_show_skip(mocker, capfd):
 
     # run it again on the existing state
     mocker.patch.object(sys, "argv", ["cmd", "--dry-run", "--show-skip", "prime"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -469,6 +470,7 @@ def test_main_clean(mocker, capfd):
 
     # clean the existing work dirs
     mocker.patch.object(sys, "argv", ["cmd", "clean"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -482,6 +484,7 @@ def test_main_clean(mocker, capfd):
 
     # clean again should not fail
     mocker.patch.object(sys, "argv", ["cmd", "clean"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -507,6 +510,7 @@ def test_main_clean_workdir(mocker, capfd):
 
     # clean the existing work dirs
     mocker.patch.object(sys, "argv", ["cmd", "--work-dir", "work_dir", "clean"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -552,6 +556,7 @@ def test_main_clean_part(mocker, capfd):
 
     # clean the existing work dirs
     mocker.patch.object(sys, "argv", ["cmd", "clean", "foo"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -572,6 +577,7 @@ def test_main_clean_part(mocker, capfd):
 
     # clean the again should not fail
     mocker.patch.object(sys, "argv", ["cmd", "clean", "foo"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None
@@ -594,6 +600,7 @@ def test_main_clean_multiple_part(mocker, capfd):
 
     # clean the existing work dirs
     mocker.patch.object(sys, "argv", ["cmd", "clean", "foo", "bar"])
+    craft_parts.Features.reset()
     with pytest.raises(SystemExit) as raised:
         main.main()
     assert raised.value.code is None

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2022 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -51,6 +51,14 @@ def test_part_dependency_cycle():
     assert err.brief == "A circular dependency chain was detected."
     assert err.details is None
     assert err.resolution == "Review the parts definition to remove dependency cycles."
+
+
+def test_feature_disabled():
+    err = errors.FeatureDisabled("bummer")
+    assert err.message == "bummer"
+    assert err.brief == "bummer"
+    assert err.details is None
+    assert err.resolution == "This operation cannot be executed."
 
 
 def test_invalid_application_name():

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -1,0 +1,49 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from craft_parts import Features
+
+
+@pytest.fixture(autouse=True)
+def setup_features():
+    Features.reset()
+    yield
+    Features.reset()
+
+
+def test_features():
+    features = Features()
+    assert features.enable_overlay is True
+
+
+def test_features_set():
+    features = Features(enable_overlay=False)
+    assert features.enable_overlay is False
+
+    # A different instance should have the previously set value
+    f2 = Features()
+    assert f2.enable_overlay is False
+
+
+def test_features_set_twice():
+    Features(enable_overlay=False)
+
+    with pytest.raises(RuntimeError) as raised:
+        Features(enable_overlay=False)
+
+    assert str(raised.value) == "parameters can only be set once"

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -28,7 +28,7 @@ def setup_features():
 
 def test_features():
     features = Features()
-    assert features.enable_overlay is True
+    assert features.enable_overlay is False
 
 
 def test_features_set():

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -211,6 +211,10 @@ class TestLifecycleManager:
 class TestOverlaySupport:
     """Overlays only supported in linux and must run as root."""
 
+    def setup_method(self):
+        Features.reset()
+        Features(enable_overlay=True)
+
     @pytest.fixture
     def parts_data(self) -> Dict[str, Any]:
         return {"parts": {"foo": {"plugin": "nil", "overlay-script": "ls"}}}

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -33,6 +33,9 @@ class TestPartSpecs:
     """Test part specification creation."""
 
     def test_marshal_unmarshal(self):
+        Features.reset()
+        Features(enable_overlay=True)
+
         data = {
             "plugin": "nil",
             "source": "http://example.com/hello-2.3.tar.gz",
@@ -126,6 +129,10 @@ class TestPartSpecs:
 
 class TestPartData:
     """Test basic part creation and representation."""
+
+    def setup_method(self):
+        Features.reset()
+        Features(enable_overlay=True)
 
     def test_part_dirs(self, new_dir):
         p = Part("foo", {"plugin": "nil"})


### PR DESCRIPTION
Craft-parts can now specify features that can be enabled or disabled
to change its behavior in certain scenarios. This change also includes
a minimally intrusive implementation of the overlay feature, which
inhibits the generation of overlay actions when this feature is
disabled.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
