### PR TITLE
sources: fix ignore patterns in local sources

### DIFF
--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -96,8 +96,6 @@ class LocalSource(SourceHandler):
         if not ignore_files:
             ignore_files = []
 
-        ignore_files.extend(self._ignore_patterns)
-
         try:
             target_mtime = os.lstat(target).st_mtime
         except FileNotFoundError:
@@ -183,12 +181,10 @@ def _ignore(
     _files: Any,
     also_ignore: Optional[List[str]] = None,
 ) -> List[str]:
-    if also_ignore:
-        patterns.extend(also_ignore)
-
+    """Build a list of files to ignore based on the given patterns."""
     ignored = []
     if directory in (source, current_directory):
-        for pattern in patterns:
+        for pattern in patterns + (also_ignore or []):
             files = glob.glob(os.path.join(directory, pattern))
             if files:
                 files = [os.path.basename(f) for f in files]

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -421,3 +421,22 @@ class TestLocalUpdate:
 
         local.update()
         assert os.path.isfile(os.path.join(destination, "dir", "file2"))
+
+    def test_ignored_files(self, new_dir):
+        Path("source").mkdir()
+        Path("destination").mkdir()
+        Path("source/foo.txt").touch()
+        Path("reference").touch()
+
+        ignore_patterns = ["*.ignore"]
+        also_ignore = ["also ignore"]
+
+        local = LocalSource(
+            "source", "destination", cache_dir=new_dir, ignore_patterns=ignore_patterns
+        )
+        local.pull()
+
+        # Add a file to ignore, existing patterns must not change.
+        local.check_if_outdated("reference", ignore_files=also_ignore)
+        assert also_ignore == ["also ignore"]
+        assert local._ignore_patterns == ["*.ignore"]


### PR DESCRIPTION
Don't create a cumulative list of patterns to ignore when processing local sources, or the list can become quite large with repetitions of the same patterns.

This is a backport of #362 to the 1.18 branch.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
