### PR TITLE
fix: stage and prime content in all partitions by default

### DIFF
--- a/tests/integration/features/partitions/lifecycle/test_lifecycle.py
+++ b/tests/integration/features/partitions/lifecycle/test_lifecycle.py
@@ -63,24 +63,11 @@ class TestCleaning:
                 source: foo
                 organize:
                   (default)/file2: (mypart)/file2
-                # stage and prime keywords can be removed after #650 is resolved
-                stage:
-                 - (default)/*
-                 - (mypart)/*
-                prime:
-                 - (default)/*
-                 - (mypart)/*
               bar:
                 plugin: dump
                 source: bar
                 organize:
                   (default)/file4: (yourpart)/file4
-                stage:
-                 - (default)/*
-                 - (yourpart)/*
-                prime:
-                 - (default)/*
-                 - (yourpart)/*
             """
         )
         Path("foo").mkdir()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

When partitions are enabled, all content will be staged and primed in all partitions by "default".

I put "default" in quotes because I'm not setting the default in the [PartSpec pydantic model](https://github.com/canonical/craft-parts/blob/c11570597d4a397aba1744fa08adcd344682246e/craft_parts/parts.py#L59).  I can't set the default value outright, but I can modify the data with a `@validator` function.  I would probably validate the usage of partitions inside the `PartSpec` model as well.  

As a final confusing note, I think @lengau and I both implemented the same validation in different ways: [here](https://github.com/canonical/craft-parts/blob/c11570597d4a397aba1744fa08adcd344682246e/craft_parts/lifecycle_manager.py#L158) and [here](https://github.com/canonical/craft-parts/blob/c11570597d4a397aba1744fa08adcd344682246e/craft_parts/lifecycle_manager.py#L162).

Fixes #650