### PR TITLE
packaging: pin Pydantic to <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def is_rtd() -> bool:
 install_requires = [
     "overrides",
     "PyYAML",
-    "pydantic>=1.9.0",
+    "pydantic>=1.9.0,<2.0.0",
     "pydantic-yaml[pyyaml]",
     "pyxdg",
     "requests",


### PR DESCRIPTION
Pydantic 2.0.0 has recently been released and craft_parts needs work to support it.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
