### PR TITLE
Release 1.25.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.1
+current_version = 1.25.2
 commit = True
 tag = True
 

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft a project from several parts."""
 
-__version__ = "1.25.1"
+__version__ = "1.25.2"
 
 from . import plugins
 from .actions import Action, ActionProperties, ActionType

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.25.2 (2023-10-24)
+-------------------
+
+- Fix compiler plugin priming in Rust plugin
+- Fix redundant channel override in Rust plugin
+- Fix validation of part dependency names
+- Fix expansion of environment variables
+
 1.25.1 (2023-09-12)
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ copyright = "2023, Canonical Ltd."
 author = "Canonical Ltd."
 
 # The full version, including alpha/beta/rc tags
-release = "1.25.1"
+release = "1.25.2"
 
 # Open Graph configuration - defines what is displayed in the website preview
 ogp_site_url = "https://canonical-craft-parts.readthedocs-hosted.com"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import re
 
 from setuptools import find_packages, setup  # type: ignore
 
-VERSION = "1.25.1"
+VERSION = "1.25.2"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
## Changelog

* Fix compiler plugin priming in Rust plugin
* Fix redundant channel override in Rust plugin
* Fix validation of part dependency names
* Fix expansion of environment variables


