### PR TITLE
fix(deb): normalize chisel slices

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -745,6 +745,8 @@ class Ubuntu(BaseRepository):
         finally:
             logger.removeHandler(handler)
 
+        normalize(install_path, repository=cls)
+
     @classmethod
     @_apt_cache_wrapper
     def is_package_installed(cls, package_name: str) -> bool:

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -53,7 +53,7 @@ def test_fetch_stage_slices(tmp_path, fake_apt_cache):
     assert not fake_apt_cache.called
 
 
-def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
+def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
     stage_dir = tmp_path / "stage"
     stage_dir.mkdir()
 
@@ -61,6 +61,9 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
     install_dir.mkdir()
 
     slices = ["package1_slice1", "package2_slice2"]
+
+    spied_normalize = mocker.spy(deb, "normalize")
+
     deb.Ubuntu.unpack_stage_packages(
         stage_packages_path=stage_dir, install_path=install_dir, stage_packages=slices
     )
@@ -75,6 +78,9 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run):
             "package2_slice2",
         ]
     )
+
+    # Make sure the contents of the cut slices have been normalized.
+    spied_normalize.assert_called_once_with(install_dir, repository=deb.Ubuntu)
 
 
 def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):


### PR DESCRIPTION
(this is the same code as before, but now cherry-picked off of `hotfix/1.26.1`)

When stage debs are unpacked, we "normalize" the contents to do things like fix absolute symlinks (as absolute links would point outside the lifecycle environment). Do the same for cut chisel slices too.

Fixes #578

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
