### PR TITLE
chroot: mark /dev mount as private

### DIFF
--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -98,16 +98,16 @@ def _cleanup_chroot(path: Path) -> None:
         _cleanup_chroot_linux(path)
 
 
-_Mount = namedtuple("_Mount", ["fstype", "src", "mountpoint", "option"])
+_Mount = namedtuple("_Mount", ["fstype", "src", "mountpoint", "options"])
 
 # Essential filesystems to mount in order to have basic utilities and
 # name resolution working inside the chroot environment.
 _linux_mounts: List[_Mount] = [
-    _Mount(None, "/etc/resolv.conf", "/etc/resolv.conf", "--bind"),
+    _Mount(None, "/etc/resolv.conf", "/etc/resolv.conf", ["--bind"]),
     _Mount("proc", "proc", "/proc", None),
     _Mount("sysfs", "sysfs", "/sys", None),
     # Device nodes require MS_REC to be bind mounted inside a container.
-    _Mount(None, "/dev", "/dev", "--rbind"),
+    _Mount(None, "/dev", "/dev", ["--rbind", "--make-rprivate"]),
 ]
 
 
@@ -129,8 +129,8 @@ def _setup_chroot_linux(path: Path) -> None:
     pid = os.getpid()
     for entry in _linux_mounts:
         args = []
-        if entry.option:
-            args.append(entry.option)
+        if entry.options:
+            args.extend(entry.options)
         if entry.fstype:
             args.append(f"-t{entry.fstype}")
 
@@ -154,7 +154,7 @@ def _cleanup_chroot_linux(path: Path) -> None:
 
         if mountpoint.exists():
             logger.debug("[pid=%d] umount: %r", pid, str(mountpoint))
-            if entry.option == "--rbind":
+            if entry.options and "--rbind" in entry.options:
                 # Mount points under /dev may be in use and make the bind mount
                 # unmountable. This may happen in destructive mode depending on
                 # the host environment, so use MNT_DETACH to defer unmounting.

--- a/tests/fake_snapd.py
+++ b/tests/fake_snapd.py
@@ -127,7 +127,8 @@ class _FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
         snap_name = parsed_url.path.split("/")[-1]
         details_func = self.snap_details_func
         if details_func:
-            status_code, params = details_func(  # pylint: disable=not-callable
+            # pylint: disable-next=not-callable
+            status_code, params = details_func(  # type: ignore
                 snap_name
             )
         else:

--- a/tests/fake_snapd.py
+++ b/tests/fake_snapd.py
@@ -128,9 +128,7 @@ class _FakeSnapdRequestHandler(fake_servers.BaseHTTPRequestHandler):
         details_func = self.snap_details_func
         if details_func:
             # pylint: disable-next=not-callable
-            status_code, params = details_func(  # type: ignore
-                snap_name
-            )
+            status_code, params = details_func(snap_name)  # type: ignore
         else:
             for snap in self.snaps_result:
                 if snap["name"] == snap_name:

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -77,7 +77,7 @@ class TestChroot:
             call("/etc/resolv.conf", f"{new_root}/etc/resolv.conf", "--bind"),
             call("proc", f"{new_root}/proc", "-tproc"),
             call("sysfs", f"{new_root}/sys", "-tsysfs"),
-            call("/dev", f"{new_root}/dev", "--rbind"),
+            call("/dev", f"{new_root}/dev", "--rbind", "--make-rprivate"),
         ]
         assert mock_umount.mock_calls == [
             call(f"{new_root}/dev", "--recursive", "--lazy"),


### PR DESCRIPTION
Address shared mount issues affecting /dev mount in chroots. This is a result of https://github.com/lxc/lxc/pull/4229 (container rootfs became a shared mount, meaning that unmounts propagates through the shared group and original mounts are unmounted too).

See https://github.com/canonical/rockcraft/issues/195 for details.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
