### PR TITLE
sequencer: use plugin properties in action planning

### DIFF
--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -256,7 +256,7 @@ class Sequencer:
             self._add_action(part, step, reason=reason)
 
         state: states.StepState
-        part_properties = part.spec.marshal()
+        part_properties = {**part.spec.marshal(), **part.plugin_properties.marshal()}
 
         # create step state
 

--- a/craft_parts/state_manager/reports.py
+++ b/craft_parts/state_manager/reports.py
@@ -16,11 +16,14 @@
 
 """Provide a report on why a step is outdated."""
 
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
 from craft_parts.steps import Step
 from craft_parts.utils import formatting_utils
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -123,6 +126,7 @@ class DirtyReport:
             reasons_count += 1
 
         if self.dirty_properties:
+            logger.debug("dirty properties: %r", self.dirty_properties)
             # Be specific only if this is the only reason
             if reasons_count > 1 or len(self.dirty_properties) > 1:
                 reasons.append("properties")
@@ -130,6 +134,7 @@ class DirtyReport:
                 reasons.append(f"{self.dirty_properties[0]!r} property")
 
         if self.dirty_project_options:
+            logger.debug("dirty project options: %r", self.dirty_project_options)
             # Be specific only if this is the only reason
             if reasons_count > 1 or len(self.dirty_project_options) > 1:
                 reasons.append("options")
@@ -137,6 +142,7 @@ class DirtyReport:
                 reasons.append(f"{self.dirty_project_options[0]!r} option")
 
         if self.changed_dependencies:
+            logger.debug("changed dependencies: %r", self.changed_dependencies)
             # Be specific only if this is the only reason
             if reasons_count > 1 or len(self.changed_dependencies) > 1:
                 reasons.append("dependencies")

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -16,6 +16,7 @@
 
 """The step state preserves step execution context information."""
 
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
@@ -23,6 +24,8 @@ from typing import Any, Dict, List, Optional, Set
 from pydantic_yaml import YamlModel
 
 from craft_parts.utils import os_utils
+
+logger = logging.getLogger(__name__)
 
 
 class MigrationState(YamlModel):
@@ -155,11 +158,13 @@ def _get_differing_keys(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Set[str
     for key, dict1_value in dict1.items():
         dict2_value = dict2.get(key)
         if dict1_value != dict2_value:
+            logger.debug("%s: %r != %r", key, dict1_value, dict2_value)
             differing_keys.add(key)
 
     for key, dict2_value in dict2.items():
         dict1_value = dict1.get(key)
         if dict1_value != dict2_value:
+            logger.debug("%s: %r != %r", key, dict1_value, dict2_value)
             differing_keys.add(key)
 
     return differing_keys


### PR DESCRIPTION
Add missing plugin properties to action planning to reflect the
complete state persisted after the previous execution run.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
