### PR TITLE
rust_plugin: multiple fixes 

### DIFF
--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -239,8 +239,6 @@ sh -s -- -y --no-modify-path --profile=minimal --default-toolchain {channel}
         for crate in options.rust_path:
             logger.info("Generating build commands for %s", crate)
             config_cmd_string = " ".join(config_cmd)
-            # TODO(liushuyu): the current fallback installation method will also install
-            # compiler plugins into the final Snap, which is likely not what we want.
             # pylint: disable=line-too-long
             rust_build_cmd_single = dedent(
                 f"""\
@@ -254,9 +252,12 @@ sh -s -- -y --no-modify-path --profile=minimal --default-toolchain {channel}
                     pushd "{crate}"
                     cargo build --workspace --release {config_cmd_string}
                     # install the final binaries
-                    # TODO(liushuyu): this will also install proc macros in the workspace,
-                    # which the user may not want to keep in the final installation
                     find ./target/release -maxdepth 1 -executable -exec install -Dvm755 {{}} "{self._part_info.part_install_dir}" ';'
+                    # remove proc_macro objects
+                    for i in "{self._part_info.part_install_dir}"/*.so; do
+                        readelf --wide --dyn-syms "$i" | grep -q '__rustc_proc_macro_decls_[0-9a-f]*__' && \
+                        rm -fv "$i"
+                    done
                     popd
                 fi\
                 """

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -87,7 +87,7 @@ class RustPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
         """
         if "rust-deps" in (part_dependencies or []):
             options = cast(RustPluginProperties, self._options)
-            if options.rust_channel:
+            if options.rust_channel and options.rust_channel != "none":
                 raise validator.errors.PluginEnvironmentValidationError(
                     part_name=self._part_name,
                     reason="rust-deps can not be used"
@@ -99,12 +99,6 @@ class RustPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
                     plugin_name="rust",
                     part_dependencies=part_dependencies,
                 )
-            # The following type ignore is to make type checking pass while
-            # issue #559 is a bug:
-            # https://github.com/canonical/craft-parts/issues/559
-            # The ignore comment (and this block comment) should be removed
-            # with the fixing of #559.
-            options.rust_channel = "none"  # type: ignore[misc]
 
 
 class RustPlugin(Plugin):

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ test_requires = [
     "isort",
     "hypothesis",
     "pydocstyle",
-    "pylint",
+    "pylint<3.0",
     "pylint-fixme-info",
     "pylint-pytest",
     "pyright==1.1.327",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request fixes the following issues:

- Typing checking issues with the `rust_channel` override. This is unnecessary because some part of the configuration check is done in the validation step, making it impossible to set both `rust-deps` and `rust-channel` to a valid value (which will install two different Rust toolchains).
- Properly removes the compiler plugins. Rust plugin can now identify and remove the compiler plugins installed in the final staging area. Rust compiler will embed two different metadata into the compiler plugin. The craft-parts Rust plugin recognizes the compiler plugin by checking the dynamic symbol inserted into the `.data.rel.ro` section.

---

This pull request fixes #559.