### PR TITLE
fix(part_handler): fetch correct target stage packages

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -898,7 +898,7 @@ class PartHandler:
             fetched_packages = packages.Repository.fetch_stage_packages(
                 cache_dir=step_info.cache_dir,
                 package_names=stage_packages,
-                arch=step_info.host_arch,
+                arch=step_info.target_arch,
                 base=step_info.base,
                 stage_packages_path=self._part.part_packages_dir,
             )

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -698,7 +698,7 @@ class TestPackages:
         assert raised.value.package_name == "pkg1"
 
     def test_pull_fetch_stage_packages_arch(self, mocker, new_dir, partitions):
-        """Verify _run_pull fetches stage packages from the host architecture."""
+        """Verify _run_pull fetches stage packages for the target architecture."""
         getpkg = mocker.patch(
             "craft_parts.packages.Repository.fetch_stage_packages",
             return_value=["pkg1"],
@@ -737,7 +737,7 @@ class TestPackages:
             base=mocker.ANY,
             package_names=mocker.ANY,
             stage_packages_path=mocker.ANY,
-            arch=part_info.host_arch,
+            arch=part_info.target_arch,
         )
 
     def test_fetch_stage_snaps(self, mocker, new_dir, partitions):

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -16,8 +16,9 @@
 
 import logging
 import os
+import platform
 from pathlib import Path
-from typing import cast
+from typing import Dict, cast
 from unittest.mock import call
 
 import pytest
@@ -706,7 +707,24 @@ class TestPackages:
         part = Part(
             "foo", {"plugin": "nil", "stage-packages": ["pkg1"]}, partitions=partitions
         )
-        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+
+        _platform_machine_translations: Dict[str, str] = {
+            # Maps other possible ``platform.machine()`` values to the arch translations below.
+            "arm64": "aarch64",
+            "armv7hl": "armv7l",
+            "i386": "i686",
+            "amd64": "x86_64",
+            "x64": "x86_64",
+        }
+
+        machine = platform.machine()
+        host_arch = _platform_machine_translations.get(machine.lower(), machine)
+        target_arch = "aarch64"
+
+        if host_arch != "x86_64":
+            target_arch = "x86_64"
+
+        info = ProjectInfo(application_name="test", cache_dir=new_dir, arch=target_arch)
         part_info = PartInfo(info, part)
         ovmgr = OverlayManager(project_info=info, part_list=[part], base_layer_dir=None)
         handler = PartHandler(


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This is a partial attempt at fixing https://github.com/canonical/snapcraft/issues/4542 specifically [Alex's comment](https://github.com/canonical/snapcraft/issues/4542#issuecomment-1934943478).

Note that this change does not take into consideration cases where the stage package is only available for `architecture: all`.