### PR TITLE
ci: bump github action versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install python packages and dependencies
@@ -63,11 +63,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install apt build dependencies


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Bump actions to take care of deprecation notices:

![image](https://github.com/canonical/craft-parts/assets/60674096/cc7b9e0c-ca19-48c7-9dcc-be947317203e)
