### PR TITLE
fix(environment): sort project variables before replacement

### DIFF
--- a/tests/integration/executor/test_environment.py
+++ b/tests/integration/executor/test_environment.py
@@ -179,3 +179,52 @@ def test_expand_environment(new_dir, mocker):
         ctx.execute(actions)
 
     assert (lf.project_info.prime_dir / "usr/aarch64-linux-gnu/bar").is_file()
+
+
+def test_expand_environment_order(new_dir, mocker):
+    """The largest replacements should occur first.
+
+    $CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR} should be replaced before $CRAFT_ARCH_TRIPLET
+    """
+    mocker.patch("platform.machine", return_value="aarch64")
+    parts_yaml = """\
+        parts:
+          foo:
+            plugin: nil
+            override-build: |
+                cat << EOF >> $CRAFT_PART_INSTALL/part-variables.txt
+                CRAFT_ARCH_TRIPLET_1: $CRAFT_ARCH_TRIPLET
+                CRAFT_ARCH_TRIPLET_2: ${CRAFT_ARCH_TRIPLET}
+                CRAFT_ARCH_TRIPLET_BUILD_FOR_1: $CRAFT_ARCH_TRIPLET_BUILD_FOR
+                CRAFT_ARCH_TRIPLET_BUILD_FOR_2: ${CRAFT_ARCH_TRIPLET_BUILD_FOR}
+                CRAFT_ARCH_TRIPLET_BUILD_ON_1: $CRAFT_ARCH_TRIPLET_BUILD_ON
+                CRAFT_ARCH_TRIPLET_BUILD_ON_1: ${CRAFT_ARCH_TRIPLET_BUILD_ON}
+                EOF
+
+        """
+
+    parts = yaml.safe_load(parts_yaml)
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_expansion",
+        cache_dir=new_dir,
+        work_dir=new_dir,
+    )
+
+    actions = lf.plan(Step.PRIME)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    with open(lf.project_info.prime_dir / "part-variables.txt", "r") as file:
+        data = file.read()
+
+    assert data == textwrap.dedent(
+        """\
+        CRAFT_ARCH_TRIPLET_1: aarch64-linux-gnu
+        CRAFT_ARCH_TRIPLET_2: aarch64-linux-gnu
+        CRAFT_ARCH_TRIPLET_BUILD_FOR_1: aarch64-linux-gnu
+        CRAFT_ARCH_TRIPLET_BUILD_FOR_2: aarch64-linux-gnu
+        CRAFT_ARCH_TRIPLET_BUILD_ON_1: aarch64-linux-gnu
+        CRAFT_ARCH_TRIPLET_BUILD_ON_1: aarch64-linux-gnu
+        """
+    )

--- a/tests/unit/executor/test_environment.py
+++ b/tests/unit/executor/test_environment.py
@@ -321,6 +321,43 @@ def test_expand_variables(new_dir, partitions, var, value):
     }
 
 
+def test_expand_variables_order(mocker, new_dir, partitions):
+    """The largest replacements should occur first.
+
+    $CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR} should be replaced before $CRAFT_ARCH_TRIPLET
+    """
+    mocker.patch("craft_parts.infos._get_host_architecture", return_value="x86_64")
+    info = ProjectInfo(
+        project_dirs=ProjectDirs(work_dir="/work", partitions=partitions),
+        arch="aarch64",
+        application_name="xyz",
+        cache_dir=new_dir,
+        project_name="test-project",
+        work_dir="/work",
+        partitions=partitions,
+    )
+    info.global_environment.update({"ENVVAR": "from_app"})
+    data = {
+        "CRAFT_ARCH_TRIPLET_1": "$CRAFT_ARCH_TRIPLET",
+        "CRAFT_ARCH_TRIPLET_2": "${CRAFT_ARCH_TRIPLET}",
+        "CRAFT_ARCH_TRIPLET_BUILD_FOR_1": "$CRAFT_ARCH_TRIPLET_BUILD_FOR",
+        "CRAFT_ARCH_TRIPLET_BUILD_FOR_2": "${CRAFT_ARCH_TRIPLET_BUILD_FOR}",
+        "CRAFT_ARCH_TRIPLET_BUILD_ON_1": "$CRAFT_ARCH_TRIPLET_BUILD_ON",
+        "CRAFT_ARCH_TRIPLET_BUILD_ON_2": "${CRAFT_ARCH_TRIPLET_BUILD_ON}",
+    }
+
+    environment.expand_environment(data, info=info)
+
+    assert data == {
+        "CRAFT_ARCH_TRIPLET_1": "aarch64-linux-gnu",
+        "CRAFT_ARCH_TRIPLET_2": "aarch64-linux-gnu",
+        "CRAFT_ARCH_TRIPLET_BUILD_FOR_1": "aarch64-linux-gnu",
+        "CRAFT_ARCH_TRIPLET_BUILD_FOR_2": "aarch64-linux-gnu",
+        "CRAFT_ARCH_TRIPLET_BUILD_ON_1": "x86_64-linux-gnu",
+        "CRAFT_ARCH_TRIPLET_BUILD_ON_2": "x86_64-linux-gnu",
+    }
+
+
 def test_expand_variables_skip(new_dir, partitions):
     info = ProjectInfo(
         project_dirs=ProjectDirs(work_dir="/work", partitions=partitions),


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Sort project variables before replacement, such that `$CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}` are replaced before `$CRAFT_ARCH_TRIPLET`.

Fixes #541
(CRAFT-2029)