### PR TITLE
chore(deps): loosen mypy requirement

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
+  ignoreDeps: [
+    "mypy",  // 1.5 removed Python 3.7 support https://github.com/canonical/craft-parts/issues/603
+  ],
   labels: ["dependencies"],  // For convenient searching in GitHub
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"]

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ docs_require = [
 ]
 
 types_requires = [
-    "mypy[reports]>=1.4.1,<1.6.0",
+    "mypy[reports]>=1.4.1,<2.0",
     "types-colorama",
     "types-docutils",
     "types-Pillow",


### PR DESCRIPTION
Also removes from renovate config until we can remove Python 3.7

One of two PRs that will fix renovate. https://github.com/canonical/craft-parts/pull/589

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
