### PR TITLE
test: use `new_dir` fixture

### DIFF
--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -46,6 +46,7 @@ def fake_conn():
     return FakeConn()
 
 
+@pytest.mark.usefixtures("new_dir")
 class TestChroot:
     """Fork process and execute in chroot."""
 
@@ -171,7 +172,7 @@ class TestChroot:
         assert mock_chroot.mock_calls == [call(Path("/some/path"))]
         assert fake_conn.sent == (1337, None)
 
-    def test_runner_error(self, new_dir, fake_conn, mock_chdir, mock_chroot):
+    def test_runner_error(self, fake_conn, mock_chdir, mock_chroot):
         chroot._runner(
             Path("/some/path"), fake_conn, target_func_error, ("func arg",), {}
         )

--- a/tests/unit/packages/test_base.py
+++ b/tests/unit/packages/test_base.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import shutil
 import sys
 from pathlib import Path
 
@@ -109,10 +108,9 @@ class TestOriginStagePackage:
             with pytest.raises(RuntimeError):
                 base.write_origin_stage_package(test_file, package)
 
+    @pytest.mark.usefixtures("new_dir")
     def test_mark_origin_stage_package(self):
         test_dir = Path(".tests-xattr-test-dir")
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
         test_dir.mkdir()
 
         Path(test_dir / "foo").touch()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

- `tests/unit/packages/test_base.py::TestOriginStagePackage::test_mark_origin_stage_package` was creating `.tests-xattr-test-dir/` in the cwd
- `tests/unit/overlays/test_chroot.py::TestChroot::test_runner` was creating `foo.txt` in the cwd