### PR TITLE
overlays: collect log messages from chrooted call

### DIFF
--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -327,6 +327,7 @@ def process_run(
     command: List[str], log_func: Callable[[str], None], **kwargs: Any
 ) -> None:
     """Run a command and handle its output."""
+    output = None
     with subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
@@ -336,9 +337,12 @@ def process_run(
     ) as proc:
         if not proc.stdout:
             return
+        output = ""
         for line in iter(proc.stdout.readline, ""):
             log_func(":: " + line.strip())
+            output += line
         ret = proc.wait()
 
     if ret:
+        # raise subprocess.CalledProcessError(ret, command, output=output)
         raise subprocess.CalledProcessError(ret, command)

--- a/tests/integration/overlays/test_chroot.py
+++ b/tests/integration/overlays/test_chroot.py
@@ -1,0 +1,105 @@
+import logging
+import os
+from textwrap import dedent
+
+import pytest
+
+from craft_parts import errors
+from craft_parts.overlays import chroot
+from craft_parts.overlays.errors import OverlayChrootExecutionError
+
+test_logger = logging.getLogger("craft_parts.fake_module")
+
+
+def call_in_chroot():
+    test_logger.info("Info message from 'inside' chroot")
+    test_logger.debug("Debug message from 'inside' chroot")
+    test_logger.warning("Warning message from 'inside' chroot")
+
+
+def error_in_chroot():
+    call_in_chroot()
+    raise errors.PartsError("Error from 'inside' chroot")
+
+
+@pytest.fixture
+def mock_get_pid(mocker):
+    """Mock for os.getpid() with a function that returns 0 for the first process
+    that calls it, 1 for the second process, etc."""
+    pids = {}
+    original_get_pid = os.getpid
+
+    def fake_get_pid():
+        real_value = original_get_pid()
+        return pids.setdefault(real_value, len(pids))
+
+    mocker.patch.object(os, "getpid", new=fake_get_pid)
+
+
+@pytest.fixture
+def mock_chroot(mocker):
+    """
+    Fixture that mocks chroot-related calls that we don't want to execute as
+    they possibly require root.
+
+    Note that the os.chroot() call is mocked, but the multiprocessing
+    infrastructure is in place - the callable passed to chroot.chroot() will be
+    called in a different process with its own logging.
+    """
+
+    # Mock chroot-related calls that we don't want to execute as they possibly
+    # require root
+    mocker.patch.object(chroot, "_setup_chroot")
+    mocker.patch.object(chroot, "_cleanup_chroot")
+    mocker.patch.object(os, "chroot")
+
+
+@pytest.fixture
+def logfile(tmp_path, caplog):
+    """Fixture that installs a log handler that writes to a file.
+
+    We check the contents of the file instead of the `caplog` records because of
+    the multiprocessing aspect of the chroot() call: we want to ensure that
+    messages are only logged once, which is hard to do with memory-based log
+    handlers. If the logfile has repeated lines, it means that both the "inner"
+    chrooted call _and_ the scaffolding code logged it (incorrectly).
+    """
+
+    logpath = tmp_path / "log.txt"
+    log = logging.getLogger()
+    handler = logging.FileHandler(logpath)
+    log.addHandler(handler)
+    caplog.set_level(logging.DEBUG)
+
+    yield logpath
+
+    log.removeHandler(handler)
+
+
+def get_expected_log(tmp_path, chroot_callable):
+    return dedent(
+        f"""\
+        [pid=0] parent process
+        [pid=0] set up chroot
+        [pid=1] child process: target={chroot_callable}
+        [pid=1] chroot to {tmp_path}
+        Info message from 'inside' chroot
+        Debug message from 'inside' chroot
+        Warning message from 'inside' chroot
+        [pid=0] clean up chroot
+        """
+    )
+
+
+def test_chroot_logging_success(tmp_path, mock_get_pid, mock_chroot, logfile):
+    """Test that messages logged by the callable passed to chroot() are captured."""
+    chroot.chroot(tmp_path, call_in_chroot)
+    assert logfile.read_text() == get_expected_log(tmp_path, call_in_chroot)
+
+
+def test_chroot_logging_error(tmp_path, mock_get_pid, mock_chroot, logfile):
+    """Test that messages logged by the callable passed to chroot() are captured,
+    even if the call fails."""
+    with pytest.raises(OverlayChrootExecutionError, match="Error from 'inside' chroot"):
+        chroot.chroot(tmp_path, error_in_chroot)
+    assert logfile.read_text() == get_expected_log(tmp_path, error_in_chroot)

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -170,7 +170,7 @@ class TestChroot:
         assert Path("foo.txt").read_text() == "func arg"
         assert mock_chdir.mock_calls == [call(Path("/some/path"))]
         assert mock_chroot.mock_calls == [call(Path("/some/path"))]
-        assert fake_conn.sent == (1337, None)
+        assert fake_conn.sent == (1337, None, [])
 
     def test_runner_error(self, new_dir, fake_conn, mock_chdir, mock_chroot):
         chroot._runner(
@@ -182,3 +182,4 @@ class TestChroot:
         assert fake_conn.sent[0] is None
         assert isinstance(fake_conn.sent[1], str)
         assert str(fake_conn.sent[1]) == "bummer"
+        assert len(fake_conn.sent[2]) == 0


### PR DESCRIPTION
The problem: log messages generated by the callable passed to `chroot()` are not being correctly "preserved" in the main process. This manifests itself by missing log messages from things like the installation of packages described in a part's overlay-packages.

This commit updates both chroot.chroot() and chroot._runner() to capture thee logged messages from the chrooted child process and return them to the parent one through their pipe. The parent process can then emit those log records in the usual path.

The integration tests "cheat" a bit because they don't actually call os.chroot(), as that needs a lot of setup, a base system to chroot into, root, etc. However, they use the rest of the multiprocessing infrastructure so they should be a reasonable approximation of real use cases.

Fixes #485

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
