### PR TITLE
packages: don't write info logs in overlays

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -931,6 +931,7 @@ class PartHandler:
 
         try:
             with overlays.PackageCacheMount(self._overlay_manager) as ctx:
+                logger.info("Fetching overlay-packages")
                 ctx.download_packages(overlay_packages)
         except packages_errors.PackageNotFound as err:
             raise errors.OverlayPackageNotFound(

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -479,7 +479,7 @@ class Ubuntu(BaseRepository):
     @classmethod
     def download_packages(cls, package_names: List[str]) -> None:
         """Download the specified packages to the local package cache area."""
-        logger.info("Downloading packages: %s", " ".join(package_names))
+        logger.debug("Downloading packages: %s", " ".join(package_names))
         env = os.environ.copy()
         env.update(
             {


### PR DESCRIPTION
This commit is a workaround for a current bad interaction between the way we perform overlay operations (a chroot in a multiprocess-created subprocess) and the way craft applications indicate progress on the cli (a spinner in a thread).

The consequence of the bad interaction is that trying to write an info message to the terminal ends up deadlocking the main thread in the subprocess because the thread that could unblock it does not exist.

Instead, log the message as 'debug' instead of 'info', and add a main- process-side 'info' message to communicate that overlay packages are being fetched.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
