### PR TITLE
sources: add 'git+ssh:' for 'git' source-type

### DIFF
--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -190,6 +190,7 @@ def get_source_type_from_uri(
     elif (
         source.startswith("git:")
         or source.startswith("git@")
+        or source.startswith("git+ssh:")
         or source.endswith(".git")
     ):
         source_type = "git"

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -53,6 +53,7 @@ def test_get_source_handler_class_with_invalid_type():
         (".tar", "tar"),
         ("git:", "git"),
         ("git@", "git"),
+        ("git+ssh:", "git"),
         (".git", "git"),
         ("lp:", "bzr"),
         ("bzr:", "bzr"),


### PR DESCRIPTION
By default, the launchpad instruction for clone will contain `git+ssh`

When cloning launchpad repo without defining source-type, I will get `Failed to pull source: unable to determine source
 type of git+ssh://git.launchpad.net/<TEAM>/<PROJECT>+git/<REPO>`

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
