### PR TITLE
feat(plugin): Refactor NPM plugin

### DIFF
--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -19,9 +19,11 @@
 import logging
 import os
 import platform
+import re
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
+import requests
 from overrides import override
 from pydantic import root_validator
 
@@ -58,6 +60,10 @@ class NpmPluginProperties(PluginProperties, PluginModel):
         """If npm-include-node is true, then npm-node-version must be defined."""
         if values.get("npm_include_node") and not values.get("npm_node_version"):
             raise ValueError("npm-node-version is required if npm-include-node is true")
+        if values.get("npm_node_version") and not values.get("npm_include_node"):
+            raise ValueError(
+                "npm-node-version has no effect if npm-include-node is false"
+            )
         return values
 
     @classmethod
@@ -118,12 +124,26 @@ class NpmPlugin(Plugin):
           If npm-include-node is true, then npm-node-version must be defined.
 
         - npm-node-version
-          (str: default: None)
-          Which version of node to download (e.g. "16.14.2")
+          (str; default: None)
+          Which version of node to download.
+          Required if npm-include-node is set to true.
+          The option accepts a NVM-style version string, you can specify:
+
+            * exact version (e.g. "20.12.2")
+            * major+minor version (e.g. "20.12")
+            * major version (e.g. "20")
+            * LTS code name (e.g. "lts/iron")
+            * latest mainline version ("node")
+
+          Note that "system" and "iojs" options are not supported.
     """
 
     properties_class = NpmPluginProperties
     validator_class = NpmPluginEnvironmentValidator
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._node_binary_path: Optional[str] = None
 
     @staticmethod
     def _get_architecture() -> str:
@@ -150,6 +170,90 @@ class NpmPlugin(Plugin):
 
         return node_arch
 
+    @staticmethod
+    def _fetch_node_release_index() -> List[Dict[str, Any]]:
+        """Fetch the list of Node.js releases.
+
+        :return: The list of Node.js releases.
+        """
+        logging.info("Fetching Node.js release index...")
+        resp = requests.get("https://nodejs.org/dist/index.json", timeout=10)
+        resp.raise_for_status()
+        versions: List[Dict[str, Any]] = resp.json()
+        return versions
+
+    @staticmethod
+    def _get_best_node_version(
+        node_version: Optional[str], target_arch: str
+    ) -> Tuple[str, str]:
+        """Get the best matching Node.js version using NVM-style version tags.
+
+        :param node_version: The version of Node.js to match.
+        :param target_arch: The target architecture.
+        :return: The best matching node version and its remote file name.
+        """
+        logging.info(
+            "Searching for Node.js version %s for %s ...", node_version, target_arch
+        )
+        versions = NpmPlugin._fetch_node_release_index()
+        node_os_id = f"linux-{target_arch}"
+        candidate = None
+        if node_version is None or node_version == "node":
+            # use the latest version if not specified
+            candidate = versions[0]
+        elif re.match(r"^\d+\.\d+\.\d+$", node_version):
+            search_version = f"v{node_version}"
+            # normal Node version
+            for version in versions:
+                if version.get("version") == search_version:
+                    candidate = version
+                    break
+        elif node_version.isdecimal() or re.match(r"^\d+\.\d+$", node_version):
+            # major-only or major.minor Node version
+            search_string = f"v{node_version}."
+            for version in versions:
+                # search for the first version that matches the major version
+                # and also contains a release for the architecture
+                if version.get("version", "").startswith(search_string) and (
+                    node_os_id in version.get("files", [])
+                ):
+                    candidate = version
+                    break
+        elif node_version.startswith("lts/"):
+            # LTS code name
+            node_version = node_version.replace("lts/", "", 1)
+            lts_string = f"{node_version.capitalize()}"
+            for version in versions:
+                lts_version = version.get("lts", False)
+                # like-wise, but search for the LTS version
+                if (
+                    lts_version
+                    and lts_version == lts_string
+                    and (node_os_id in version.get("files", []))
+                ):
+                    candidate = version
+                    break
+        else:
+            raise ValueError(f"Invalid Node.js version specifier: {node_version}")
+
+        if candidate is None:
+            raise RuntimeError(
+                f"Node.js {node_version} does not exist or is unavailable for {target_arch}"
+            )
+        if node_os_id not in candidate.get("files", []):
+            raise RuntimeError(
+                f"Node.js {candidate['version']} is unavailable for {target_arch}"
+            )
+
+        logging.info(
+            "Found matching Node.js version %s (%s)",
+            candidate["version"],
+            candidate["date"],
+        )
+        selected_version = candidate["version"]
+        file_name = f"node-{selected_version}-{node_os_id}.tar.gz"
+        return selected_version, file_name
+
     @override
     def get_build_snaps(self) -> Set[str]:
         """Return a set of required snaps to install in the build environment."""
@@ -165,37 +269,67 @@ class NpmPlugin(Plugin):
     @override
     def get_build_environment(self) -> Dict[str, str]:
         """Return a dictionary with the environment to use in the build step."""
+        # set the Node environment to production mode
+        base_env = {
+            "NODE_ENV": "production",
+        }
         if cast(NpmPluginProperties, self._options).npm_include_node:
-            return {"PATH": "${CRAFT_PART_INSTALL}/bin:${PATH}"}
-        return {}
+            base_env["PATH"] = "${CRAFT_PART_INSTALL}/bin:${PATH}"
+        return base_env
+
+    @override
+    def get_pull_commands(self) -> List[str]:
+        """Return a list of commands to run during the pull step."""
+        options = cast(NpmPluginProperties, self._options)
+        if options.npm_include_node:
+            arch = self._get_architecture()
+            version = options.npm_node_version
+            resolved_version, file_name = self._get_best_node_version(version, arch)
+
+            node_uri = f"https://nodejs.org/dist/{resolved_version}/{file_name}"
+            checksum_uri = f"https://nodejs.org/dist/{resolved_version}/SHASUMS256.txt"
+            self._node_binary_path = os.path.join(
+                self._part_info.part_cache_dir, file_name
+            )
+            return [
+                dedent(
+                    f"""\
+                if [ ! -f "{self._node_binary_path}" ]; then
+                    mkdir -p "{self._part_info.part_cache_dir}"
+                    curl --retry 5 -s "{checksum_uri}" -o "{self._part_info.part_cache_dir}"/SHASUMS256.txt
+                    curl --retry 5 -s "{node_uri}" -o "{self._node_binary_path}"
+                fi
+                cd "{self._part_info.part_cache_dir}"
+                sha256sum --ignore-missing --strict -c SHASUMS256.txt
+                """
+                )
+            ]
+        return []
 
     @override
     def get_build_commands(self) -> List[str]:
         """Return a list of commands to run during the build step."""
-        options = cast(NpmPluginProperties, self._options)
-
-        command: List[str] = []
-
-        if options.npm_include_node:
-            arch = self._get_architecture()
-            version = options.npm_node_version
-
-            node_uri = (
-                f"https://nodejs.org/dist/v{version}"
-                f"/node-v{version}-linux-{arch}.tar.gz"
+        cmd = [
+            dedent(
+                """\
+            NPM_VERSION="$(npm --version)"
+            # use the new-style install command if npm >= 10.0.0
+            if ((${NPM_VERSION%%.*}>=10)); then
+                npm install -g --prefix "${CRAFT_PART_INSTALL}" --install-links "${PWD}"
+            else
+                npm install -g --prefix "${CRAFT_PART_INSTALL}" "$(npm pack . | tail -1)"
+            fi
+            """
             )
-            command.append(
+        ]
+        if self._node_binary_path is not None:
+            cmd.insert(
+                0,
                 dedent(
                     f"""\
-                    if [ ! -f "${{CRAFT_PART_INSTALL}}/bin/node" ]; then
-                        curl -s "{node_uri}" |
-                        tar xzf - -C "${{CRAFT_PART_INSTALL}}/" \
-                        --no-same-owner --strip-components=1
-                    fi
-                    """
-                )
+                tar -xzf "{self._node_binary_path}" -C "${{CRAFT_PART_INSTALL}}/" \
+                    --no-same-owner --strip-components=1
+                """
+                ),
             )
-        command.append(
-            'npm install -g --prefix "${CRAFT_PART_INSTALL}" $(npm pack . | tail -1)'
-        )
-        return command
+        return cmd

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -86,6 +86,7 @@ JavaPlugin
 LDFLAGS
 LLVM
 LTO
+LTS
 LXD
 LayerHash
 LayerMount
@@ -108,6 +109,7 @@ MigrationState
 Multipass
 NOOP
 NPM
+NVM
 Namespaced
 NetworkRequestError
 NilPlugin
@@ -313,13 +315,16 @@ infos
 ing
 initialized
 iterable
+iojs
 jdk
 jre
+js
 kwargs
 ldflags
 lifecycle
 linters
 lto
+lts
 mcraft
 md
 metaclass

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -1,0 +1,59 @@
+.. _craft_parts_npm_plugin:
+
+NPM Plugin
+=============
+
+The NPM plugin can be used for Node.js projects that use NPM (or Yarn) as the package manager.
+
+Keywords
+--------
+
+In addition to the common :ref:`plugin <part-properties-plugin>` and
+:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+plugin-specific keywords:
+
+npm-include-node
+~~~~~~~~~~~~~~~~~~
+**Type:** boolean
+**Default:** False
+
+If this option is set to ``true``, the plugin will download and include the 
+Node.js binaries and its dependencies in the Snap.
+If ``npm-include-node`` is true, then :ref:`npm-node-version` must be defined.
+
+.. _npm-node-version:
+
+npm-node-version
+~~~~~~~~~~~~~~~~~~~
+**Type:** string
+**Default:** ``null``
+
+Which version of Node.js to download and include in the final Snap.
+Required if ``npm-include-node`` is set to true.
+
+The option accepts a NVM-style version string, you can specify one of:
+
+* exact version (e.g. "20.12.2")
+* major+minor version (e.g. "20.12")
+* major version (e.g. "20")
+* LTS code name (e.g. "lts/iron")
+* latest mainline version ("node")
+
+When specifying a non-exact version identifer, the plugin will select
+the latest version that satisfies the specified version range. If
+the version picked by the plugin does not publish binaries for the
+target architecture, the plugin will pick the nearest version that 
+both satisfies the version range and also publishes binaries
+for the target architecture.
+
+.. warning::
+    In the ``nvm`` utility, you can specify "system" to use system
+    Node.js package, but this is unsupported in this plugin, as we
+    are using upstream Node.js binaries.
+
+    Also, the ``iojs`` specifier is unsupported in this plugin,
+    as the ``iojs`` project was merged back to Node.js circa. 2015.
+    Using very old ``iojs`` runtime poses a significant security
+    hazard. If your project still requires a JavaScript runtime
+    from nearly a decade ago, you should seriously considering
+    migrating to the modern Node.js runtime.

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -13,49 +13,49 @@ In addition to the common :ref:`plugin <part-properties-plugin>` and
 plugin-specific keywords:
 
 npm-include-node
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 **Type:** boolean
 **Default:** False
 
-If this option is set to ``true``, the plugin will download and include the 
+When set to ``true``, the plugin downloads and includes the 
 Node.js binaries and its dependencies in the resulting package.
-If ``npm-include-node`` is true, then :ref:`npm-node-version` must be defined.
+If ``npm-include-node`` is ``true``, then :ref:`npm-node-version` must be defined.
 
 .. _npm-node-version:
 
 npm-node-version
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 **Type:** string
 **Default:** ``null``
 
 Which version of Node.js to download and include in the final package.
-Required if ``npm-include-node`` is set to true.
+Required if ``npm-include-node`` is set to ``true``.
 
 The option accepts an NVM-style version string; you can specify one of:
 
-* exact version (e.g. "20.12.2")
-* major+minor version (e.g. "20.12")
-* major version (e.g. "20")
-* LTS code name (e.g. "lts/iron")
-* latest mainline version ("node")
+* exact version (e.g. ``"20.12.2"``)
+* major+minor version (e.g. ``"20.12"``)
+* major version (e.g. ``"20"``)
+* LTS code name (e.g. ``"lts/iron"``)
+* latest mainline version (``"node"``)
 
-When specifying a non-exact version identifier, the plugin will select
+When specifying a non-exact version identifier, the plugin selects
 the latest version that satisfies the specified version range. If
 the version picked by the plugin does not publish binaries for the
-target architecture, the plugin will pick the nearest version that 
+target architecture, the plugin picks the nearest version that 
 both satisfies the version range and also publishes binaries
 for the target architecture.
 
 .. warning::
-    In the ``nvm`` utility, you can specify "system" to use system
+    In the ``nvm`` utility, you can specify ``system`` to use the system
     Node.js package, but this is unsupported in this plugin, as we
     are using upstream Node.js binaries.
 
     Also, the ``iojs`` specifier is unsupported in this plugin,
     as the ``iojs`` project was merged back to Node.js circa. 2015.
-    Using very old ``iojs`` runtime poses a significant security
+    Using a very old ``iojs`` runtime poses a significant security
     hazard. If your project still requires a JavaScript runtime
-    from nearly a decade ago, you should seriously considering
+    from nearly a decade ago, consider
     migrating to the modern Node.js runtime.
 
 Examples
@@ -63,7 +63,7 @@ Examples
 
 The following example declares a part using the ``npm`` plugin.
 In this example, we show how you may build the ``terser`` utility
-(an utility for compressing and obfuscating JavaScript code).
+(a utility for compressing and obfuscating JavaScript code).
 It uses the latest mainline stable version of Node.js and includes
 a copy of the Node.js runtime inside the final package.
 
@@ -78,7 +78,7 @@ a copy of the Node.js runtime inside the final package.
             npm-node-version: "node"
 
 Another example that shows how to install an application that
-published to npm registry but does not require Node.js runtime
+is published to the npm registry but does not require a Node.js runtime
 to run.
 
 .. code-block:: yaml

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -57,3 +57,38 @@ for the target architecture.
     hazard. If your project still requires a JavaScript runtime
     from nearly a decade ago, you should seriously considering
     migrating to the modern Node.js runtime.
+
+Examples
+--------
+
+The following example declares a part using the ``npm`` plugin.
+In this example, we show how you may build the ``terser`` utility
+(an utility for compressing and obfuscating JavaScript code).
+It uses the latest mainline stable version of Node.js and includes
+a copy of the Node.js runtime inside the final package.
+
+.. code-block:: yaml
+
+    parts:
+        app:
+            plugin: npm
+            source: https://github.com/terser/terser
+            source-type: git
+            npm-include-node: true
+            npm-node-version: "node"
+
+Another example that shows how to install an application that
+published to npm registry but does not require Node.js runtime
+to run.
+
+.. code-block:: yaml
+
+    parts:
+        app:
+            plugin: npm
+            source: https://registry.npmjs.org/esbuild/-/esbuild-0.21.3.tgz
+            source-type: tar
+            npm-include-node: false
+            build-snaps:
+            # use Node.js Snap during the build-time only
+                - node

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -39,7 +39,7 @@ The option accepts a NVM-style version string, you can specify one of:
 * LTS code name (e.g. "lts/iron")
 * latest mainline version ("node")
 
-When specifying a non-exact version identifer, the plugin will select
+When specifying a non-exact version identifier, the plugin will select
 the latest version that satisfies the specified version range. If
 the version picked by the plugin does not publish binaries for the
 target architecture, the plugin will pick the nearest version that 

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -18,7 +18,7 @@ npm-include-node
 **Default:** False
 
 If this option is set to ``true``, the plugin will download and include the 
-Node.js binaries and its dependencies in the Snap.
+Node.js binaries and its dependencies in the resulting package.
 If ``npm-include-node`` is true, then :ref:`npm-node-version` must be defined.
 
 .. _npm-node-version:
@@ -28,10 +28,10 @@ npm-node-version
 **Type:** string
 **Default:** ``null``
 
-Which version of Node.js to download and include in the final Snap.
+Which version of Node.js to download and include in the final package.
 Required if ``npm-include-node`` is set to true.
 
-The option accepts a NVM-style version string, you can specify one of:
+The option accepts an NVM-style version string; you can specify one of:
 
 * exact version (e.g. "20.12.2")
 * major+minor version (e.g. "20.12")

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -12,6 +12,7 @@ lifecycle.
 
    /common/craft-parts/reference/plugins/dump_plugin.rst
    /common/craft-parts/reference/plugins/maven_plugin.rst
+   /common/craft-parts/reference/plugins/npm_plugin.rst
    /common/craft-parts/reference/plugins/python_plugin.rst
    /common/craft-parts/reference/plugins/rust_plugin.rst
 

--- a/tests/integration/plugins/test_npm.py
+++ b/tests/integration/plugins/test_npm.py
@@ -161,8 +161,8 @@ def test_npm_plugin_include_node(new_dir, partitions):
         ctx.execute(actions)
 
     binary = Path(lifecycle.project_info.prime_dir, "bin", "npm-hello")
-
-    output = subprocess.check_output([str(binary)], text=True)
+    node_path = Path(lifecycle.project_info.prime_dir, "bin", "node")
+    assert node_path.exists()
+    # try to use bundled Node.js to execute the script
+    output = subprocess.check_output([str(node_path), str(binary)], text=True)
     assert output == "hello world\n"
-
-    assert Path(lifecycle.project_info.prime_dir, "bin", "node").exists()

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -199,7 +199,7 @@ class TestPluginNpmPlugin:
         properties = NpmPlugin.properties_class.unmarshal({"source": "."})
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
-        assert plugin.get_build_environment() == {}
+        assert plugin.get_build_environment() == {"NODE_ENV": "production"}
 
     def test_get_build_environment_include_node_false(self, part_info, new_dir):
         properties = NpmPlugin.properties_class.unmarshal(
@@ -210,7 +210,7 @@ class TestPluginNpmPlugin:
         )
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
-        assert plugin.get_build_environment() == {}
+        assert plugin.get_build_environment() == {"NODE_ENV": "production"}
 
     def test_get_build_environment_include_node_true(self, part_info, new_dir):
         properties = NpmPlugin.properties_class.unmarshal(
@@ -224,6 +224,7 @@ class TestPluginNpmPlugin:
 
         assert plugin.get_build_environment() == {
             "PATH": "${CRAFT_PART_INSTALL}/bin:${PATH}",
+            "NODE_ENV": "production",
         }
 
     def test_get_build_commands(self, part_info, new_dir):
@@ -231,7 +232,13 @@ class TestPluginNpmPlugin:
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
         assert plugin.get_build_commands() == [
-            'npm install -g --prefix "${CRAFT_PART_INSTALL}" $(npm pack . | tail -1)',
+            'NPM_VERSION="$(npm --version)"\n'
+            "# use the new-style install command if npm >= 10.0.0\n"
+            "if ((${NPM_VERSION%%.*}>=10)); then\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" --install-links "${PWD}"\n'
+            "else\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" "$(npm pack . | tail -1)"\n'
+            "fi\n",
         ]
 
     def test_get_build_commands_false(self, part_info, new_dir):
@@ -241,7 +248,13 @@ class TestPluginNpmPlugin:
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
         assert plugin.get_build_commands() == [
-            'npm install -g --prefix "${CRAFT_PART_INSTALL}" $(npm pack . | tail -1)',
+            'NPM_VERSION="$(npm --version)"\n'
+            "# use the new-style install command if npm >= 10.0.0\n"
+            "if ((${NPM_VERSION%%.*}>=10)); then\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" --install-links "${PWD}"\n'
+            "else\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" "$(npm pack . | tail -1)"\n'
+            "fi\n",
         ]
 
     def test_get_build_commands_include_node_true(self, part_info, mocker, new_dir):
@@ -250,19 +263,41 @@ class TestPluginNpmPlugin:
             {
                 "source": ".",
                 "npm-include-node": True,
-                "npm-node-version": "16.14.2",
+                "npm-node-version": "99.99.99",
             }
         )
+        NpmPlugin._fetch_node_release_index = lambda: [
+            {
+                "version": "v99.99.99",
+                "date": "3304-12-31",
+                "files": ["linux-x64"],
+                "lts": False,
+                "security": False,
+            }
+        ]
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
+        assert plugin.get_pull_commands() == [
+            f'if [ ! -f "{part_info.part_cache_dir}/node-v99.99.99-linux-x64.tar.gz" ]; then\n'
+            f'    mkdir -p "{part_info.part_cache_dir}"\n'
+            f'    curl --retry 5 -s "https://nodejs.org/dist/v99.99.99/SHASUMS256.txt" -o "{part_info.part_cache_dir}"/SHASUMS256.txt\n'
+            f'    curl --retry 5 -s "https://nodejs.org/dist/v99.99.99/node-v99.99.99-linux-x64.tar.gz" -o "{part_info.part_cache_dir}/node-v99.99.99-linux-x64.tar.gz"\n'
+            "fi\n"
+            f'cd "{part_info.part_cache_dir}"\n'
+            "sha256sum --ignore-missing --strict -c SHASUMS256.txt\n"
+        ]
+
         assert plugin.get_build_commands() == [
-            'if [ ! -f "${CRAFT_PART_INSTALL}/bin/node" ]; then\n'
-            '    curl -s "https://nodejs.org/dist/v16.14.2/'
-            'node-v16.14.2-linux-x64.tar.gz" |\n'
-            '    tar xzf - -C "${CRAFT_PART_INSTALL}/"                         '
-            "--no-same-owner --strip-components=1\n"
+            f'tar -xzf "{part_info.part_cache_dir}/node-v99.99.99-linux-x64.tar.gz"'
+            ' -C "${CRAFT_PART_INSTALL}/"                     --no-same-owner '
+            "--strip-components=1\n",
+            'NPM_VERSION="$(npm --version)"\n'
+            "# use the new-style install command if npm >= 10.0.0\n"
+            "if ((${NPM_VERSION%%.*}>=10)); then\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" --install-links "${PWD}"\n'
+            "else\n"
+            '    npm install -g --prefix "${CRAFT_PART_INSTALL}" "$(npm pack . | tail -1)"\n'
             "fi\n",
-            'npm install -g --prefix "${CRAFT_PART_INSTALL}" $(npm pack . | tail -1)',
         ]
 
     def test_get_build_commands_include_node_true_no_node_version(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request refactors the NPM plugin and contains the following changes:

* npm-node-version option now accepts an NVM-style version identifier
* Move Node.js download to pull commands
* Verify SHA256 checksums after the Node.js download
* Use new-style npm-install commands if `npm` version is newer than ~~8.x~~ 10.x
* Set `NODE_ENV` to production by default
* Add documentation