### PR TITLE
ci: update Chisel version again

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,7 +84,7 @@ jobs:
           # the test files in /tmp/pytest-*
           sudo snap install --classic --channel=latest/stable go
           git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout v0.8.1
+          cd chisel-tmp && git checkout v0.9.0
           go mod download
           sudo go build -o /usr/bin ./...
           chisel --help


### PR DESCRIPTION
Version 0.8.1 was meant as a temporary stopgap; version 0.9.0 has the actual support for the breaking changes in chisel-releases.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
