### PR TITLE
feat: add a utility function that determines whether a part has slices

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -99,12 +99,9 @@ class PartSpec(BaseModel):
             # This check is only relevant in deb systems.
             return values
 
-        def is_slice(name: str) -> bool:
-            return "_" in name
-
         # Detect a mixture of .deb packages and chisel slices.
         stage_packages = values.get("stage-packages", [])
-        has_slices = any(name for name in stage_packages if is_slice(name))
+        has_slices = part_has_slices(values)
         has_packages = any(name for name in stage_packages if not is_slice(name))
 
         if has_slices and has_packages:
@@ -640,6 +637,23 @@ def part_has_overlay(data: Dict[str, Any]) -> bool:
     spec = _get_part_spec(data)
 
     return spec.has_overlay
+
+
+def part_has_slices(data: Dict[str, Any]) -> bool:
+    """Whether the part described by ``data`` has slices in its stage-packages.
+
+    :param data: The part data to query.
+    """
+    stage_packages = data.get("stage-packages", [])
+    return any(name for name in stage_packages if is_slice(name))
+
+
+def is_slice(name: str) -> bool:
+    """Whether the stage-package is a slice or a package.
+
+    :param name: name of the package.
+    """
+    return "_" in name
 
 
 def _get_part_spec(data: Dict[str, Any]) -> PartSpec:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
A utility function is needed in rockcraft to determine whether parts has slices in them. 
Instead of implementing such a function in rockcraft, it is better to implement it in craft-parts instead.