### PR TITLE
callbacks: add callback to explicitly list base packages

### DIFF
--- a/craft_parts/callbacks.py
+++ b/craft_parts/callbacks.py
@@ -19,7 +19,7 @@
 import itertools
 import logging
 from collections import namedtuple
-from typing import Callable, Iterable, List, Optional, Union
+from typing import Callable, Iterable, List, Optional, Set, Union
 
 from craft_parts import errors
 from craft_parts.infos import ProjectInfo, StepInfo
@@ -107,7 +107,7 @@ def unregister_all() -> None:
     _POST_STEP_HOOKS[:] = []
 
 
-def get_stage_packages_filters(project_info: ProjectInfo) -> Optional[Iterable[str]]:
+def get_stage_packages_filters(project_info: ProjectInfo) -> Optional[Set[str]]:
     """Obtain the list of stage packages to be filtered out.
 
     :param project_info: The project information to be sent to callback functions.
@@ -117,7 +117,9 @@ def get_stage_packages_filters(project_info: ProjectInfo) -> Optional[Iterable[s
     if not _STAGE_PACKAGE_FILTERS:
         return None
 
-    return itertools.chain(*[f.function(project_info) for f in _STAGE_PACKAGE_FILTERS])
+    return set(
+        itertools.chain(*[f.function(project_info) for f in _STAGE_PACKAGE_FILTERS])
+    )
 
 
 def run_prologue(project_info: ProjectInfo) -> None:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -86,10 +86,6 @@ class Executor:
 
         This method is called before executing lifecycle actions.
         """
-        packages.Repository.stage_packages_filters = (
-            callbacks.get_stage_packages_filters(self._project_info)
-        )
-
         self._install_build_packages()
         self._install_build_snaps()
 
@@ -102,6 +98,11 @@ class Executor:
                 ctx.refresh_packages_list()
 
         callbacks.run_prologue(self._project_info)
+
+        # obtain the stage package exclusion set.
+        packages.Repository.stage_packages_filters = (
+            callbacks.get_stage_packages_filters(self._project_info)
+        )
 
     def epilogue(self) -> None:
         """Finish and clean the execution environment.

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -86,6 +86,10 @@ class Executor:
 
         This method is called before executing lifecycle actions.
         """
+        packages.Repository.stage_packages_filters = (
+            callbacks.get_stage_packages_filters(self._project_info)
+        )
+
         self._install_build_packages()
         self._install_build_snaps()
 

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -56,8 +56,8 @@ class LifecycleManager:
         directory will be used if none is specified.
     :param arch: The architecture to build for. Defaults to the host system
         architecture.
-    :param base: The system base the project being processed will run on. Defaults
-        to the system where Craft Parts is being executed.
+    :param base: [deprecated] The system base the project being processed will
+        run on. Defaults to the system where Craft Parts is being executed.
     :param parallel_build_count: The maximum number of concurrent jobs to be
         used to build each part of this project.
     :param application_package_name: The name of the application package, if required

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -21,7 +21,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Set, Tuple, Type
+from typing import Any, List, Optional, Set, Tuple, Type
 
 from craft_parts import xattrs
 
@@ -34,7 +34,7 @@ _STAGE_PACKAGE_KEY = "origin_stage_package"
 class BaseRepository(abc.ABC):
     """Base implementation for a platform specific repository handler."""
 
-    stage_packages_filters: Optional[Iterable[str]] = None
+    stage_packages_filters: Optional[Set[str]] = None
 
     @classmethod
     @abc.abstractmethod

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -21,7 +21,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import Any, List, Optional, Set, Tuple, Type
+from typing import Any, Iterable, List, Optional, Set, Tuple, Type
 
 from craft_parts import xattrs
 
@@ -33,6 +33,8 @@ _STAGE_PACKAGE_KEY = "origin_stage_package"
 
 class BaseRepository(abc.ABC):
     """Base implementation for a platform specific repository handler."""
+
+    stage_packages_filters: Optional[Iterable[str]] = None
 
     @classmethod
     @abc.abstractmethod

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 from craft_parts.utils import deb_utils, file_utils, os_utils
 
@@ -307,11 +307,11 @@ def _get_filtered_stage_package_names(
     *,
     base: str,
     package_list: List[DebPackage],
-    base_package_names: Optional[Iterable[str]],
+    base_package_names: Optional[Set[str]],
 ) -> Set[str]:
     """Get filtered packages by name only - no version or architectures."""
     if base_package_names:
-        filtered_packages = set(base_package_names)
+        filtered_packages = base_package_names
     else:
         manifest_packages = {p.name for p in get_packages_in_base(base=base)}
         ignored_packages = _IGNORE_FILTERS.get(base, set())

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -146,7 +146,7 @@ def test_python_plugin_override_get_system_interpreter(new_dir):
 
 
 @pytest.mark.parametrize("remove_symlinks", (True, False))
-def test_python_plugin_no_system_interpreter(new_dir, remove_symlinks):
+def test_python_plugin_no_system_interpreter(new_dir, remove_symlinks: bool):
     """Check that the build fails if a payload interpreter is needed but not found."""
 
     class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -530,7 +530,7 @@ class TestBuildPackages:
 
 
 @pytest.mark.parametrize(
-    "source_type, packages",
+    "source_type, pkgs",
     [
         ("7zip", {"p7zip-full"}),
         ("bzr", {"bzr"}),
@@ -546,8 +546,8 @@ class TestBuildPackages:
         ("whatever-unknown", set()),
     ],
 )
-def test_packages_for_source_type(source_type, packages):
-    assert deb.Ubuntu.get_packages_for_source_type(source_type) == packages
+def test_packages_for_source_type(source_type, pkgs):
+    assert deb.Ubuntu.get_packages_for_source_type(source_type) == pkgs
 
 
 @pytest.fixture
@@ -575,11 +575,11 @@ def fake_dpkg_query(mocker):
 class TestGetPackagesInBase:
     def test_hardcoded_bases(self):
         for base in ("core", "core16", "core18"):
-            packages = [
+            pkgs = [
                 DebPackage.from_unparsed(p)
                 for p in deb._DEFAULT_FILTERED_STAGE_PACKAGES
             ]
-            assert deb.get_packages_in_base(base=base) == packages
+            assert deb.get_packages_in_base(base=base) == pkgs
 
     def test_package_list_from_dpkg_list(self, tmpdir, mocker):
         dpkg_list_path = Path(tmpdir, "dpkg.list")
@@ -660,6 +660,8 @@ class TestStagePackagesFilters:
             arch="amd64",
         )
 
+        # pylint: disable=unnecessary-dunder-call
+
         fake_deb_run.assert_has_calls([call(["apt-get", "update"])])
         fake_apt_cache.assert_has_calls(
             [
@@ -672,6 +674,8 @@ class TestStagePackagesFilters:
                 call().__enter__().fetch_archives(debs_path),
             ]
         )
+
+        # pylint: enable=unnecessary-dunder-call
 
         assert fetched_packages == ["fake-package=1.0"]
 

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
+from typing import Generator, List
 
 import pytest
 
@@ -44,6 +45,18 @@ def _callback_3(info: ProjectInfo) -> None:
 def _callback_4(info: ProjectInfo) -> None:
     greet = getattr(info, "greet")
     print(f"{greet} callback 4")
+
+
+def _callback_filter_1(info: ProjectInfo) -> List[str]:
+    greet = getattr(info, "greet")
+    print(f"{greet} filter 1")
+    return ["a", "b", "c"]
+
+
+def _callback_filter_2(info: ProjectInfo) -> Generator[str, None, None]:
+    greet = getattr(info, "greet")
+    print(f"{greet} filter 2")
+    return (i for i in ["d", "e", "f"])
 
 
 class TestCallbackRegistration:
@@ -107,6 +120,19 @@ class TestCallbackRegistration:
         # But we can register a different one
         callbacks.register_epilogue(_callback_4)
 
+    def test_register_stage_packages_filters(self):
+        callbacks.register_stage_packages_filter(_callback_filter_1)
+
+        # A callback function shouldn't be registered again
+        with pytest.raises(errors.CallbackRegistrationError) as raised:
+            callbacks.register_stage_packages_filter(_callback_filter_1)
+        assert raised.value.message == (
+            "callback function '_callback_filter_1' is already registered."
+        )
+
+        # But we can register a different one
+        callbacks.register_stage_packages_filter(_callback_filter_2)
+
     def test_register_both_pre_and_post(self):
         callbacks.register_pre_step(_callback_1)
         callbacks.register_post_step(_callback_1)
@@ -116,11 +142,15 @@ class TestCallbackRegistration:
         callbacks.register_epilogue(_callback_3)
 
     def test_unregister_all(self):
+        callbacks.register_stage_packages_filter(_callback_filter_1)
+        callbacks.register_stage_packages_filter(_callback_filter_2)
         callbacks.register_pre_step(_callback_1)
         callbacks.register_post_step(_callback_1)
         callbacks.register_prologue(_callback_3)
         callbacks.register_epilogue(_callback_3)
         callbacks.unregister_all()
+        callbacks.register_stage_packages_filter(_callback_filter_1)
+        callbacks.register_stage_packages_filter(_callback_filter_2)
         callbacks.register_pre_step(_callback_1)
         callbacks.register_post_step(_callback_1)
         callbacks.register_prologue(_callback_3)
@@ -189,3 +219,25 @@ class TestCallbackExecution:
         out, err = capfd.readouterr()
         assert not err
         assert out == "hello callback 3\nhello callback 4\n"
+
+    @pytest.mark.parametrize(
+        "funcs,result,message",
+        [
+            ([_callback_filter_1], ["a", "b", "c"], "hello filter 1\n"),
+            ([_callback_filter_2], ["d", "e", "f"], "hello filter 2\n"),
+            (
+                [_callback_filter_1, _callback_filter_2],
+                ["a", "b", "c", "d", "e", "f"],
+                "hello filter 1\nhello filter 2\n",
+            ),
+        ],
+    )
+    def test_filter_package_list(self, capfd, funcs, result, message):
+        for fn in funcs:
+            callbacks.register_stage_packages_filter(fn)
+        res = callbacks.get_stage_packages_filters(self._project_info)
+        assert list(res) == result
+
+        out, err = capfd.readouterr()
+        assert not err
+        assert out == message

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -223,11 +223,11 @@ class TestCallbackExecution:
     @pytest.mark.parametrize(
         "funcs,result,message",
         [
-            ([_callback_filter_1], ["a", "b", "c"], "hello filter 1\n"),
-            ([_callback_filter_2], ["d", "e", "f"], "hello filter 2\n"),
+            ([_callback_filter_1], {"a", "b", "c"}, "hello filter 1\n"),
+            ([_callback_filter_2], {"d", "e", "f"}, "hello filter 2\n"),
             (
                 [_callback_filter_1, _callback_filter_2],
-                ["a", "b", "c", "d", "e", "f"],
+                {"a", "b", "c", "d", "e", "f"},
                 "hello filter 1\nhello filter 2\n",
             ),
         ],
@@ -236,8 +236,7 @@ class TestCallbackExecution:
         for fn in funcs:
             callbacks.register_stage_packages_filter(fn)
         res = callbacks.get_stage_packages_filters(self._project_info)
-        assert res is not None
-        assert list(res) == result
+        assert res == result
 
         out, err = capfd.readouterr()
         assert not err

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -236,6 +236,7 @@ class TestCallbackExecution:
         for fn in funcs:
             callbacks.register_stage_packages_filter(fn)
         res = callbacks.get_stage_packages_filters(self._project_info)
+        assert res is not None
         assert list(res) == result
 
         out, err = capfd.readouterr()


### PR DESCRIPTION
Craft Parts includes mechanisms to filter out stage package dependencies
in snap bases. This is now deprecated, and a function providing an
explicit list of exclusions should be registered by the application
as a callback.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-1724