### PR TITLE
lint: use correct types for SnapSource test

### DIFF
--- a/tests/unit/sources/test_snap_source.py
+++ b/tests/unit/sources/test_snap_source.py
@@ -40,11 +40,17 @@ class TestSnapSource:
         # pylint: enable=attribute-defined-outside-init
 
     @pytest.mark.parametrize(
-        "param", ["source_tag", "source_branch", "source_commit", "source_depth"]
+        ("param", "value"),
+        [
+            ("source_tag", "fake-tag"),
+            ("source_branch", "fake-branch"),
+            ("source_commit", "fake-commit"),
+            ("source_depth", 1),
+        ],
     )
-    def test_invalid_parameter(self, new_dir, param):
+    def test_invalid_parameter(self, new_dir, param, value):
         with pytest.raises(errors.InvalidSourceOption) as raised:
-            kwargs = {param: "foo"}
+            kwargs = {param: value}
             sources.SnapSource(
                 source="test.snap", part_src_dir=Path(), cache_dir=new_dir, **kwargs
             )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

[Pyright 1.1.312](https://github.com/microsoft/pyright/releases/tag/1.1.312) now type-checks kwargs. This started causing the following error:

```
pyright setup.py craft_parts tests
/home/runner/work/craft-parts/craft-parts/tests/unit/sources/test_snap_source.py
  /home/runner/work/craft-parts/craft-parts/tests/unit/sources/test_snap_source.py:49:79 - error: Argument of type "str" cannot be assigned to parameter "source_depth" of type "int | None" in function "__init__"
    Type "str" cannot be assigned to type "int | None"
      "str" is incompatible with "int"
      Type cannot be assigned to type "None" (reportGeneralTypeIssues)
  /home/runner/work/craft-parts/craft-parts/tests/unit/sources/test_snap_source.py:49:79 - error: Argument of type "str" cannot be assigned to parameter "project_dirs" of type "ProjectDirs | None" in function "__init__"
    Type "str" cannot be assigned to type "ProjectDirs | None"
      "str" is incompatible with "ProjectDirs"
      Type cannot be assigned to type "None" (reportGeneralTypeIssues)
2 errors, 0 warnings, 0 informations 
```

Similar to https://github.com/snapcore/snapcraft/pull/4205