### PR TITLE
tests: add jammy packages to stage package apt cache

### DIFF
--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -63,6 +63,9 @@ class TestAptStageCache:
                 "pci.ids",
                 "perl-base",
                 "tar",
+                # dependencies in jammy
+                "gcc-13-base",
+                "libgcc-s1",
             }
 
             cache.mark_packages(package_names)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This week, a unit test started [failing](https://github.com/canonical/craft-parts/actions/runs/5536668539/jobs/10119585228?pr=493#step:8:179) on the Ubuntu 22.04 CI runner:
```
FAILED tests/unit/packages/test_apt_cache.py::TestAptStageCache::test_stage_packages - AssertionError: assert ['gcc-13-base...', 'pciutils'] == ['libpci3', 'pciutils']
  At index 0 diff: 'gcc-13-base' != 'libpci3'
  Left contains 2 more items, first extra item: 'libpci3'
  Full diff:
  - ['libpci3', 'pciutils']
  + ['gcc-13-base', 'libgcc-s1', 'libpci3', 'pciutils']
```

I'm not sure what changed or if this is the right solution...