### PR TITLE
plugins: better checking for needed payload python

### DIFF
--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -145,13 +145,20 @@ def test_python_plugin_override_get_system_interpreter(new_dir):
     assert os.readlink(python_link) == "use-this-python"
 
 
-def test_python_plugin_no_system_interpreter(new_dir):
-    """Override the system interpreter, link should use it."""
+@pytest.mark.parametrize("remove_symlinks", (True, False))
+def test_python_plugin_no_system_interpreter(new_dir, remove_symlinks):
+    """Check that the build fails if a payload interpreter is needed but not found."""
 
     class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
         @override
         def _get_system_python_interpreter(self) -> Optional[str]:
             return None
+
+        @override
+        def _should_remove_symlinks(self) -> bool:
+            # Parametrize this to make sure that the build fails even if the
+            # venv symlinks will be removed.
+            return remove_symlinks
 
     plugins.register({"python": MyPythonPlugin})
 


### PR DESCRIPTION
This commit handles the case where the venv symlinks must be removed, but a part-provided Python interpreter *must* be present. This is done by deferring the symlink removal to the end of the build, so that the existing check for a valid interpreter can be performed.

This is to address the "Rockcraft/ubuntu" case in the following table of existing scenarios:
![image](https://github.com/canonical/craft-parts/assets/1951299/1f0199d0-3c11-48a0-917b-d8f4560982d5)

That case is particularly bad because the "failure to have the build fail" results in a ROCK that is completely unusable, because of an additional (usrmerge) bug that will be addressed in a separate PR/issue.


CRAFT-1725
