### PR TITLE
plugins: refactor python plugin for subclassing

### DIFF
--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -18,7 +18,7 @@
 
 import shlex
 from textwrap import dedent
-from typing import Any, Dict, List, Set, cast
+from typing import Any, Dict, List, Optional, Set, cast
 
 from .base import Plugin, PluginModel, extract_plugin_properties
 from .properties import PluginProperties
@@ -147,44 +147,91 @@ class PythonPlugin(Plugin):
         build_commands.append(f"[ -f setup.py ] && pip install {constraints} -U .")
 
         # Now fix shebangs.
+        script_interpreter = self._get_script_interpreter()
         build_commands.append(
             dedent(
                 f"""\
-            find "{self._part_info.part_install_dir}" -type f -executable -print0 | xargs -0 \
-                sed -i "1 s|^#\\!${{PARTS_PYTHON_VENV_INTERP_PATH}}.*$|#\\!/usr/bin/env ${{PARTS_PYTHON_INTERPRETER}}|"
-            """
+                find "{self._part_info.part_install_dir}" -type f -executable -print0 | xargs -0 \\
+                    sed -i "1 s|^#\\!${{PARTS_PYTHON_VENV_INTERP_PATH}}.*$|{script_interpreter}|"
+                """
             )
         )
 
-        # Lastly, fix the symlink to the "real" python3 interpreter.
+        # And check if venv symlinks should be removed.
+        if self._should_remove_symlinks():
+            build_commands.append(
+                dedent(
+                    f"""\
+                    echo Removing python symlinks in {self._part_info.part_install_dir}/bin
+                    rm "{self._part_info.part_install_dir}"/bin/python*
+                    """
+                )
+            )
+            return build_commands
+
+        # If we didn't remove the symlink, point it to the real python3 interpreter.
+        python_interpreter = self._get_system_python_interpreter() or ""
         build_commands.append(
             dedent(
                 f"""\
-            determine_link_target() {{
-                opts_state="$(set +o +x | grep xtrace)"
-                interp_dir="$(dirname "${{PARTS_PYTHON_VENV_INTERP_PATH}}")"
-                # Determine python based on PATH, then resolve it, e.g:
-                # (1) <application venv dir>/bin/python3 -> /usr/bin/python3.8
-                # (2) /usr/bin/python3 -> /usr/bin/python3.8
-                # (3) /root/stage/python3 -> /root/stage/python3.8
-                # (4) /root/parts/<part>/install/usr/bin/python3 -> /root/parts/<part>/install/usr/bin/python3.8
-                python_path="$(which "${{PARTS_PYTHON_INTERPRETER}}")"
-                python_path="$(readlink -e "${{python_path}}")"
-                for dir in "{self._part_info.part_install_dir}" "{self._part_info.stage_dir}"; do
-                    if  echo "${{python_path}}" | grep -q "${{dir}}"; then
-                        python_path="$(realpath --strip --relative-to="${{interp_dir}}" \\
-                                "${{python_path}}")"
-                        break
-                    fi
-                done
-                echo "${{python_path}}"
-                eval "${{opts_state}}"
-            }}
+                # look for a provisioned python interpreter
+                opts_state="$(set +o|grep errexit)"
+                set +e
+                install_dir="{self._part_info.part_install_dir}/usr/bin"
+                stage_dir="{self._part_info.stage_dir}/usr/bin"
+                payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "python3.*" -print -quit 2>/dev/null)
 
-            python_path="$(determine_link_target)"
-            ln -sf "${{python_path}}" "${{PARTS_PYTHON_VENV_INTERP_PATH}}"
-            """
+                if [ -n "$payload_python" ]; then
+                    # We found a provisioned interpreter, use it.
+                    installed_python="${{payload_python##{self._part_info.part_install_dir}}}"
+                    if [ "$installed_python" = "$payload_python" ]; then
+                        # Found a staged interpreter.
+                        symlink_target="..${{payload_python##{self._part_info.stage_dir}}}"
+                    else
+                        # The interpreter was installed but not staged yet.
+                        symlink_target="..$installed_python"
+                    fi
+                else
+                    # Otherwise use what _get_system_python_interpreter() told us.
+                    symlink_target="{python_interpreter}"
+                fi
+
+                if [ -z "$symlink_target" ]; then
+                    echo "No suitable Python interpreter found, giving up."
+                    exit 1
+                fi
+
+                eval "${{opts_state}}"
+                ln -sf "${{symlink_target}}" "${{PARTS_PYTHON_VENV_INTERP_PATH}}"
+                """
             )
         )
 
         return build_commands
+
+    def _should_remove_symlinks(self) -> bool:
+        """Configure executables symlink removal.
+
+        This method can be overridden by application-specific subclasses to control
+        whether symlinks in the virtual environment should be removed. Default is
+        False.  If True, the venv-created symlinks to python* in bin/ will be
+        removed and will not be recreated.
+        """
+        return False
+
+    def _get_system_python_interpreter(self) -> Optional[str]:
+        """Obtain the path to the system-provided python interpreter.
+
+        This method can be overridden by application-specific subclasses. It
+        returns the path to the Python that bin/python3 should be symlinked to
+        if Python is not part of the payload.
+        """
+        return '$(readlink -f "$(which "${PARTS_PYTHON_INTERPRETER}")")'
+
+    def _get_script_interpreter(self) -> str:
+        """Obtain the shebang line to use in Python scripts.
+
+        This method can be overridden by application-specific subclasses. It
+        returns the script interpreter to use in existing Python scripts.
+        """
+        return "#!/usr/bin/env ${PARTS_PYTHON_INTERPRETER}"

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -1,1 +1,202 @@
-# TODO: add python plugin integration test after executor lands
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import textwrap
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import yaml
+from overrides import override
+
+import craft_parts.plugins.plugins
+from craft_parts import LifecycleManager, Step, errors, plugins
+
+
+def setup_function():
+    plugins.unregister_all()
+
+
+def teardown_module():
+    plugins.unregister_all()
+
+
+def test_python_plugin_symlink(new_dir):
+    """Run in the standard scenario with no overrides."""
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    python_link = Path(lf.project_info.prime_dir, "bin", "python3")
+    assert python_link.is_symlink()
+
+    # In regular Ubuntu this would be /usr/bin/python3.* but in GH this can be
+    # something like /opt/hostedtoolcache/Python/3.9.16/x64/bin/python3.9
+    assert os.path.isabs(python_link)
+    assert os.path.basename(python_link).startswith("python3")
+
+
+def test_python_plugin_override_get_system_interpreter(new_dir):
+    """Override the system interpreter, link should use it."""
+
+    class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
+        @override
+        def _get_system_python_interpreter(self) -> Optional[str]:
+            return "use-this-python"
+
+    plugins.register({"python": MyPythonPlugin})
+
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    python_link = Path(lf.project_info.prime_dir, "bin", "python3")
+    assert python_link.is_symlink()
+    assert os.readlink(python_link) == "use-this-python"
+
+
+def test_python_plugin_no_system_interpreter(new_dir):
+    """Override the system interpreter, link should use it."""
+
+    class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
+        @override
+        def _get_system_python_interpreter(self) -> Optional[str]:
+            return None
+
+    plugins.register({"python": MyPythonPlugin})
+
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx, pytest.raises(errors.PluginBuildError):
+        ctx.execute(actions)
+
+
+def test_python_plugin_remove_symlinks(new_dir):
+    """Override symlink removal."""
+
+    class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
+        @override
+        def _should_remove_symlinks(self) -> bool:
+            return True
+
+    plugins.register({"python": MyPythonPlugin})
+
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    python_link = Path(lf.project_info.prime_dir, "bin", "python3")
+    assert python_link.exists() is False
+
+
+def test_python_plugin_fix_shebangs(new_dir):
+    """Check if shebangs are properly fixed in scripts."""
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    primed_script = Path("prime/bin/pip")
+    assert primed_script.open().readline().rstrip() == "#!/usr/bin/env python3"
+
+
+def test_python_plugin_override_shebangs(new_dir):
+    """Override what we want in script shebang lines."""
+
+    class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
+        @override
+        def _get_script_interpreter(self) -> str:
+            return "#!/my/script/interpreter"
+
+    plugins.register({"python": MyPythonPlugin})
+
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: python
+            source: .
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    primed_script = Path("prime/bin/pip")
+    assert primed_script.open().readline().rstrip() == "#!/my/script/interpreter"


### PR DESCRIPTION
The location of the Python interpreter executable can depend on application-specific parameters that cannot be determined by a generic parts plugin. To address that, allow applications to subclass and override methods in the Python plugin in order to use custom logic to set the interpreter location.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
