### PR TITLE
plugins/rust_plugin: rewrite the plugin to improve UX

### DIFF
--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -14,9 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The rust plugin."""
+"""The craft Rust plugin."""
 
 import logging
+import subprocess
+from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, cast
 
 from overrides import override
@@ -30,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 # A workaround for mypy false positives
 # see https://github.com/samuelcolvin/pydantic/issues/975#issuecomment-551147305
+# The proper fix requires Python 3.9+ (needs `typing.Annotated`)
 if TYPE_CHECKING:
     UniqueStrList = List[str]
 else:
@@ -37,12 +40,16 @@ else:
 
 
 class RustPluginProperties(PluginProperties, PluginModel):
-    """The part properties used by the rust plugin."""
+    """The part properties used by the Rust plugin."""
 
     # part properties required by the plugin
     rust_features: UniqueStrList = []
     rust_path: UniqueStrList = ["."]
+    rust_channel: Optional[str] = None
+    rust_use_global_lto: bool = False
+    rust_no_default_features: bool = False
     source: str
+    after: Optional[UniqueStrList] = None
 
     @classmethod
     @override
@@ -56,7 +63,9 @@ class RustPluginProperties(PluginProperties, PluginModel):
         :raise pydantic.ValidationError: If validation fails.
         """
         plugin_data = extract_plugin_properties(
-            data, plugin_name="rust", required=["source"]
+            data,
+            plugin_name="rust",
+            required=["source"],
         )
         return cls(**plugin_data)
 
@@ -76,28 +85,62 @@ class RustPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
 
         :param part_dependencies: A list of the parts this part depends on.
         """
-        for dependency in ["cargo", "rustc"]:
-            self.validate_dependency(
-                dependency=dependency,
-                plugin_name="rust",
-                part_dependencies=part_dependencies,
-            )
+        if "rust-deps" in (part_dependencies or []):
+            options = cast(RustPluginProperties, self._options)
+            if options.rust_channel:
+                raise validator.errors.PluginEnvironmentValidationError(
+                    part_name=self._part_name,
+                    reason="rust-deps can not be used"
+                    "when rust-channel is also specified",
+                )
+            for dependency in ["cargo", "rustc"]:
+                self.validate_dependency(
+                    dependency=dependency,
+                    plugin_name="rust",
+                    part_dependencies=part_dependencies,
+                )
+            options.rust_channel = "none"
 
 
 class RustPlugin(Plugin):
-    """A plugin for rust projects.
+    """A craft plugin for Rust applications.
+
+    This Rust plugin is useful for building Rust based parts.
+
+    Rust uses cargo to drive the build.
 
     This plugin uses the common plugin keywords as well as those for "sources".
     For more information check the 'plugins' topic for the former and the
     'sources' topic for the latter.
 
     Additionally, this plugin uses the following plugin-specific keywords:
+        - rust-channel
+          (string, default "stable")
+          Used to select which Rust channel or version to use.
+          It can be one of "stable", "beta", "nightly" or a version number.
+          If you don't want this plugin to install Rust toolchain for you,
+          you can put "none" for this option.
+
         - rust-features
-          (list of unique strings; default: [])
-          List of rust features to install.
+          (list of strings)
+          Features used to build optional dependencies
+
         - rust-path
-          (list of unique strings; default: ["."])
-          Path of rust project. Currently, only the first path in the list is used.
+          (list of strings, default [.])
+          Build specific crates inside the workspace
+
+        - rust-no-default-features
+          (boolean, default False)
+          Whether to disable the default features in this crate.
+          Equivalent to setting `--no-default-features` on the commandline.
+
+        - rust-use-global-lto
+          (boolean, default False)
+          Whether to use global LTO.
+          This option may significantly impact the build performance but
+          reducing the final binary size.
+          This will forcibly enable LTO for all the crates you specified,
+          regardless of whether you have LTO enabled in the Cargo.toml file
     """
 
     properties_class = RustPluginProperties
@@ -111,32 +154,107 @@ class RustPlugin(Plugin):
     @override
     def get_build_packages(self) -> Set[str]:
         """Return a set of required packages to install in the build environment."""
-        return {"gcc", "git"}
+        return {"curl", "gcc", "git", "pkg-config", "findutils"}
+
+    def _check_system_rust(self) -> bool:
+        """Check if Rust is installed on the system."""
+        try:
+            rust_version = subprocess.check_output(["rustc", "--version"], text=True)
+            cargo_version = subprocess.check_output(["cargo", "--version"], text=True)
+            return "rustc" in rust_version and "cargo" in cargo_version
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    def _check_rustup(self) -> bool:
+        try:
+            rustup_version = subprocess.check_output(["rustup", "--version"])
+            return "rustup" in rustup_version.decode("utf-8")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    def _get_setup_rustup(self, channel: str) -> List[str]:
+        return [
+            f"""\
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+sh -s -- -y --no-modify-path --profile=minimal --default-toolchain {channel}
+"""
+        ]
 
     @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
-        return {"PATH": "${HOME}/.cargo/bin:${PATH}"}
+        return {
+            "PATH": "${HOME}/.cargo/bin:${PATH}",
+        }
+
+    @override
+    def get_pull_commands(self) -> List[str]:
+        """Return a list of commands to run during the pull step."""
+        options = cast(RustPluginProperties, self._options)
+        if not options.rust_channel and self._check_system_rust():
+            logger.info("Rust is installed on the system, skipping rustup")
+            return []
+
+        rust_channel = options.rust_channel or "stable"
+        if rust_channel == "none":
+            return []
+        if not self._check_rustup():
+            logger.info("Rustup not found, installing it")
+            return self._get_setup_rustup(rust_channel)
+        logger.info("Switch rustup channel to %s", rust_channel)
+        return [
+            f"rustup update {rust_channel}",
+            f"rustup default {rust_channel}",
+        ]
 
     @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
         options = cast(RustPluginProperties, self._options)
 
-        install_command_list = [
-            "cargo",
-            "install",
-            "--locked",
-            "--path",
-            options.rust_path[0],  # TODO: support more than 1 path
-            "--root",
-            '"${CRAFT_PART_INSTALL}"',
-            "--force",
-        ]
+        rust_build_cmd: List[str] = []
+        config_cmd: List[str] = []
 
         if options.rust_features:
-            install_command_list.extend(
-                ["--features", f"'{' '.join(options.rust_features)}'"]
+            features_string = " ".join(options.rust_features)
+            config_cmd.extend(["--features", f"'{features_string}'"])
+
+        if options.rust_use_global_lto:
+            logger.info("Adding overrides for LTO support")
+            config_cmd.extend(
+                [
+                    "--config 'profile.release.lto = true'",
+                    "--config 'profile.release.codegen-units = 1'",
+                ]
             )
 
-        return [" ".join(install_command_list)]
+        if options.rust_no_default_features:
+            config_cmd.append("--no-default-features")
+
+        for crate in options.rust_path:
+            logger.info("Generating build commands for %s", crate)
+            config_cmd_string = " ".join(config_cmd)
+            # TODO(liushuyu): the current fallback installation method will also install
+            # compiler plugins into the final Snap, which is likely not what we want.
+            # pylint: disable=line-too-long
+            rust_build_cmd_single = dedent(
+                f"""\
+                if cargo read-manifest --manifest-path "{crate}"/Cargo.toml > /dev/null; then
+                    cargo install -f --locked --path "{crate}" --root "{self._part_info.part_install_dir}" {config_cmd_string}
+                    # remove the installation metadata
+                    rm -f "{self._part_info.part_install_dir}"/.crates{{.toml,2.json}}
+                else
+                    # virtual workspace is a bit tricky,
+                    # we need to build the whole workspace and then copy the binaries ourselves
+                    pushd "{crate}"
+                    cargo build --workspace --release {config_cmd_string}
+                    # install the final binaries
+                    # TODO(liushuyu): this will also install proc macros in the workspace,
+                    # which the user may not want to keep in the final installation
+                    find ./target/release -maxdepth 1 -executable -exec install -Dvm755 {{}} "{self._part_info.part_install_dir}" ';'
+                    popd
+                fi\
+                """
+            )
+            rust_build_cmd.append(rust_build_cmd_single)
+        return rust_build_cmd

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -29,7 +29,7 @@ from craft_parts.utils import os_utils
 IS_CI: bool = os.getenv("CI") == "true"
 
 # These are the Ubuntu versions that Chisel currently supports.
-SUPPORTED_UBUNTU_VERSIONS = {"22.04", "22.10"}
+SUPPORTED_UBUNTU_VERSIONS = {"20.04", "22.04", "22.10"}
 
 
 def _current_release_supported() -> bool:

--- a/tests/unit/plugins/test_rust_plugin.py
+++ b/tests/unit/plugins/test_rust_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,7 +17,7 @@
 import pytest
 from pydantic import ValidationError
 
-from craft_parts import errors
+from craft_parts.errors import PluginEnvironmentValidationError
 from craft_parts.infos import PartInfo, ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.plugins.rust_plugin import RustPlugin
@@ -31,210 +31,171 @@ def part_info(new_dir):
     )
 
 
-class TestPluginRustPlugin:
-    """Rust plugin tests."""
+def test_get_build_snaps(part_info):
+    properties = RustPlugin.properties_class.unmarshal({"source": "."})
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    assert plugin.get_build_snaps() == set()
 
-    def test_validate_environment(self, dependency_fixture, part_info):
-        cargo = dependency_fixture("cargo")
-        rustc = dependency_fixture("rustc")
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(
-            part_name="my-part",
-            env=f"PATH={str(cargo.parent)}:{str(rustc.parent)}",
-            properties=properties,
-        )
-        validator.validate_environment()
+def test_get_build_packages(part_info):
+    properties = RustPlugin.properties_class.unmarshal({"source": "."})
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    assert plugin.get_build_packages() == {
+        "curl",
+        "gcc",
+        "git",
+        "pkg-config",
+        "findutils",
+    }
 
-    @pytest.mark.parametrize(
-        "dependencies",
-        [
-            ("cargo", ["rustc"]),
-            ("rustc", ["cargo"]),
-        ],
+
+def test_get_build_environment(part_info):
+    properties = RustPlugin.properties_class.unmarshal({"source": "."})
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+
+    assert plugin.get_build_environment() == {"PATH": "${HOME}/.cargo/bin:${PATH}"}
+
+
+def test_get_build_commands_default(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-channel": "stable"}
     )
-    def test_validate_environment_missing_dependencies(
-        self, dependencies, dependency_fixture, part_info
-    ):
-        """Validate that missing dependencies raise an exception.
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: False
 
-        :param dependencies: tuple consisting of 1 missing dependency
-        and a list of valid dependencies
-        """
-        missing_dependency_name, valid_dependency_names = dependencies
-        path = "PATH="
-
-        for valid_dependencies_name in valid_dependency_names:
-            valid_dependency = dependency_fixture(valid_dependencies_name)
-            path += f":{str(valid_dependency.parent)}"
-
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        validator = plugin.validator_class(
-            part_name="my-part", env=path, properties=properties
-        )
-        with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
-            validator.validate_environment()
-
-        assert raised.value.reason == f"'{missing_dependency_name}' not found"
-
-    @pytest.mark.parametrize(
-        "dependencies",
-        [
-            ("cargo", ["rustc"]),
-            ("rustc", ["cargo"]),
-        ],
+    commands = plugin.get_build_commands()
+    assert (
+        plugin.get_pull_commands()[0]
+        == """curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+sh -s -- -y --no-modify-path --profile=minimal --default-toolchain stable
+"""
     )
-    def test_validate_environment_broken_dependencies(
-        self, dependencies, dependency_fixture, part_info
-    ):
-        """Validate that broken dependencies raise an exception.
+    assert 'cargo install -f --locked --path "."' in commands[0]
 
-        :param dependencies: tuple consisting of 1 broken dependency
-        and a list of valid dependencies
-        """
-        broken_dependency_name, valid_dependency_names = dependencies
-        broken_dependency = dependency_fixture(broken_dependency_name, broken=True)
-        path = f"PATH={str(broken_dependency.parent)}"
 
-        for valid_dependencies_name in valid_dependency_names:
-            valid_dependency = dependency_fixture(valid_dependencies_name)
-            path += f":{str(valid_dependency.parent)}"
+def test_get_build_commands_no_install(part_info):
+    def _check_rustup():
+        raise RuntimeError("should not be called")
 
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-channel": "none"}
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = _check_rustup
 
-        validator = plugin.validator_class(
-            part_name="my-part", env=path, properties=properties
-        )
-        with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
-            validator.validate_environment()
+    commands = plugin.get_build_commands()
+    assert len(commands) == 1
+    assert plugin.get_pull_commands() == []
+    assert 'cargo install -f --locked --path "."' in commands[0]
 
-        assert (
-            raised.value.reason
-            == f"'{broken_dependency_name}' failed with error code 33"
-        )
 
-    def test_validate_environment_part_dependencies(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
+def test_get_build_commands_use_lto(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-use-global-lto": True, "rust-channel": "stable"}
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: True
 
-        validator = plugin.validator_class(
-            part_name="my-part", env="PATH=/foo", properties=properties
-        )
+    commands = plugin.get_build_commands()
+    assert len(commands) == 1
+    assert "curl" not in plugin.get_pull_commands()[0]
+    assert 'cargo install -f --locked --path "."' in commands[0]
+    assert "--config 'profile.release.lto = true'" in commands[0]
+
+
+def test_get_build_commands_multiple_crates(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-path": ["a", "b", "c"], "rust-channel": "stable"}
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: True
+
+    commands = plugin.get_build_commands()
+    assert len(commands) == 3
+    assert "curl" not in plugin.get_pull_commands()[0]
+    assert 'cargo install -f --locked --path "a"' in commands[0]
+    assert 'cargo install -f --locked --path "b"' in commands[1]
+    assert 'cargo install -f --locked --path "c"' in commands[2]
+
+
+def test_get_build_commands_multiple_features(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-features": ["ft-a", "ft-b"], "rust-channel": "stable"}
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: True
+
+    commands = plugin.get_build_commands()
+    assert len(commands) == 1
+    assert "curl" not in plugin.get_pull_commands()[0]
+    assert 'cargo install -f --locked --path "."' in commands[0]
+    assert "--features 'ft-a ft-b'" in commands[0]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "stable",
+        "nightly",
+        "beta",
+        "1.65",
+        "1.71.1",
+        "nightly-2022-12-01",
+        "stable-x86_64-fortanix-unknown-sgx",
+        "nightly-2023-06-14-aarch64-nintendo-switch-freestanding",
+    ],
+)
+def test_get_build_commands_different_channels(part_info, value):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "rust-channel": value}
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: False
+    commands = plugin.get_build_commands()
+    assert len(commands) == 1
+    assert f"--default-toolchain {value}" in plugin.get_pull_commands()[0]
+
+
+@pytest.mark.parametrize(
+    "rust_path",
+    [None, "i am a string", {"i am": "a dictionary"}, ["duplicate", "duplicate"]],
+)
+def test_get_build_commands_rust_path_invalid(rust_path, part_info):
+    with pytest.raises(ValidationError):
+        RustPlugin.properties_class.unmarshal({"source": ".", "rust-path": rust_path})
+
+
+def test_error_on_conflict_config(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {
+            "source": ".",
+            "rust-path": ["a", "b", "c"],
+            "after": ["rust-deps"],
+            "rust-channel": "stable",
+        }
+    )
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    validator = plugin.validator_class(
+        part_name="my-part", properties=properties, env=""
+    )
+    with pytest.raises(PluginEnvironmentValidationError):
         validator.validate_environment(part_dependencies=["rust-deps"])
 
-    @pytest.mark.parametrize(
-        "satisfied_dependency,error_dependency",
-        [
-            ("cargo", "rustc"),
-            ("rustc", "cargo"),
-        ],
+
+def test_get_pull_commands_compat(part_info):
+    properties = RustPlugin.properties_class.unmarshal(
+        {"source": ".", "after": ["rust-deps"]}
     )
-    def test_validate_environment_missing_part_dependencies(
-        self,
-        satisfied_dependency,
-        error_dependency,
-        dependency_fixture,
-        new_dir,
-        part_info,
-    ):
-        """Validate that missing part dependencies raise an exception.
+    plugin = RustPlugin(properties=properties, part_info=part_info)
+    plugin._check_rustup = lambda: False
 
-        :param dependencies: tuple consisting of 1 missing part dependency
-        and a list of valid part dependencies
-        """
-        dependency = dependency_fixture(name=satisfied_dependency)
+    commands = plugin.get_build_commands()
+    assert plugin.get_pull_commands() == []
+    assert 'cargo install -f --locked --path "."' in commands[0]
 
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        validator = plugin.validator_class(
-            part_name="my-part",
-            properties=properties,
-            env=f"PATH={str(dependency.parent)}",
-        )
-        with pytest.raises(errors.PluginEnvironmentValidationError) as raised:
-            validator.validate_environment(part_dependencies=[])
+def test_get_out_of_source_build(part_info):
+    properties = RustPlugin.properties_class.unmarshal({"source": "."})
+    plugin = RustPlugin(properties=properties, part_info=part_info)
 
-        assert raised.value.reason == (
-            f"{error_dependency!r} not found and part 'my-part' "
-            "does not depend on a part named 'rust-deps' that "
-            "would satisfy the dependency"
-        )
-
-    def test_get_build_snaps(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-        assert plugin.get_build_snaps() == set()
-
-    def test_get_build_packages(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-        assert plugin.get_build_packages() == {"gcc", "git"}
-
-    def test_get_build_environment(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        assert plugin.get_build_environment() == {
-            "PATH": "${HOME}/.cargo/bin:${PATH}",
-        }
-
-    def test_get_build_commands(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        assert plugin.get_build_commands() == [
-            'cargo install --locked --path . --root "${CRAFT_PART_INSTALL}" --force',
-        ]
-
-    def test_get_build_commands_rust_features(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal(
-            {"source": ".", "rust-features": ["test-feature-1", "test-feature-2"]}
-        )
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        assert plugin.get_build_commands() == [
-            'cargo install --locked --path . --root "${CRAFT_PART_INSTALL}" --force '
-            "--features 'test-feature-1 test-feature-2'",
-        ]
-
-    @pytest.mark.parametrize(
-        "rust_features",
-        [None, "i am a string", {"i am": "a dictionary"}, ["duplicate", "duplicate"]],
-    )
-    def test_get_build_commands_rust_features_invalid(self, rust_features, part_info):
-        with pytest.raises(ValidationError):
-            RustPlugin.properties_class.unmarshal(
-                {"source": ".", "rust-features": rust_features}
-            )
-
-    def test_get_build_commands_rust_path(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal(
-            {"source": ".", "rust-path": ["test-path-1", "test-path-2"]}
-        )
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        assert plugin.get_build_commands() == [
-            "cargo install --locked --path test-path-1"
-            ' --root "${CRAFT_PART_INSTALL}" --force',
-        ]
-
-    @pytest.mark.parametrize(
-        "rust_path",
-        [None, "i am a string", {"i am": "a dictionary"}, ["duplicate", "duplicate"]],
-    )
-    def test_get_build_commands_rust_path_invalid(self, rust_path, part_info):
-        with pytest.raises(ValidationError):
-            RustPlugin.properties_class.unmarshal(
-                {"source": ".", "rust-path": rust_path}
-            )
-
-    def test_get_out_of_source_build(self, part_info):
-        properties = RustPlugin.properties_class.unmarshal({"source": "."})
-        plugin = RustPlugin(properties=properties, part_info=part_info)
-
-        assert plugin.get_out_of_source_build() is False
+    assert plugin.get_out_of_source_build() is False


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The new plugin will install the Rustup toolchain by default (opt-out possible) and also makes it more intelligent.

Three new options have been added:

- One option for enabling LTO (more optimized binary)
- One option for specifying Rust toolchain channel/version
- One option for disabling default features in the Rust crate