### PR TITLE
chore(linter): refine ruff configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,3 +175,8 @@ classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
     "I001",  # isort leaves init files alone by default, this makes ruff ignore them too.
     "F401",  # Allows unused imports in __init__ files.
 ]
+
+[tool.ruff.format]
+quote-style = "double"
+docstring-code-format = true
+skip-magic-trailing-comma = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ allow-star-arg-any = true
 [tool.ruff.pylint]
 max-args = 8
 max-branches = 16
+max-locals = 18
+# max-attributes = 16
 
 [tool.ruff.pep8-naming]
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request adds the previously removed Pylint rules back to Ruff (since Ruff recently added support for them).
The commented-out rule is currently a work in progress upstream: https://github.com/astral-sh/ruff/pull/9844.