### PR TITLE
partitions: validate usage of partitions in parts

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -30,7 +30,7 @@ from craft_parts.dirs import ProjectDirs
 from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo
 from craft_parts.overlays import LayerHash
-from craft_parts.parts import Part, part_by_name
+from craft_parts.parts import Part, part_by_name, validate_partition_usage
 from craft_parts.state_manager import states
 from craft_parts.steps import Step
 
@@ -149,6 +149,9 @@ class LifecycleManager:
             part_list.append(_build_part(name, spec, project_dirs, strict_mode))
 
         self._has_overlay = any(p.has_overlay for p in part_list)
+
+        if partitions:
+            validate_partition_usage(part_list, partitions)
 
         # a base layer is mandatory if overlays are in use
         if self._has_overlay:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -16,8 +16,9 @@
 
 """Definitions and helpers to handle parts."""
 
+import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from pydantic import BaseModel, Field, ValidationError, root_validator, validator
 
@@ -28,6 +29,7 @@ from craft_parts.packages import platform
 from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
+from craft_parts.utils.formatting_utils import humanize_list
 
 
 class PartSpec(BaseModel):
@@ -320,6 +322,61 @@ class Part:
         """Return whether this part declares overlay content."""
         return self.spec.has_overlay
 
+    def check_partition_usage(self, partitions: List[str]) -> List[str]:
+        """Check if partitions are properly used in a part.
+
+        :param partitions: The list of valid partitions.
+
+        :returns: A list of invalid uses of partitions in the part.
+        """
+        error_list: List[str] = []
+
+        if not Features().enable_partitions:
+            return error_list
+
+        for fileset_name, fileset in [
+            ("overlay", self.spec.overlay_files),
+            # only the destination of organize filepaths use partitions
+            ("organize", self.spec.organize_files.values()),
+            ("stage", self.spec.stage_files),
+            ("prime", self.spec.prime_files),
+        ]:
+            error_list.extend(
+                self._check_partitions_in_filepaths(fileset_name, fileset, partitions)
+            )
+
+        return error_list
+
+    def _check_partitions_in_filepaths(
+        self, fileset_name: str, fileset: Iterable[str], partitions: List[str]
+    ) -> List[str]:
+        """Check if partitions are properly used in a fileset.
+
+        If a filepath begins with a parentheses, then the text inside the parentheses
+        must be a valid partition.
+
+        :param fileset_name: The name of the fileset being checked.
+        :param fileset: The list of filepaths to check.
+        :param partitions: The list of valid partitions.
+
+        :returns: A list of invalid uses of partitions in the fileset.
+        """
+        error_list = []
+
+        for filepath in fileset:
+            match = re.match("^-?\\((?P<partition>.*?)\\)", filepath)
+            if match:
+                partition = match.group("partition")
+                if partition not in partitions:
+                    error_list.append(
+                        f"    unknown partition {partition!r} in {filepath!r}"
+                    )
+
+        if error_list:
+            error_list.insert(0, f"  parts -> {self.name} -> {fileset_name}")
+
+        return error_list
+
 
 def part_by_name(name: str, part_list: List[Part]) -> Part:
     """Obtain the part with the given name from the part list.
@@ -467,6 +524,33 @@ def validate_part(data: Dict[str, Any]) -> None:
     :param data: The part data to validate.
     """
     _get_part_spec(data)
+
+
+def validate_partition_usage(part_list: List[Part], partitions: List[str]) -> None:
+    """Validate usage of partitions in a list of parts.
+
+    For each part, the use of partitions in filepaths in overlay, stage, prime, and
+    organize keywords are validated.
+
+    :param part_list: The list of parts to validate.
+    :param partitions: The list of valid partitions.
+
+    :raises ValueError: If partitions are not used properly in the list of parts.
+    """
+    if not Features().enable_partitions:
+        return
+
+    error_list = []
+
+    for part in part_list:
+        error_list.extend(part.check_partition_usage(partitions))
+
+    if error_list:
+        raise ValueError(
+            "Error: Invalid usage of partitions:\n"
+            + "\n".join(error_list)
+            + f"\nValid partitions are {humanize_list(partitions, 'and')}."
+        )
 
 
 def part_has_overlay(data: Dict[str, Any]) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,18 @@ def enable_partitions_feature():
     Features.reset()
 
 
+@pytest.fixture
+def enable_all_features():
+    assert Features().enable_overlay is False
+    assert Features().enable_partitions is False
+    Features.reset()
+    Features(enable_overlay=True, enable_partitions=True)
+
+    yield
+
+    Features.reset()
+
+
 @pytest.fixture(autouse=True)
 def temp_xdg(tmpdir, mocker):
     """Use a temporary locaction for XDG directories."""

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -1,0 +1,215 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+import pytest
+
+from craft_parts import parts
+from craft_parts.parts import Part
+from tests.unit import test_parts
+
+
+class TestPartSpecs(test_parts.TestPartSpecs):
+    """Test part specification creation."""
+
+
+class TestPartData(test_parts.TestPartData):
+    """Test basic part creation and representation."""
+
+
+class TestPartOrdering(test_parts.TestPartOrdering):
+    """Test part ordering."""
+
+
+class TestPartUnmarshal(test_parts.TestPartUnmarshal):
+    """Verify data unmarshaling on part creation."""
+
+
+class TestPartHelpers(test_parts.TestPartHelpers):
+    """Test part-related helper functions."""
+
+
+class TestPartValidation(test_parts.TestPartValidation):
+    """Part validation considering plugin-specific attributes."""
+
+
+class TestPartPartitionUsage:
+    """Test usage of partitions in parts."""
+
+    @pytest.fixture
+    def partition_list(self):
+        """Return a list of partitions, 'default' and 'kernel'."""
+        return ["default", "kernel"]
+
+    @pytest.fixture
+    def valid_filesets(self):
+        """Return a list of valid filesets when the partition feature is enabled.
+
+        Assumes "default" and "partition" are valid partitions.
+        """
+        return [
+            "test",
+            "(default)",
+            "(default)/test",
+            "(default)/test/(otherdir)",
+            "(default)/test/(otherdir-123)",
+            "(default)/test/(default)",
+            "(default)/test/(kernel)",
+            "test(default)",
+            "test(default)/test",
+            "test/(default)/test",
+            "(kernel)",
+            "(kernel)/test",
+            "(kernel)/test/(otherdir)",
+            "(kernel)/test/(otherdir-123)",
+            "(kernel)/test/(default)",
+            "(kernel)/test/(kernel)",
+            "test/(kernel)",
+            "test(kernel)/test",
+        ]
+
+    @pytest.fixture
+    def invalid_filesets(self):
+        """Return a list of invalid filesets when the partition feature is enabled.
+
+        Assumes "default" and "partition" are the only valid partitions.
+        """
+        return [
+            "()",
+            "(foo)",
+            "(bar)/test",
+            "(baz)",
+            "(123)/test",
+            "(123)/test/(456)",
+            "(123)/test/(default)",
+            "(123)/test/(kernel)",
+        ]
+
+    def test_part_valid_partition_usage(self, valid_filesets, partition_list):
+        """Proper use of partitions in parts should not raise an error."""
+        part_data = {
+            "organize": {
+                f"test-{index}": item for index, item in enumerate(valid_filesets)
+            },
+            "stage": valid_filesets,
+            "prime": valid_filesets,
+        }
+
+        part_list = [Part("a", part_data), Part("b", part_data)]
+
+        assert not parts.validate_partition_usage(part_list, partition_list)
+
+    def test_part_invalid_partition_usage_simple(self, partition_list):
+        """Raise an error if partitions are improperly used in parts."""
+        part_data = {
+            "organize": {"test": "(foo)"},
+            "stage": ["(bar)/test"],
+            "prime": ["(baz)"],
+        }
+
+        with pytest.raises(ValueError) as raised:
+            parts.validate_partition_usage([Part("part-a", part_data)], partition_list)
+
+        assert str(raised.value) == dedent(
+            """\
+            Error: Invalid usage of partitions:
+              parts -> part-a -> organize
+                unknown partition 'foo' in '(foo)'
+              parts -> part-a -> stage
+                unknown partition 'bar' in '(bar)/test'
+              parts -> part-a -> prime
+                unknown partition 'baz' in '(baz)'
+            Valid partitions are 'default' and 'kernel'."""
+        )
+
+    def test_part_invalid_partition_usage_complex(
+        self, valid_filesets, invalid_filesets, partition_list
+    ):
+        """Raise an error if partitions are improperly used in parts."""
+        part_data = {
+            "organize": {
+                f"test-{index}": item
+                for index, item in enumerate(valid_filesets + invalid_filesets)
+            },
+            "stage": valid_filesets + invalid_filesets,
+            "prime": valid_filesets + invalid_filesets,
+        }
+
+        part_list = [Part("part-a", part_data), Part("part-b", part_data)]
+
+        with pytest.raises(ValueError) as raised:
+            parts.validate_partition_usage(part_list, partition_list)
+
+        assert str(raised.value) == dedent(
+            """\
+            Error: Invalid usage of partitions:
+              parts -> part-a -> organize
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-a -> stage
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-a -> prime
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> organize
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> stage
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> prime
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+            Valid partitions are 'default' and 'kernel'."""
+        )

--- a/tests/unit/features/test_parts.py
+++ b/tests/unit/features/test_parts.py
@@ -1,0 +1,215 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+import pytest
+
+from craft_parts import parts
+from craft_parts.parts import Part
+
+
+@pytest.mark.usefixtures("enable_all_features")
+class TestPartPartitionUsage:
+    """Test usage of partitions in parts with overlays enabled."""
+
+    @pytest.fixture
+    def partition_list(self):
+        """Return a list of partitions, 'default' and 'kernel'."""
+        return ["default", "kernel"]
+
+    @pytest.fixture
+    def valid_filesets(self):
+        """Return a list of valid filesets when the partition feature is enabled.
+
+        Assumes "default" and "partition" are valid partitions.
+        """
+        return [
+            "test",
+            "(default)",
+            "(default)/test",
+            "(default)/test/(otherdir)",
+            "(default)/test/(otherdir-123)",
+            "(default)/test/(default)",
+            "(default)/test/(kernel)",
+            "test(default)",
+            "test(default)/test",
+            "test/(default)/test",
+            "(kernel)",
+            "(kernel)/test",
+            "(kernel)/test/(otherdir)",
+            "(kernel)/test/(otherdir-123)",
+            "(kernel)/test/(default)",
+            "(kernel)/test/(kernel)",
+            "test/(kernel)",
+            "test(kernel)/test",
+        ]
+
+    @pytest.fixture
+    def invalid_filesets(self):
+        """Return a list of invalid filesets when the partition feature is enabled.
+
+        Assumes "default" and "partition" are the only valid partitions.
+        """
+        return [
+            "()",
+            "(foo)",
+            "(bar)/test",
+            "(baz)",
+            "(123)/test",
+            "(123)/test/(456)",
+            "(123)/test/(default)",
+            "(123)/test/(kernel)",
+        ]
+
+    def test_part_valid_partition_usage(self, valid_filesets, partition_list):
+        """Proper use of partitions in parts should not raise an error."""
+        part_data = {
+            "organize": {
+                f"test-{index}": item for index, item in enumerate(valid_filesets)
+            },
+            "overlay": valid_filesets,
+            "stage": valid_filesets,
+            "prime": valid_filesets,
+        }
+
+        part_list = [Part("a", part_data), Part("b", part_data)]
+
+        assert not parts.validate_partition_usage(part_list, partition_list)
+
+    def test_part_invalid_partition_usage_simple(self, partition_list):
+        """Raise an error if partitions are improperly used in parts."""
+        # simple example with a few violations
+        part_data = {
+            "organize": {"test": "(foo)/test"},
+            "overlay": ["(bar)/test"],
+            "stage": ["(baz)/test"],
+            "prime": ["(123)/test"],
+        }
+
+        with pytest.raises(ValueError) as raised:
+            parts.validate_partition_usage([Part("part-a", part_data)], partition_list)
+
+        assert str(raised.value) == dedent(
+            """\
+            Error: Invalid usage of partitions:
+              parts -> part-a -> overlay
+                unknown partition 'bar' in '(bar)/test'
+              parts -> part-a -> organize
+                unknown partition 'foo' in '(foo)/test'
+              parts -> part-a -> stage
+                unknown partition 'baz' in '(baz)/test'
+              parts -> part-a -> prime
+                unknown partition '123' in '(123)/test'
+            Valid partitions are 'default' and 'kernel'."""
+        )
+
+    def test_part_invalid_partition_usage_complex(
+        self, valid_filesets, invalid_filesets, partition_list
+    ):
+        """Raise an error if partitions are improperly used in parts."""
+        part_data = {
+            "organize": {
+                f"test-{index}": item
+                for index, item in enumerate(valid_filesets + invalid_filesets)
+            },
+            "overlay": valid_filesets + invalid_filesets,
+            "stage": valid_filesets + invalid_filesets,
+            "prime": valid_filesets + invalid_filesets,
+        }
+
+        part_list = [Part("part-a", part_data), Part("part-b", part_data)]
+
+        with pytest.raises(ValueError) as raised:
+            parts.validate_partition_usage(part_list, partition_list)
+
+        assert str(raised.value) == dedent(
+            """\
+            Error: Invalid usage of partitions:
+              parts -> part-a -> overlay
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-a -> organize
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-a -> stage
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-a -> prime
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> overlay
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> organize
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> stage
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+              parts -> part-b -> prime
+                unknown partition '' in '()'
+                unknown partition 'foo' in '(foo)'
+                unknown partition 'bar' in '(bar)/test'
+                unknown partition 'baz' in '(baz)'
+                unknown partition '123' in '(123)/test'
+                unknown partition '123' in '(123)/test/(456)'
+                unknown partition '123' in '(123)/test/(default)'
+                unknown partition '123' in '(123)/test/(kernel)'
+            Valid partitions are 'default' and 'kernel'."""
+        )

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -118,6 +118,23 @@ class TestPartSpecs:
             PartSpec.unmarshal(data)
 
 
+class TestPartPartitionUsage:
+    """Test usage of partitions in parts."""
+
+    def test_part_invalid_partition_usage_no_error(self):
+        """Do not error for invalid partition usage when the feature is disabled."""
+        # if partitions were enabled, this would raise a ValueError
+        part_data = {
+            "organize": {"test": "(foo)"},
+            "stage": ["(bar)/test"],
+            "prime": ["(baz)"],
+        }
+
+        part_list = [Part("a", part_data), Part("b", part_data)]
+
+        assert not parts.validate_partition_usage(part_list, ["default", "kernel"])
+
+
 class TestPartData:
     """Test basic part creation and representation."""
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Validate usage of partitions in filepaths listed in the `organize`, `overlay`, `stage`, and `prime` keywords for parts.

(CRAFT-1844)