### PR TITLE
feat(rust_plugin): use `rustup` snap and more options

### DIFF
--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -52,6 +52,7 @@ class RustPluginProperties(PluginProperties, PluginModel):
     rust_use_global_lto: bool = False
     rust_no_default_features: bool = False
     rust_ignore_toolchain_file: bool = False
+    rust_cargo_parameters: List[str] = []
     source: str
     after: Optional[UniqueStrList] = None
 
@@ -169,6 +170,10 @@ class RustPlugin(Plugin):
           reducing the final binary size.
           This will forcibly enable LTO for all the crates you specified,
           regardless of whether you have LTO enabled in the Cargo.toml file
+
+        - rust-cargo-parameters
+          (list of strings)
+          Append additional parameters to the Cargo command line.
     """
 
     properties_class = RustPluginProperties
@@ -270,6 +275,9 @@ class RustPlugin(Plugin):
 
         if options.rust_no_default_features:
             config_cmd.append("--no-default-features")
+
+        if options.rust_cargo_parameters:
+            config_cmd.extend(options.rust_cargo_parameters)
 
         for crate in options.rust_path:
             logger.info("Generating build commands for %s", crate)

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -152,7 +152,9 @@ class RustPlugin(Plugin):
 
         - rust-features
           (list of strings)
-          Features used to build optional dependencies
+          Features used to build optional dependencies.
+          You can specify ["*"] for all features
+          (including all the optional ones).
 
         - rust-path
           (list of strings, default [.])
@@ -261,8 +263,15 @@ class RustPlugin(Plugin):
         config_cmd: List[str] = []
 
         if options.rust_features:
-            features_string = " ".join(options.rust_features)
-            config_cmd.extend(["--features", f"'{features_string}'"])
+            if "*" in options.rust_features:
+                if len(options.rust_features) > 1:
+                    raise ValueError(
+                        "Please specify either the wildcard feature or a list of specific features"
+                    )
+                config_cmd.append("--all-features")
+            else:
+                features_string = " ".join(options.rust_features)
+                config_cmd.extend(["--features", f"'{features_string}'"])
 
         if options.rust_use_global_lto:
             logger.info("Adding overrides for LTO support")

--- a/docs/base/rust_plugin.rst
+++ b/docs/base/rust_plugin.rst
@@ -31,6 +31,8 @@ rust-features
 Features used to build optional dependencies.
 This is equivalent to the ``--features`` option in Cargo.
 
+You can also use ``["*"]`` to select all the feautures available in the project.
+
 .. note::
   This option does not override any default features
   specified by the project itself.
@@ -75,6 +77,24 @@ in the Cargo.toml file.
 This is equivalent to the ``lto = "fat"`` option in the Cargo.toml file.
 
 If you want better runtime performance, see the :ref:`Performance tuning<perf-tuning>` section below.
+
+rust-ignore-toolchain-file
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Type:** boolean
+**Default:** false
+
+Whether to ignore the ``rust-toolchain.toml`` and ``rust-toolchain`` file.
+The upstream project can use this file to specify which Rust
+toolchain to use and which component to install.
+If you don't want to follow the upstream project's specifications,
+you can put true for this option to ignore the toolchain file.
+
+rust-cargo-parameters
+~~~~~~~~~~~~~~~~~~~~~
+**Type:** list of strings
+**Default:** []
+
+Append additional parameters to the Cargo command line.
 
 Environment variables
 ---------------------

--- a/docs/base/rust_plugin.rst
+++ b/docs/base/rust_plugin.rst
@@ -96,6 +96,40 @@ rust-cargo-parameters
 
 Append additional parameters to the Cargo command line.
 
+rust-inherit-ldflags
+~~~~~~~~~~~~~~~~~~~~~
+**Type:** boolean
+**Default:** false
+
+Whether to inherit the LDFLAGS from the environment.
+This option will add the LDFLAGS from the environment to the
+Rust linker directives.
+
+Cargo build system and Rust compiler by default do not respect the `LDFLAGS`
+environment variable. This option will cause the craft-parts plugin to
+forcibly add the contents inside the `LDFLAGS` to the Rust linker directives
+by wrapping and appending the `LDFLAGS` value to `RUSTFLAGS`.
+
+.. note::
+  You may use this option to tune the Rust binary in a classic Snap to respect
+  the Snap linkage, so that the binary will not find the libraries in the host
+  filesystem.
+
+  Here is an example on how you might do this on core22:
+
+  .. code-block:: yaml
+
+        parts:
+          my-classic-app:
+            plugin: rust
+            source: .
+            rust-inherit-ldflags: true
+            build-environment:
+              - LDFLAGS: >
+                  -Wl,-rpath=\$ORIGIN/lib:/snap/core22/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+                  -Wl,-dynamic-linker=$(find /snap/core22/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -name 'ld*.so.*' -print | head -n1)
+
+
 Environment variables
 ---------------------
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request adds a few more options to the existing Rust plugin. It also switches to the `rustup` Snap instead of the ad-hoc installation method.