### PR TITLE
docs: Link filesets specification from part properties

### DIFF
--- a/docs/base/part_properties.rst
+++ b/docs/base/part_properties.rst
@@ -186,7 +186,8 @@ prime
 
 **Step:** prime
 
-The files to copy from the staging area to the priming area.
+The files to copy from the staging area to the priming area,
+see :ref:`filesets_specifying_paths`.
 
 .. _part-properties-sources:
 .. _source:
@@ -293,11 +294,12 @@ found in the :mod:`craft_parts.sources` file.
 
 stage
 -----
-**Type:** array of unique strings with at least item
+**Type:** array of unique strings with at least 1 item
 
 **Step:** stage
 
-The files to copy from the building area to the staging area.
+The files to copy from the building area to the staging area,
+see :ref:`filesets_specifying_paths`.
 
 .. _stage_packages:
 

--- a/docs/explanation/filesets.rst
+++ b/docs/explanation/filesets.rst
@@ -33,6 +33,8 @@ Filesets are defined for individual parts. The scope of each fileset is the
 part it is defined in. Filesets defined in one part cannot be used by another
 part, and filesets cannot be shared between parts.
 
+.. _filesets_specifying_paths:
+
 Specifying paths
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Was looking for how the `prime` and `stage` part properties take glob-like inclusion and exclusion patterns, but the docs didn't point to the fact that these are "filesets".

Add a link to the fileset specification explanation, so that people looking for all the possible fileset-specific ways of specifying files to include and exclude can find it easily.

Also, "at least item" -> "at least 1 item"

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?