### PR TITLE
plugins: be more specific in search for payload Python

### DIFF
--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -135,10 +135,16 @@ class PythonPlugin(Plugin):
                 set +e
                 install_dir="{self._part_info.part_install_dir}/usr/bin"
                 stage_dir="{self._part_info.stage_dir}/usr/bin"
-                payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "python3.*" -print -quit 2>/dev/null)
+
+                # look for the right Python version - if the venv was created with python3.10,
+                # look for python3.10
+                basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
+                echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
+                payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
 
                 if [ -n "$payload_python" ]; then
                     # We found a provisioned interpreter, use it.
+                    echo Found interpreter in payload: \\"${{payload_python}}\\"
                     installed_python="${{payload_python##{self._part_info.part_install_dir}}}"
                     if [ "$installed_python" = "$payload_python" ]; then
                         # Found a staged interpreter.
@@ -149,6 +155,7 @@ class PythonPlugin(Plugin):
                     fi
                 else
                     # Otherwise use what _get_system_python_interpreter() told us.
+                    echo "Python interpreter not found in payload."
                     symlink_target="{python_interpreter}"
                 fi
 

--- a/tests/unit/plugins/test_python_plugin.py
+++ b/tests/unit/plugins/test_python_plugin.py
@@ -80,10 +80,16 @@ def get_build_commands(
             set +e
             install_dir="{new_dir}/parts/p1/install/usr/bin"
             stage_dir="{new_dir}/stage/usr/bin"
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "python3.*" -print -quit 2>/dev/null)
+
+            # look for the right Python version - if the venv was created with python3.10,
+            # look for python3.10
+            basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
+            echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.
+                echo Found interpreter in payload: \\"${{payload_python}}\\"
                 installed_python="${{payload_python##{new_dir}/parts/p1/install}}"
                 if [ "$installed_python" = "$payload_python" ]; then
                     # Found a staged interpreter.
@@ -94,6 +100,7 @@ def get_build_commands(
                 fi
             else
                 # Otherwise use what _get_system_python_interpreter() told us.
+                echo "Python interpreter not found in payload."
                 symlink_target="$(readlink -f "$(which "${{PARTS_PYTHON_INTERPRETER}}")")"
             fi
 


### PR DESCRIPTION
This commit updates the Python plugin to be more restrictive when looking for the interpreter in the parts' payload: if the venv is created using "python3.10", then that exact version of Python must be found in the payload in order to be usable.

In addition to avoiding issues from incompatible versions, this handles cases like the Python 3.6 package (from the deadsnakes ppa) that has both a "python3.6" and a "python3.6m" binaries by default.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
