### PR TITLE
deps: loosen pydantic dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ def is_rtd() -> bool:
 install_requires = [
     "overrides",
     "PyYAML",
-    "pydantic==1.9.0",  # needed by pydanic-yaml 0.6.3
-    "pydantic-yaml",
+    "pydantic>=1.9.0",
+    "pydantic-yaml[pyyaml]",
     "pyxdg",
     "requests",
     "requests-unixsocket",


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Pydantic was frozen at 1.9 due a pydantic-yaml dependency that has been resolved upstream. https://github.com/canonical/craft-parts/pull/221/commits/b42526df48de47857ce807336da3eed4ef14f017