### PR TITLE
build(deps): pin overrides!=7.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ def is_rtd() -> bool:
 
 
 install_requires = [
-    "overrides",
+    # see https://github.com/mkorpela/overrides/issues/121
+    "overrides<7.6",
     "PyYAML",
     "pydantic>=1.9.0,<2.0.0",
     "pydantic-yaml[pyyaml]>=0.11.0,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def is_rtd() -> bool:
 
 install_requires = [
     # see https://github.com/mkorpela/overrides/issues/121
-    "overrides<7.6",
+    "overrides!=7.6.0",
     "PyYAML",
     "pydantic>=1.9.0,<2.0.0",
     "pydantic-yaml[pyyaml]>=0.11.0,<1.0.0",


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

`overrides` 7.6.0 introduced a bug: https://github.com/mkorpela/overrides/issues/121

A handful of python plugin tests are failing with:
```
FAILED tests/integration/plugins/test_python.py::test_python_plugin_no_system_interpreter[True] - TypeError: test_python_plugin_no_system_interpreter.<locals>.MyPythonPlugin._get_system_python_interpreter: No super class method found
```

due to how the tests override superclass functions:
```
    class MyPythonPlugin(craft_parts.plugins.plugins.PythonPlugin):
        @override
        def _get_system_python_interpreter(self) -> Optional[str]:
            return None
```

Our options are:
1. Merge this PR
2. Use the workaround described in the bug linked above
3. Wait for a fix in `overrides`