### PR TITLE
executor: add prologue INFO-level log messages

### DIFF
--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -233,7 +233,7 @@ class Executor:
         if self._extra_build_packages:
             build_packages.update(self._extra_build_packages)
 
-        logger.info("Installing requested build-packages")
+        logger.info("Installing build-packages")
         packages.Repository.install_packages(sorted(build_packages))
 
     def _install_build_snaps(self) -> None:
@@ -257,7 +257,7 @@ class Executor:
                 ", ".join(build_snaps),
             )
         else:
-            logger.info("Installing requested build-snaps")
+            logger.info("Installing build-snaps")
             packages.snaps.install_snaps(build_snaps)
 
     def _verify_plugin_environment(self) -> None:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -94,6 +94,7 @@ class Executor:
         # update the overlay environment package list to allow installation of
         # overlay packages.
         if any(p.spec.overlay_packages for p in self._part_list):
+            logger.info("Updating base overlay system")
             with overlays.PackageCacheMount(self._overlay_manager) as ctx:
                 callbacks.run_configure_overlay(
                     self._project_info.overlay_mount_dir, self._project_info
@@ -232,6 +233,7 @@ class Executor:
         if self._extra_build_packages:
             build_packages.update(self._extra_build_packages)
 
+        logger.info("Installing requested build-packages")
         packages.Repository.install_packages(sorted(build_packages))
 
     def _install_build_snaps(self) -> None:
@@ -255,6 +257,7 @@ class Executor:
                 ", ".join(build_snaps),
             )
         else:
+            logger.info("Installing requested build-snaps")
             packages.snaps.install_snaps(build_snaps)
 
     def _verify_plugin_environment(self) -> None:

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -892,7 +892,7 @@ class PartHandler:
             return None
 
         try:
-            logger.info("Fetching requested stage-packages")
+            logger.info("Fetching stage-packages")
             fetched_packages = packages.Repository.fetch_stage_packages(
                 cache_dir=step_info.cache_dir,
                 package_names=stage_packages,

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -892,6 +892,7 @@ class PartHandler:
             return None
 
         try:
+            logger.info("Fetching requested stage-packages")
             fetched_packages = packages.Repository.fetch_stage_packages(
                 cache_dir=step_info.cache_dir,
                 package_names=stage_packages,

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -42,10 +42,6 @@ def test_logging_info(new_dir, caplog, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["build"])
     monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
 
-    import subprocess
-    result = subprocess.check_output(["snap", "list"]).decode()
-    assert 0, result
-
     main.main()
 
     assert "Installing build-packages" in caplog.text

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -26,6 +26,9 @@ parts_yaml = textwrap.dedent(
       foo:
         plugin: nil
         build-packages: [libc6]
+        # Note that this will fail if pyright is not already installed and the
+        # test is executed as a regular user
+        build-snaps: [pyright] 
         stage-packages: [hello]
     """
 )
@@ -41,5 +44,6 @@ def test_logging_info(new_dir, caplog, monkeypatch):
 
     main.main()
 
-    assert "Installing requested build-packages" in caplog.text
-    assert "Fetching requested stage-packages" in caplog.text
+    assert "Installing build-packages" in caplog.text
+    assert "Installing build-snaps" in caplog.text
+    assert "Fetching stage-packages" in caplog.text

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -42,6 +42,10 @@ def test_logging_info(new_dir, caplog, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["build"])
     monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
 
+    import subprocess
+    result = subprocess.check_output(["snap", "list"]).decode()
+    assert 0, result
+
     main.main()
 
     assert "Installing build-packages" in caplog.text

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -26,9 +26,9 @@ parts_yaml = textwrap.dedent(
       foo:
         plugin: nil
         build-packages: [libc6]
-        # Note that this will fail if pyright is not already installed and the
+        # Note that this will fail if core20 is not already installed and the
         # test is executed as a regular user
-        build-snaps: [pyright] 
+        build-snaps: [core20] 
         stage-packages: [hello]
     """
 )

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import logging
+import sys
+import textwrap
+from pathlib import Path
+
+from craft_parts import main
+
+parts_yaml = textwrap.dedent(
+    """
+    parts:
+      foo:
+        plugin: nil
+        build-packages: [libc6]
+        stage-packages: [hello]
+    """
+)
+
+
+def test_logging_info(new_dir, caplog, monkeypatch):
+    """Test some expected INFO-level log messages from whole-program execution."""
+    caplog.set_level(logging.INFO, logger="craft_parts")
+    Path("parts.yaml").write_text(parts_yaml)
+
+    monkeypatch.setattr(sys, "argv", ["build"])
+    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
+
+    main.main()
+
+    assert "Installing requested build-packages" in caplog.text
+    assert "Fetching requested stage-packages" in caplog.text


### PR DESCRIPTION
Add informational messages to distinguish when we're installing build-packages, installing build-snaps, updating the overlay base system and fetching stage-packages, as these are potentially time-consuming operations and with the exception of fetching the stage-packages they all happen before we even start executing lifecycle steps.

Fixes #508

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
