### PR TITLE
fix(parts): validate part dependency name

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -148,9 +148,9 @@ class LifecycleManager:
 
         part_list = []
         for name, spec in parts_data.items():
-            part_list.append(
-                _build_part(name, spec, project_dirs, strict_mode, partitions)
-            )
+            part = _build_part(name, spec, project_dirs, strict_mode, partitions)
+            _validate_part_dependencies(part, parts_data)
+            part_list.append(part)
 
         if partitions:
             validate_partition_usage(part_list, partitions)
@@ -347,6 +347,12 @@ def _build_part(
     )
 
     return part
+
+
+def _validate_part_dependencies(part: Part, parts_data: Dict[str, Any]) -> None:
+    for name in part.dependencies:
+        if name not in parts_data:
+            raise errors.InvalidPartName(name)
 
 
 def _validate_partition_usage_in_parts(part_list, partitions):

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -87,6 +87,14 @@ class TestLifecycleManager:
             )
         assert raised.value.name == name
 
+    def test_part_dependency_name_invalid(self, new_dir):
+        self._data["parts"]["foo"]["after"] = ["trololo"]
+        with pytest.raises(errors.InvalidPartName) as raised:
+            lifecycle_manager.LifecycleManager(
+                self._data, application_name="test", cache_dir=new_dir
+            )
+        assert raised.value.part_name == "trololo"
+
     @pytest.mark.parametrize("work_dir", [".", "work_dir"])
     def test_project_info(self, new_dir, work_dir):
         lf = lifecycle_manager.LifecycleManager(

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -91,7 +91,10 @@ class TestLifecycleManager:
         self._data["parts"]["foo"]["after"] = ["trololo"]
         with pytest.raises(errors.InvalidPartName) as raised:
             lifecycle_manager.LifecycleManager(
-                self._data, application_name="test", cache_dir=new_dir
+                self._data,
+                application_name="test",
+                cache_dir=new_dir,
+                **self._lcm_kwargs,
             )
         assert raised.value.part_name == "trololo"
 


### PR DESCRIPTION
Raise an error if a part depends on a non-existing part name.

Fixes: #539

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Example output from application:
```
$ snapcraft --destructive-mode 
Initializing parts lifecycle :: A part named 'trololo' is not defined in the parts list.
Review the parts definition and make sure it's correct.
```