### PR TITLE
tests: add jammy packages to stage package apt cache (#494)

### DIFF
--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -63,6 +63,9 @@ class TestAptStageCache:
                 "pci.ids",
                 "perl-base",
                 "tar",
+                # dependencies in jammy
+                "gcc-13-base",
+                "libgcc-s1",
             }
 
             cache.mark_packages(package_names)


### PR DESCRIPTION
New packages are marked for installation on Jammy - see #495

(cherry picked from commit dcdab5926caecd1848b6c3c0db9decf8f8ed02cd)

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
