### PR TITLE
ci: set default node version to 16

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,6 +95,10 @@ jobs:
           # Remove newer go and install regular version for 20.04
           sudo snap remove go
           sudo apt install -y golang
+      - name: specify node version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Run unit tests
         run: |
           make test-units


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This should work aroud the issue with the node integration tests from the image change to default to node 18