### PR TITLE
fix(parts): set field defaults using default_factory

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -57,8 +57,7 @@ class _RunHandler(Protocol):
         *,
         stdout: Stream,
         stderr: Stream,
-    ) -> StepState:
-        ...
+    ) -> StepState: ...
 
 
 class _UpdateHandler(Protocol):
@@ -68,8 +67,7 @@ class _UpdateHandler(Protocol):
         *,
         stdout: Stream,
         stderr: Stream,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 class PartHandler:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -54,10 +54,10 @@ class PartSpec(BaseModel):
     build_packages: List[str] = []
     build_environment: List[Dict[str, str]] = []
     build_attributes: List[str] = []
-    organize_files: Dict[str, str] = Field({}, alias="organize")
-    overlay_files: List[str] = Field(["*"], alias="overlay")
-    stage_files: List[str] = Field(["*"], alias="stage")
-    prime_files: List[str] = Field(["*"], alias="prime")
+    organize_files: Dict[str, str] = Field(default_factory=lambda: {}, alias="organize")
+    overlay_files: List[str] = Field(default_factory=lambda: ["*"], alias="overlay")
+    stage_files: List[str] = Field(default_factory=lambda: ["*"], alias="stage")
+    prime_files: List[str] = Field(default_factory=lambda: ["*"], alias="prime")
     override_pull: Optional[str] = None
     overlay_script: Optional[str] = None
     override_build: Optional[str] = None

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -18,7 +18,17 @@ import sys
 import textwrap
 from pathlib import Path
 
+import craft_parts
 from craft_parts import main
+
+
+def setup_function():
+    craft_parts.Features.reset()
+
+
+def teardown_function():
+    craft_parts.Features.reset()
+
 
 parts_yaml = textwrap.dedent(
     """


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

I was getting some PyRight errors when trying to create a `PartSpec` with just a `plugin` value:

```python3
foo = PartSpec(plugin="foo")
```

PyRight gives me this error:
```
error: Arguments missing for parameters "organize", "overlay", "stage", "prime" (reportCallIssue)
```

It could also be PyRight misinterpreting something, but using `default_value` instead of `default` for mutable types seems like a good idea anyway, and as a side effect seems to silence PyRight's error report.

Conceptually, the `pydantic.Field`'s `default` vs `default_factory` have the same semantic as Python's own [`dataclasses.field`](https://docs.python.org/3/library/dataclasses.html#dataclasses.field) class, which says about `default_type`:

>  Among other purposes, this can be used to specify fields with mutable default values, as discussed below.

Installed versions:

- Python 3.11.6
- via pip: craft-cli                     2.5.0
- via pip: craft-parts                   1.20.0
- via pip: craft-providers               1.12.0
- via pip: pydantic 1.10.12
- via pip: pydantic_core 2.14.6
- via pip: pydantic-yaml 0.11.2
- via snap: pyright            1.1.348          746    latest/stable  alexmurray*  classic

This might interact with #601.

See also: https://github.com/canonical/craft-parts/pull/601/files#r1463405279