### PR TITLE
sequencer: only load project vars in adopting part (#509)

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -174,6 +174,11 @@ class ProjectInfo:
         return self._project_name
 
     @property
+    def project_vars_part_name(self) -> Optional[str]:
+        """Return the name of the part that can set project vars."""
+        return self._project_vars_part_name
+
+    @property
     def project_options(self) -> Dict[str, Any]:
         """Obtain a project-wide options dictionary."""
         return {

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -200,8 +200,15 @@ class Sequencer:
             current_step,
             action_type=ActionType.SKIP,
             reason="already ran",
-            project_vars=self._sm.project_vars(part, current_step),
+            project_vars=self._get_project_vars(part, current_step),
         )
+
+    def _get_project_vars(
+        self, part: Part, step: Step
+    ) -> Optional[Dict[str, ProjectVar]]:
+        if part.name == self._project_info.project_vars_part_name:
+            return self._sm.project_vars(part, step)
+        return None
 
     def _process_dependencies(self, part: Part, step: Step) -> None:
         prerequisite_step = steps.dependency_prerequisite_step(step)

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -68,6 +68,7 @@ def test_project_info(mocker, new_dir, tc_arch, tc_target_arch, tc_triplet, tc_c
         "project_vars_part_name": "adopt",
         "project_vars": {"a": ProjectVar(value="b")},
     }
+    assert x.project_vars_part_name == "adopt"
     assert x.global_environment == {}
 
     assert x.parts_dir == new_dir / "parts"


### PR DESCRIPTION
Project variables exist only in the part scope and should be ignored
in other parts' states. In the existing implementation these values
are persisted in each part, which leads to double assignment errors
when a step is executed for parts in a order that's different from
the previous execution (see example in LP #1831135).

There are different ways to address this issue, the current fix
tries to be minimally disruptive by just ignoring persisted values
when reloading the state. We can refactor this code later to have
a cleaner implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
