### PR TITLE
feat(info): support armv8l

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -483,6 +483,7 @@ _PLATFORM_MACHINE_TRANSLATIONS: Dict[str, str] = {
     # Maps other possible ``platform.machine()`` values to the arch translations below.
     "arm64": "aarch64",
     "armv7hl": "armv7l",
+    "armv8l": "armv7l",
     "i386": "i686",
     "amd64": "x86_64",
     "x64": "x86_64",

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -653,6 +653,7 @@ def test_step_info_get_project_var():
     [
         ("arm64", "aarch64"),
         ("armv7hl", "armv7l"),
+        ("armv8l", "armv7l"),
         ("i386", "i686"),
         ("AMD64", "x86_64"),
         ("x64", "x86_64"),


### PR DESCRIPTION
Allow building armhf snaps on armv8l.
Fixes issue: https://github.com/canonical/craft-parts/issues/696
Referenced here: https://forum.snapcraft.io/t/invalidarchitecture-architecture-armv8l-is-not-supported/39455/7

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
