### PR TITLE
chore(ci): update chisel

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,9 +80,11 @@ jobs:
           sudo apt install -y ninja-build cmake scons qt5-qmake \
                               autoconf automake autopoint gcc git gperf help2man libtool texinfo
           # Build Chisel: needs a newer version of go than is available in Ubuntu 20.04
+          # note: we can't use the snap here because it has strict confinement and can't access
+          # the test files in /tmp/pytest-*
           sudo snap install --classic --channel=latest/stable go
           git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout f0bff5a30dfdcb400b # known "good" commit until Chisel has versions
+          cd chisel-tmp && git checkout v0.8.1
           go mod download
           sudo go build -o /usr/bin ./...
           chisel --help


### PR DESCRIPTION
A new version of chisel-releases breaks compatibility with chisel binaries older than v0.8.1.

Ref: https://github.com/canonical/rockcraft/pull/449

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

We'll also need to cherry-pick this into any live hotfix branch