### PR TITLE
plugins: fix pip path in python plugin

### DIFF
--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -127,6 +127,8 @@ class PythonPlugin(Plugin):
 
         options = cast(PythonPluginProperties, self._options)
 
+        pip = f"{self._part_info.part_install_dir}/bin/pip"
+
         if options.python_constraints:
             constraints = " ".join(f"-c {c!r}" for c in options.python_constraints)
         else:
@@ -136,15 +138,15 @@ class PythonPlugin(Plugin):
             python_packages = " ".join(
                 [shlex.quote(pkg) for pkg in options.python_packages]
             )
-            python_packages_cmd = f"pip install {constraints} -U {python_packages}"
+            python_packages_cmd = f"{pip} install {constraints} -U {python_packages}"
             build_commands.append(python_packages_cmd)
 
         if options.python_requirements:
             requirements = " ".join(f"-r {r!r}" for r in options.python_requirements)
-            requirements_cmd = f"pip install {constraints} -U {requirements}"
+            requirements_cmd = f"{pip} install {constraints} -U {requirements}"
             build_commands.append(requirements_cmd)
 
-        build_commands.append(f"[ -f setup.py ] && pip install {constraints} -U .")
+        build_commands.append(f"[ -f setup.py ] && {pip} install {constraints} -U .")
 
         # Now fix shebangs.
         script_interpreter = self._get_script_interpreter()

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -35,6 +35,31 @@ def teardown_module():
     plugins.unregister_all()
 
 
+def test_python_plugin(new_dir):
+    """Prime a simple python source."""
+    source_location = Path(__file__).parent / "test_python"
+
+    parts_yaml = textwrap.dedent(
+        f"""\
+        parts:
+          foo:
+            plugin: python
+            source: {source_location}
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = LifecycleManager(parts, application_name="test_python", cache_dir=new_dir)
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    primed_script = Path(lf.project_info.prime_dir, "bin", "mytest")
+    assert primed_script.exists()
+    assert primed_script.open().readline().rstrip() == "#!/usr/bin/env python3"
+
+
 def test_python_plugin_symlink(new_dir):
     """Run in the standard scenario with no overrides."""
     parts_yaml = textwrap.dedent(

--- a/tests/integration/plugins/test_python/mytest/__init__.py
+++ b/tests/integration/plugins/test_python/mytest/__init__.py
@@ -1,0 +1,2 @@
+def main():
+    print("it works!")

--- a/tests/integration/plugins/test_python/setup.py
+++ b/tests/integration/plugins/test_python/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from distutils.core import setup
+
+setup(
+    name="plugin_test",
+    version="0.1",
+    entry_points={"console_scripts": ["mytest=mytest:main"]},
+)


### PR DESCRIPTION
Make sure the plugin uses pip from the venv it created, to prevent installing packages in unexpected locations if PATH is changed.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
