### PR TITLE
fix(deb): normalize chisel slices

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -745,6 +745,8 @@ class Ubuntu(BaseRepository):
         finally:
             logger.removeHandler(handler)
 
+        normalize(install_path, repository=cls)
+
     @classmethod
     @_apt_cache_wrapper
     def is_package_installed(cls, package_name: str) -> bool:

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -107,3 +107,46 @@ def test_chisel_error(tmp_path, caplog):
     chisel_error = ':: error: slices of package "invalid-chisel" not found'
     assert err.details is not None
     assert err.details == chisel_error
+
+
+@pytest.mark.skipif(
+    not _current_release_supported(), reason="Test needs Chisel support"
+)
+def test_chisel_normalize_paths(new_dir, partitions):
+    """Check that the contents of cut chisel slices are "normalized" just like
+    staged debs.
+    """
+
+    # We specifically use the openjdk-8-jre-headless_core slice here because
+    # it contains multiple symlinks with absolute paths
+    _parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            stage-packages: [openjdk-8-jre-headless_core]
+        """
+    )
+
+    partition_dir = "default" if partitions else "."
+
+    parts = yaml.safe_load(_parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_slice",
+        cache_dir=new_dir,
+        work_dir=new_dir,
+        partitions=partitions,
+    )
+
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    root = Path(new_dir, "prime", partition_dir)
+    link = root / "usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.policy"
+    assert link.is_symlink()
+    # Symlink must point to the file in the prime dir
+    assert link.resolve(strict=True) == root / "etc/java-8-openjdk/security/java.policy"

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -52,7 +52,7 @@ def test_fetch_stage_slices(tmp_path, fake_apt_cache):
     assert not fake_apt_cache.called
 
 
-def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
+def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
     stage_dir = tmp_path / "stage"
     stage_dir.mkdir()
 
@@ -60,6 +60,9 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
     install_dir.mkdir()
 
     slices = ["package1_slice1", "package2_slice2"]
+
+    spied_normalize = mocker.spy(deb, "normalize")
+
     deb.Ubuntu.unpack_stage_packages(
         stage_packages_path=stage_dir, install_path=install_dir, stage_packages=slices
     )
@@ -74,6 +77,9 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
             "package2_slice2",
         ]
     )
+
+    # Make sure the contents of the cut slices have been normalized.
+    spied_normalize.assert_called_once_with(install_dir, repository=deb.Ubuntu)
 
 
 def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):


### PR DESCRIPTION
When stage debs are unpacked, we "normalize" the contents to do things like fix absolute symlinks (as absolute links would point outside the lifecycle environment). Do the same for cut chisel slices too.

Fixes #578

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
