### PR TITLE
executor: fix subdir in pull and build steps

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -198,7 +198,7 @@ class PartHandler:
         self._run_step(
             step_info=step_info,
             scriptlet_name="override-pull",
-            work_dir=self._part.part_src_dir,
+            work_dir=self._part.part_src_subdir,
             stdout=stdout,
             stderr=stderr,
         )
@@ -301,7 +301,7 @@ class PartHandler:
                 self._run_step(
                     step_info=step_info,
                     scriptlet_name="override-build",
-                    work_dir=self._part.part_build_dir,
+                    work_dir=self._part.part_build_subdir,
                     stdout=stdout,
                     stderr=stderr,
                 )
@@ -309,7 +309,7 @@ class PartHandler:
             self._run_step(
                 step_info=step_info,
                 scriptlet_name="override-build",
-                work_dir=self._part.part_build_dir,
+                work_dir=self._part.part_build_subdir,
                 stdout=stdout,
                 stderr=stderr,
             )

--- a/tests/unit/features/overlay/test_executor_part_handler.py
+++ b/tests/unit/features/overlay/test_executor_part_handler.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
+from unittest.mock import call
 
 import pytest
 
@@ -107,7 +108,7 @@ class TestPartHandling(test_part_handler.TestPartHandling):
         assert file1.exists() is False
         assert file2.is_file()
 
-    def test_run_build(self, mocker):
+    def test_run_build(self, mocker, new_dir):
         mocker.patch("craft_parts.executor.step_handler.StepHandler._builtin_build")
         mocker.patch(
             "craft_parts.packages.Repository.get_installed_packages",
@@ -118,10 +119,10 @@ class TestPartHandling(test_part_handler.TestPartHandling):
             return_value=["snapcraft=6466"],
         )
         mocker.patch("subprocess.check_output", return_value=b"os-info")
+        mock_run_step = mocker.spy(PartHandler, "_run_step")
 
-        state = self._handler._run_build(
-            StepInfo(self._part_info, Step.BUILD), stdout=None, stderr=None
-        )
+        step_info = StepInfo(self._part_info, Step.BUILD)
+        state = self._handler._run_build(step_info, stdout=None, stderr=None)
         assert state == states.BuildState(
             part_properties=self._part.spec.marshal(),
             project_options=self._part_info.project_options,
@@ -134,6 +135,17 @@ class TestPartHandling(test_part_handler.TestPartHandling):
             },
             overlay_hash="d12e3f53ba91f94656abc940abb50b12b209d246",
         )
+
+        assert mock_run_step.mock_calls == [
+            call(
+                self._handler,
+                step_info=step_info,
+                scriptlet_name="override-build",
+                work_dir=Path(new_dir, "parts/foo/build"),
+                stdout=None,
+                stderr=None,
+            )
+        ]
 
         self._mock_mount_overlayfs.assert_called_with(
             f"{self._part_info.overlay_mount_dir}",


### PR DESCRIPTION
The working directories for the pull and build steps should
also be set accordingly when source-subdir is set.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
