### PR TITLE
deps: make python-apt dependency optional

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,14 +71,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libapt-pkg-dev intltool fuse-overlayfs
-      - name: Install python-apt dependencies
-        run: |
-          pip install https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-distutils-extra/2.43/python-distutils-extra_2.43.tar.xz
-          pip install https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz
       - name: Install general python dependencies
         run: |
-          pip install .[dev]
-          pip install -e .
+          pip install -e .[dev,${{ matrix.adjective }}-dev]
       - name: Install additional test dependencies
         run: |
           sudo apt install -y ninja-build cmake scons

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ all available options run:
 make help
 ```
 
+## Development Environment
+
+In order to develop any `apt` related items, the `python-apt` package is needed.
+The `apt` extra will require this package in general. For development on an
+Ubuntu system, the `focal-dev`, `jammy-dev`, and `lunar-dev` extras are available
+instead, which will build a local `python-apt` package that matches the
+declared Ubuntu version.
+
+Apt package prerequisites for this development environment on an Ubuntu system can be installed with:
+
+```bash
+sudo apt install libapt-pkg-dev intltool fuse-overlayfs
+```
+
 ## Running tests
 
 To run all tests in the suite run:

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -26,12 +26,18 @@ from contextlib import ContextDecorator
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-import apt
-import apt.cache
-import apt.package
-import apt.progress
-import apt.progress.base
-import apt_pkg
+try:
+    import apt
+    import apt.cache
+    import apt.package
+    import apt.progress
+    import apt.progress.base
+    import apt_pkg
+except ImportError as e:
+    raise ImportError(
+        "python-apt is needed for apt operations. "
+        "Check the craft-parts README for more information."
+    ) from e
 
 from craft_parts.utils import os_utils
 

--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,6 @@ install_requires = [
     "urllib3<2",  # keep compatible API
 ]
 
-
-if is_ubuntu() and not is_rtd():
-    install_requires.append("python-apt")
-
-
 dev_requires = [
     "autoflake",
     "twine",
@@ -108,6 +103,21 @@ extras_requires = {
     "docs": docs_require,
     "test": test_requires + types_requires,
     "types": types_requires,
+    # Python-apt bindings for specific Ubuntu versions.
+    # Up to date package links can be found at https://launchpad.net/ubuntu/+source/python-apt
+    # Note: These extras can break requirements from other packages, so
+    # do not use them in dependencies unless you know what you're doing.
+    "focal-dev": [
+        "python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz"
+    ],
+    "jammy-dev": [
+        "python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz"
+    ],
+    "lunar-dev": [
+        "python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.5.3ubuntu1/python-apt_2.5.3ubuntu1.tar.xz"
+    ],
+    # Generic "apt" extra for handling any apt-based platforms (e.g. Debian, Ubuntu)
+    "apt": ["python-apt"],
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ package = editable
 extras =
     dev
     test
+    focal-dev
 env_dir = {work_dir}/linting
 runner = ignore_env_name_mismatch
 
@@ -77,7 +78,7 @@ commands =
 description = Static type checking
 base = testenv, lint
 env_dir = {work_dir}/typing
-extras = dev, types
+extras = dev, types, focal-dev
 labels = lint, type
 allowlist_externals =
     mypy: mkdir


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

OK, so this is a different mechanism for hopefully making the python-apt dependency easier to deal with.

1. `python-apt` is made an optional dependency with a graceful notification about it.
2. Several optional extras are added to specify a specific package for developer convenience.

Unfortunately, the second would not work without the first, at least not in any way I could figure out, as `python-apt` without a specified location would get an attempted install before the version with the specified location (rather than being deduplicated).