### PR TITLE
plugins: check if plugin properties are dirty

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -105,7 +105,11 @@ class PartHandler:
             part_info=part_info,
         )
 
-        self._part_properties = part.spec.marshal()
+        self._part_properties = {
+            **part.spec.marshal(),
+            **part.plugin_properties.marshal(),
+        }
+
         self._source_handler = sources.get_source_handler(
             cache_dir=part_info.cache_dir,
             part=part,

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -20,11 +20,9 @@ import abc
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type
 
-from pydantic import BaseModel
-
 from craft_parts.actions import ActionProperties
 
-from .properties import PluginProperties
+from .properties import PluginProperties, PluginPropertiesModel
 from .validator import PluginEnvironmentValidator
 
 if TYPE_CHECKING:
@@ -117,21 +115,13 @@ class JavaPlugin(Plugin):
         return link_java + link_jars
 
 
-class PluginModel(BaseModel):
+class PluginModel(PluginPropertiesModel):
     """Model for plugins using pydantic validation.
 
     Plugins with configuration properties can use pydantic validation to unmarshal
     data from part specs. In this case, extract plugin-specific properties using
     the :func:`extract_plugin_properties` helper.
     """
-
-    class Config:
-        """Pydantic model configuration."""
-
-        validate_assignment = True
-        extra = "forbid"
-        allow_mutation = False
-        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
 
 
 def extract_plugin_properties(

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -16,19 +16,35 @@
 
 """Definitions and helpers for plugin options."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
 
 
-class PluginProperties:
+class PluginPropertiesModel(BaseModel):
+    """Model for plugins properties using pydantic validation."""
+
+    class Config:
+        """Pydantic model configuration."""
+
+        validate_assignment = True
+        extra = "forbid"
+        allow_mutation = False
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+
+
+class PluginProperties(PluginPropertiesModel):
     """Options specific to a plugin.
 
     PluginProperties should be subclassed into plugin-specific property
     classes and populated from a dictionary containing part properties.
+
+    By default all plugin properties will be compared to check if the
+    build step is dirty. This can be overridden in each plugin if needed.
     """
 
-    # pylint: disable=unused-argument
-
     @classmethod
+    # pylint: disable-next=unused-argument
     def unmarshal(cls, data: Dict[str, Any]) -> "PluginProperties":
         """Populate class attributes from the part specification.
 
@@ -37,3 +53,18 @@ class PluginProperties:
         :return: The populated plugin properties data object.
         """
         return cls()
+
+    def marshal(self) -> Dict[str, Any]:
+        """Obtain a dictionary containing the plugin properties."""
+        return self.dict(by_alias=True)
+
+    @classmethod
+    def get_pull_properties(cls) -> List[str]:
+        """Obtain the list of properties affecting the pull stage."""
+        return []
+
+    @classmethod
+    def get_build_properties(cls) -> List[str]:
+        """Obtain the list of properties affecting the build stage."""
+        properties = cls.schema(by_alias=True).get("properties")
+        return list(properties.keys()) if properties else []

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -16,8 +16,9 @@
 
 """State definitions for the build step."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
+from overrides import override
 from pydantic import validator
 
 from .step_state import StepState, validate_hex_string
@@ -34,6 +35,7 @@ class BuildState(StepState):
     )
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "BuildState":
         """Create and populate a new ``BuildState`` object from dictionary data.
 
@@ -51,10 +53,17 @@ class BuildState(StepState):
 
         return cls(**data)
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    @override
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step.
 
         :param part_properties: A dictionary containing all part properties.
+        :param extra_properties: Additional relevant properties to return.
 
         :return: A dictionary containing properties of interest.
         """
@@ -65,14 +74,12 @@ class BuildState(StepState):
             "disable-parallel",
             "organize",
             "override-build",
+            *(extra_properties or []),
         ]
 
-        properties: Dict[str, Any] = {}
-        for name in relevant_properties:
-            properties[name] = part_properties.get(name)
+        return {name: part_properties.get(name) for name in relevant_properties}
 
-        return properties
-
+    @override
     def project_options_of_interest(
         self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-buildnil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -16,7 +16,9 @@
 
 """State definitions for the overlay step."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
+
+from overrides import override
 
 from .step_state import StepState
 
@@ -25,6 +27,7 @@ class OverlayState(StepState):
     """Context information for the overlay step."""
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "OverlayState":
         """Create and populate a new ``OverlayState`` object from dictionary data.
 
@@ -42,19 +45,29 @@ class OverlayState(StepState):
 
         return cls(**data)
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    @override
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step.
 
         :param part_properties: A dictionary containing all part properties.
+        :param extra_properties: Additional relevant properties to return.
 
         :return: A dictionary containing properties of interest.
         """
-        return {
-            "filesets": part_properties.get("filesets", {}) or {},
-            "overlay-script": part_properties.get("overlay-script"),
-            "overlay": part_properties.get("overlay", ["*"]) or ["*"],
-        }
+        relevant_properties = [
+            "overlay-script",
+            "overlay",
+            *(extra_properties or []),
+        ]
 
+        return {name: part_properties.get(name) for name in relevant_properties}
+
+    @override
     def project_options_of_interest(
         self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -16,7 +16,9 @@
 
 """State definitions for the prime state."""
 
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Optional, Set
+
+from overrides import override
 
 from .step_state import StepState
 
@@ -28,6 +30,7 @@ class PrimeState(StepState):
     primed_stage_packages: Set[str] = set()
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "PrimeState":
         """Create and populate a new ``PrimeState`` object from dictionary data.
 
@@ -45,18 +48,29 @@ class PrimeState(StepState):
 
         return cls(**data)
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    @override
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step.
 
         :param part_properties: A dictionary containing all part properties.
+        :param extra_properties: Additional relevant properties to be returned.
 
         :return: A dictionary containing properties of interest.
         """
-        return {
-            "override-prime": part_properties.get("override-prime"),
-            "prime": part_properties.get("prime", ["*"]) or ["*"],
-        }
+        relevant_properties = [
+            "override-prime",
+            "prime",
+            *(extra_properties or []),
+        ]
 
+        return {name: part_properties.get(name) for name in relevant_properties}
+
+    @override
     def project_options_of_interest(
         self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Optional
 
+from overrides import override
+
 from .step_state import StepState
 
 
@@ -29,6 +31,7 @@ class PullState(StepState):
     outdated_dirs: Optional[List[str]] = None
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "PullState":
         """Create and populate a new ``PullState`` object from dictionary data.
 
@@ -46,10 +49,17 @@ class PullState(StepState):
 
         return cls(**data)
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    @override
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step.
 
         :param part_properties: A dictionary containing all part properties.
+        :param extra_properties: Additional relevant properties to return.
 
         :return: A dictionary containing properties of interest.
         """
@@ -66,14 +76,12 @@ class PullState(StepState):
             "override-pull",
             "stage-packages",
             "overlay-packages",
+            *(extra_properties or []),
         ]
 
-        properties: Dict[str, Any] = {}
-        for name in relevant_properties:
-            properties[name] = part_properties.get(name)
+        return {name: part_properties.get(name) for name in relevant_properties}
 
-        return properties
-
+    @override
     def project_options_of_interest(
         self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -16,8 +16,9 @@
 
 """State definitions for the stage step."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
+from overrides import override
 from pydantic import validator
 
 from .step_state import StepState, validate_hex_string
@@ -33,6 +34,7 @@ class StageState(StepState):
     )
 
     @classmethod
+    @override
     def unmarshal(cls, data: Dict[str, Any]) -> "StageState":
         """Create and populate a new ``StageState`` object from dictionary data.
 
@@ -50,19 +52,28 @@ class StageState(StepState):
 
         return cls(**data)
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    @override
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step.
 
         :param part_properties: A dictionary containing all part properties.
+        :param extra_properties: Additional relevant properties to be returned.
 
         :return: A dictionary containing properties of interest.
         """
-        return {
-            "filesets": part_properties.get("filesets", {}) or {},
-            "override-stage": part_properties.get("override-stage"),
-            "stage": part_properties.get("stage", ["*"]) or ["*"],
-        }
+        relevant_properties = [
+            "override-stage",
+            "stage",
+            *(extra_properties or []),
+        ]
+        return {name: part_properties.get(name) for name in relevant_properties}
 
+    @override
     def project_options_of_interest(
         self, project_options: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2022 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -18,7 +18,7 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any, Dict, List, Optional, Set
 
 from pydantic_yaml import YamlModel
 
@@ -84,7 +84,12 @@ class StepState(MigrationState, ABC):
         allow_population_by_field_name = True
 
     @abstractmethod
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """Return relevant properties concerning this step."""
 
     @abstractmethod
@@ -93,7 +98,9 @@ class StepState(MigrationState, ABC):
     ) -> Dict[str, Any]:
         """Return relevant project options concerning this step."""
 
-    def diff_properties_of_interest(self, other_properties: Dict[str, Any]) -> Set[str]:
+    def diff_properties_of_interest(
+        self, other_properties: Dict[str, Any], also_compare: Optional[List[str]] = None
+    ) -> Set[str]:
         """Return properties of interest that differ.
 
         Take a dictionary of properties and compare to our own, returning
@@ -105,8 +112,12 @@ class StepState(MigrationState, ABC):
             project options stored in this state.
         """
         return _get_differing_keys(
-            self.properties_of_interest(self.part_properties),
-            self.properties_of_interest(other_properties),
+            self.properties_of_interest(
+                self.part_properties, extra_properties=also_compare
+            ),
+            self.properties_of_interest(
+                other_properties, extra_properties=also_compare
+            ),
         )
 
     def diff_project_options_of_interest(

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2016-2021 Canonical Ltd.
+# Copyright 2016-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/integration/lifecycle/test_plugin_property_state.py
+++ b/tests/integration/lifecycle/test_plugin_property_state.py
@@ -1,0 +1,263 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import pytest
+import yaml
+from overrides import override
+
+import craft_parts
+from craft_parts import Action, ActionType, Part, Step, plugins
+from craft_parts.state_manager import states
+
+
+def setup_function():
+    plugins.unregister_all()
+
+
+def teardown_module():
+    plugins.unregister_all()
+
+
+class ExamplePluginProperties(plugins.PluginProperties):
+    """The application-defined plugin properties."""
+
+    example_property: Optional[int]
+
+    @classmethod
+    @override
+    def unmarshal(cls, data: Dict[str, Any]) -> "ExamplePluginProperties":
+        plugin_data = plugins.extract_plugin_properties(data, plugin_name="example")
+        return cls(**plugin_data)
+
+
+class ExamplePlugin(plugins.Plugin):
+    """Our application plugin."""
+
+    properties_class = ExamplePluginProperties
+
+    @override
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    @override
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    @override
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    @override
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+@pytest.mark.parametrize("step", list(Step))
+def test_plugin_property_state(new_dir, step):
+    plugins.register({"example": ExamplePlugin})
+
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """\
+            parts:
+              foo:
+                plugin: example
+                example-property: 42
+            """
+        )
+    )
+
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+
+    # build parts
+    actions = lcm.plan(Step.PRIME)
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    # check if state file contains the plugin property
+    part = Part("foo", {"plugin": "example"})
+    state = states.load_step_state(part, step)
+    assert state is not None
+    assert state.part_properties["example-property"] == 42
+
+
+def test_plugin_property_build_dirty(new_dir):
+    plugins.register({"example": ExamplePlugin})
+
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """\
+            parts:
+              foo:
+                plugin: example
+                example-property: 42
+            """
+        )
+    )
+
+    # build parts
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    # run again, verify that all actions are skipped
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    assert actions == [
+        Action("foo", Step.PULL, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.OVERLAY, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.STAGE, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.PRIME, ActionType.SKIP, reason="already ran"),
+    ]
+
+    # change the plugin property and run again, it reruns from build
+    data["parts"]["foo"]["example-property"] = 43
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    assert actions == [
+        Action("foo", Step.PULL, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.OVERLAY, ActionType.SKIP, reason="already ran"),
+        Action(
+            "foo",
+            Step.BUILD,
+            ActionType.RERUN,
+            reason="'example-property' property changed",
+        ),
+        Action("foo", Step.STAGE),
+        Action("foo", Step.PRIME),
+    ]
+
+
+class Example2PluginProperties(plugins.PluginProperties):
+    """The application-defined plugin properties."""
+
+    example_property: Optional[int]
+
+    @classmethod
+    @override
+    def unmarshal(cls, data: Dict[str, Any]) -> "Example2PluginProperties":
+        plugin_data = plugins.extract_plugin_properties(data, plugin_name="example")
+        return cls(**plugin_data)
+
+    @classmethod
+    @override
+    def get_pull_properties(cls) -> List[str]:
+        return ["example-property"]
+
+
+class Example2Plugin(plugins.Plugin):
+    """Another application plugin."""
+
+    properties_class = Example2PluginProperties
+
+    @override
+    def get_build_snaps(self) -> Set[str]:
+        return set()
+
+    @override
+    def get_build_packages(self) -> Set[str]:
+        return set()
+
+    @override
+    def get_build_environment(self) -> Dict[str, str]:
+        return {}
+
+    @override
+    def get_build_commands(self) -> List[str]:
+        return []
+
+
+def test_plugin_property_pull_dirty(new_dir):
+    plugins.register({"example": Example2Plugin})
+
+    data = yaml.safe_load(
+        textwrap.dedent(
+            """\
+            parts:
+              foo:
+                plugin: example
+                example-property: 42
+            """
+        )
+    )
+
+    # build parts
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    with lcm.action_executor() as aex:
+        aex.execute(actions)
+
+    # run again, verify that all actions are skipped
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    assert actions == [
+        Action("foo", Step.PULL, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.OVERLAY, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.BUILD, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.STAGE, ActionType.SKIP, reason="already ran"),
+        Action("foo", Step.PRIME, ActionType.SKIP, reason="already ran"),
+    ]
+
+    # change the plugin property and run again, it reruns from pull
+    data["parts"]["foo"]["example-property"] = 43
+    lcm = craft_parts.LifecycleManager(
+        application_name="example",
+        all_parts=data,
+        cache_dir=Path(),
+    )
+    actions = lcm.plan(Step.PRIME)
+    assert actions == [
+        Action(
+            "foo",
+            Step.PULL,
+            ActionType.RERUN,
+            reason="'example-property' property changed",
+        ),
+        Action("foo", Step.OVERLAY),
+        Action("foo", Step.BUILD),
+        Action("foo", Step.STAGE),
+        Action("foo", Step.PRIME),
+    ]

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from dataclasses import dataclass
 from typing import Any, Dict, List, Set, cast
 
 import pytest
@@ -25,7 +24,6 @@ from craft_parts.plugins import Plugin, PluginProperties
 from craft_parts.plugins.base import extract_plugin_properties
 
 
-@dataclass
 class FooPluginProperties(PluginProperties):
     """Test plugin properties."""
 

--- a/tests/unit/plugins/test_properties.py
+++ b/tests/unit/plugins/test_properties.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/plugins/test_properties.py
+++ b/tests/unit/plugins/test_properties.py
@@ -14,9 +14,30 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Any, Dict, List, Optional
+
 from craft_parts.plugins import PluginProperties
 
 
 def test_properties_unmarshal():
     prop = PluginProperties.unmarshal({})
     assert isinstance(prop, PluginProperties)
+
+
+class FooProperties(PluginProperties):
+    foo_parameters: Optional[List[str]]
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "FooProperties":
+        return cls(**data)
+
+
+def test_properties_marshal():
+    prop = FooProperties.unmarshal({"foo-parameters": ["foo", "bar"]})
+    assert prop.marshal() == {"foo-parameters": ["foo", "bar"]}
+
+
+def test_properties_defaults():
+    prop = FooProperties.unmarshal({})
+    assert prop.get_pull_properties() == []
+    assert prop.get_build_properties() == ["foo-parameters"]

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -117,3 +117,31 @@ class TestBuildStateChanges:
     def test_project_option_changes(self, project_options):
         state = BuildState(project_options=project_options)
         assert state.diff_project_options_of_interest({}) == set()
+
+    def test_extra_property_changes(self, properties):
+        augmented_properties = {**properties, "extra-property": "foo"}
+        state = BuildState(part_properties=augmented_properties)
+
+        relevant_properties = [
+            "after",
+            "build-attributes",
+            "build-packages",
+            "disable-parallel",
+            "organize",
+            "override-build",
+            "extra-property",
+        ]
+
+        for prop in augmented_properties.keys():
+            other = augmented_properties.copy()
+            other[prop] = "new value"
+
+            diff = state.diff_properties_of_interest(
+                other, also_compare=["extra-property"]
+            )
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert diff == {prop}
+            else:
+                # relevant properties didn't change
+                assert diff == set()

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -104,3 +104,23 @@ class TestPrimeStateChanges:
     def test_project_option_changes(self, project_options):
         state = PrimeState(project_options=project_options)
         assert state.diff_project_options_of_interest({}) == set()
+
+    def test_extra_property_changes(self, properties):
+        augmented_properties = {**properties, "extra-property": "foo"}
+        state = PrimeState(part_properties=augmented_properties)
+
+        relevant_properties = ["override-prime", "prime", "extra-property"]
+
+        for prop in augmented_properties.keys():
+            other = augmented_properties.copy()
+            other[prop] = "new value"
+
+            diff = state.diff_properties_of_interest(
+                other, also_compare=["extra-property"]
+            )
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert diff == {prop}
+            else:
+                # relevant properties didn't change
+                assert diff == set()

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -114,3 +114,36 @@ class TestPullStateChanges:
     def test_project_option_changes(self, project_options):
         state = PullState(project_options=project_options)
         assert state.diff_project_options_of_interest({}) == set()
+
+    def test_extra_property_changes(self, properties):
+        augmented_properties = {**properties, "extra-property": "foo"}
+        state = PullState(part_properties=augmented_properties)
+
+        relevant_properties = [
+            "plugin",
+            "source",
+            "source-commit",
+            "source-depth",
+            "source-tag",
+            "source-type",
+            "source-branch",
+            "source-subdir",
+            "source-submodules",
+            "override-pull",
+            "stage-packages",
+            "extra-property",
+        ]
+
+        for prop in augmented_properties.keys():
+            other = augmented_properties.copy()
+            other[prop] = "new value"
+
+            diff = state.diff_properties_of_interest(
+                other, also_compare=["extra-property"]
+            )
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert diff == {prop}
+            else:
+                # relevant properties didn't change
+                assert diff == set()

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -111,3 +111,28 @@ class TestStageStateChanges:
     def test_project_option_changes(self, project_options):
         state = StageState(project_options=project_options)
         assert state.diff_project_options_of_interest({}) == set()
+
+    def test_extra_property_changes(self, properties):
+        augmented_properties = {**properties, "extra-property": "foo"}
+        state = StageState(part_properties=augmented_properties)
+
+        relevant_properties = [
+            "filesets",
+            "override-stage",
+            "stage",
+            "extra-property",
+        ]
+
+        for prop in augmented_properties.keys():
+            other = augmented_properties.copy()
+            other[prop] = "new value"
+
+            diff = state.diff_properties_of_interest(
+                other, also_compare=["extra-property"]
+            )
+            if prop in relevant_properties:
+                # relevant project options changed
+                assert diff == {prop}
+            else:
+                # relevant properties didn't change
+                assert diff == set()

--- a/tests/unit/state_manager/test_step_state.py
+++ b/tests/unit/state_manager/test_step_state.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import pytest
 import yaml
@@ -55,7 +55,12 @@ class TestMigrationState:
 class SomeStepState(step_state.StepState):
     """A concrete step state implementing abstract methods."""
 
-    def properties_of_interest(self, part_properties: Dict[str, Any]) -> Dict[str, Any]:
+    def properties_of_interest(
+        self,
+        part_properties: Dict[str, Any],
+        *,
+        extra_properties: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
         return {"name": part_properties.get("name")}
 
     def project_options_of_interest(

--- a/tests/unit/state_manager/test_step_state.py
+++ b/tests/unit/state_manager/test_step_state.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
Add plugin properties to the part state and allow the plugin to list properties to be used to verify if the pull or build steps are dirty.

This implementation ensures compatibility with the current plugin API and doesn't require changes in existing plugins. By default, all plugin properties will be verified against the previous build step state. This can be overridden by each plugin if needed.

The implementation is also designed to work with strict plugins where plugin properties changes may require a repull. In this case, each plugin must return the list of properties relevant to the pull step according to the offline build mode.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
