### PR TITLE
fix(sequencer): rerun steps only if explicitly requested

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,7 +84,7 @@ jobs:
           # Build Chisel: needs a newer version of go than is available in Ubuntu 20.04
           sudo snap install --classic --channel=latest/stable go
           git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout v0.9.0
+          cd chisel-tmp && git checkout v0.9.1
           go mod download
           sudo go build -o /usr/bin ./...
           chisel --help
@@ -149,7 +149,7 @@ jobs:
           # the test files in /tmp/pytest-*
           sudo snap install --classic --channel=latest/stable go
           git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout v0.9.0
+          cd chisel-tmp && git checkout v0.9.1
           go mod download
           sudo go build -o /usr/bin ./...
           chisel --help

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -223,7 +223,11 @@ class LifecycleManager:
         packages.Repository.refresh_packages_list()
 
     def plan(
-        self, target_step: Step, part_names: Optional[Sequence[str]] = None, *, rerun: bool=False
+        self,
+        target_step: Step,
+        part_names: Optional[Sequence[str]] = None,
+        *,
+        rerun: bool = False,
     ) -> List[Action]:
         """Obtain the list of actions to be executed given the target step and parts.
 

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -223,7 +223,7 @@ class LifecycleManager:
         packages.Repository.refresh_packages_list()
 
     def plan(
-        self, target_step: Step, part_names: Optional[Sequence[str]] = None
+        self, target_step: Step, part_names: Optional[Sequence[str]] = None, *, rerun: bool=False
     ) -> List[Action]:
         """Obtain the list of actions to be executed given the target step and parts.
 
@@ -234,7 +234,7 @@ class LifecycleManager:
         :return: The list of :class:`Action` objects that should be executed in
             order to reach the target step for the specified parts.
         """
-        return self._sequencer.plan(target_step, part_names)
+        return self._sequencer.plan(target_step, part_names, rerun=rerun)
 
     def reload_state(self) -> None:
         """Reload the ephemeral state from disk."""

--- a/craft_parts/overlays/layers.py
+++ b/craft_parts/overlays/layers.py
@@ -78,7 +78,7 @@ class LayerHash:
 
         :param part: The part whose layer hash will be loaded.
 
-        :return: A layer hash object containing the loaded validaton hash,
+        :return: A layer hash object containing the loaded validation hash,
             or None if the file doesn't exist.
         """
         hash_file = part.part_state_dir / "layer_hash"

--- a/craft_parts/packages/yum.py
+++ b/craft_parts/packages/yum.py
@@ -144,7 +144,7 @@ class YUMRepository(BaseRepository):
 
         # XXX Facundo 2023-02-07: the information returned by this method is not used
         # anywhere, so we should clean it up and just return None (here, and in the
-        # Ubuntu reposity too, where a further cleaning should be done) -- related
+        # Ubuntu repository too, where a further cleaning should be done) -- related
         # to this, `list_only` should go away.
         return []
 

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -74,6 +74,7 @@ class Sequencer:
         self,
         target_step: Step,
         part_names: Optional[Sequence[str]] = None,
+        *,
         rerun: bool = False,
     ) -> List[Action]:
         """Determine the list of steps to execute for each part.
@@ -127,7 +128,6 @@ class Sequencer:
         current_step: Step,
         target_step: Step,
         part: Part,
-        part_names: Optional[Sequence[str]],
         reason: Optional[str] = None,
         rerun_target_step: bool = False,
     ) -> None:

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -71,12 +71,16 @@ class Sequencer:
                 self._overlay_viewers.add(part)
 
     def plan(
-        self, target_step: Step, part_names: Optional[Sequence[str]] = None
+        self,
+        target_step: Step,
+        part_names: Optional[Sequence[str]] = None,
+        rerun: bool = False,
     ) -> List[Action]:
         """Determine the list of steps to execute for each part.
 
         :param target_step: The final step to execute for the given part names.
         :param part_names: The names of the parts to process.
+        :param rerun: Whether the step is cleaned before execution.
 
         :returns: The list of actions that should be executed.
         """
@@ -84,7 +88,7 @@ class Sequencer:
             raise errors.FeatureError("Overlay step is not supported.")
 
         self._actions = []
-        self._add_all_actions(target_step, part_names)
+        self._add_all_actions(target_step, part_names, rerun_target_step=rerun)
         return self._actions
 
     def reload_state(self) -> None:
@@ -98,6 +102,8 @@ class Sequencer:
         target_step: Step,
         part_names: Optional[Sequence[str]] = None,
         reason: Optional[str] = None,
+        *,
+        rerun_target_step: bool = False,
     ) -> None:
         selected_parts = part_list_by_name(part_names, self._part_list)
         if not selected_parts:
@@ -112,6 +118,7 @@ class Sequencer:
                     part=part,
                     part_names=part_names,
                     reason=reason,
+                    rerun_target_step=rerun_target_step,
                 )
 
     def _add_step_actions(
@@ -122,6 +129,7 @@ class Sequencer:
         part: Part,
         part_names: Optional[Sequence[str]],
         reason: Optional[str] = None,
+        rerun_target_step: bool = False,
     ) -> None:
         """Verify if this step should be executed."""
         # if overlays disabled, don't generate overlay actions
@@ -138,12 +146,12 @@ class Sequencer:
 
         # If the step has already run:
         #
-        # 1. If the step is the exact step that was requested, and the part was
-        #    explicitly listed, run it again.
+        # 1. If the step is the exact step that was requested, check whether it
+        #    should be re-executed.
 
-        if part_names and current_step == target_step and part.name in part_names:
+        if current_step == target_step and rerun_target_step:
             if not reason:
-                reason = "requested step"
+                reason = "rerun step"
             self._rerun_step(part, current_step, reason=reason)
             return
 

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -117,7 +117,6 @@ class Sequencer:
                     current_step=current_step,
                     target_step=target_step,
                     part=part,
-                    part_names=part_names,
                     reason=reason,
                     rerun_target_step=rerun_target_step,
                 )

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -104,7 +104,7 @@ def test_basic_lifecycle_actions(new_dir, partitions, mocker):
     assert actions == [
         # fmt: off
         Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        Action("bar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on
     ]
     with lf.action_executor() as ctx:
@@ -124,7 +124,7 @@ def test_basic_lifecycle_actions(new_dir, partitions, mocker):
         Action("foo", Step.PULL, action_type=ActionType.RERUN, reason="'source' property changed"),
         Action("foo", Step.BUILD, action_type=ActionType.RUN, reason="required to build 'bar'"),
         Action("foo", Step.STAGE, action_type=ActionType.RUN, reason="required to build 'bar'"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
         # fmt: on
     ]
     with lf.action_executor() as ctx:
@@ -162,7 +162,7 @@ def test_basic_lifecycle_actions(new_dir, partitions, mocker):
                properties=ActionProperties(changed_files=["a.tar.gz"], changed_dirs=[])),
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
-        Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="required to build 'bar'"),
+        Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="'BUILD' step changed"),
         Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
         Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -186,6 +186,49 @@ def test_basic_lifecycle_actions(new_dir, partitions, mocker):
         ctx.execute(actions)
 
 
+def test_lifecycle_rerun_actions(new_dir, partitions, mocker):
+    parts = yaml.safe_load(basic_parts_yaml)
+
+    Path("a.tar.gz").touch()
+
+    # no need to untar the file
+    mocker.patch("craft_parts.sources.tar_source.TarSource.provision")
+
+    # See https://gist.github.com/sergiusens/dcae19c301eb59e091f92ab29d7d03fc
+
+    # first run
+    # command pull
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir, partitions=partitions
+    )
+    actions = lf.plan(Step.PULL)
+    assert actions == [
+        Action("foo", Step.PULL),
+        Action("bar", Step.PULL),
+        Action("foobar", Step.PULL),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # rerun skips pull...
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir, partitions=partitions
+    )
+    actions = lf.plan(Step.PULL)
+    assert actions == [
+        Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
+    ]
+
+    # ...except if explicit rerun is set
+    actions = lf.plan(Step.PULL, rerun=True)
+    assert actions == [
+        Action("foo", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"),
+        Action("bar", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"),
+        Action("foobar", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"),
+    ]
+
 @pytest.mark.usefixtures("new_dir")
 class TestCleaning:
     @pytest.fixture(autouse=True)

--- a/tests/integration/lifecycle/test_lifecycle.py
+++ b/tests/integration/lifecycle/test_lifecycle.py
@@ -229,6 +229,7 @@ def test_lifecycle_rerun_actions(new_dir, partitions, mocker):
         Action("foobar", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"),
     ]
 
+
 @pytest.mark.usefixtures("new_dir")
 class TestCleaning:
     @pytest.fixture(autouse=True)

--- a/tests/integration/lifecycle/test_lifecycle_overlay.py
+++ b/tests/integration/lifecycle/test_lifecycle_overlay.py
@@ -116,7 +116,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
         # fmt: off
         Action("bar", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("bar", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        Action("bar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on
     ]
     with lf.action_executor() as ctx:

--- a/tests/integration/lifecycle/test_lifecycle_overlay.py
+++ b/tests/integration/lifecycle/test_lifecycle_overlay.py
@@ -138,7 +138,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
         Action("foo", Step.OVERLAY, action_type=ActionType.RUN, reason="required to build 'bar'"),
         Action("foo", Step.BUILD, action_type=ActionType.RUN, reason="required to build 'bar'"),
         Action("foo", Step.STAGE, action_type=ActionType.RUN, reason="required to build 'bar'"),
-        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="requested step"),
+        Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
         # fmt: on
     ]
     with lf.action_executor() as ctx:
@@ -183,7 +183,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
-        Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="required to build 'bar'"),
+        Action("foo", Step.STAGE, action_type=ActionType.RERUN, reason="'BUILD' step changed"),
         Action("bar", Step.BUILD, action_type=ActionType.RERUN, reason="stage for part 'foo' changed"),
         Action("foobar", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
         # fmt: on

--- a/tests/integration/lifecycle/test_overlay.py
+++ b/tests/integration/lifecycle/test_overlay.py
@@ -116,7 +116,7 @@ class TestOverlayLayerOrder:
         assert actions == [
             # fmt: off
             Action("p3", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
-            Action("p3", Step.OVERLAY, action_type=ActionType.RERUN, reason="requested step"),
+            Action("p3", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
             # fmt: on
         ]
 
@@ -146,9 +146,7 @@ class TestOverlayLayerOrder:
         assert actions == [
             # fmt: off
             Action("p3", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
-            Action("p2", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
-            Action("p2", Step.OVERLAY, action_type=ActionType.RERUN, reason="required to overlay 'p3'"),
-            Action("p3", Step.OVERLAY, action_type=ActionType.RERUN, reason="requested step"),
+            Action("p3", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
             # fmt: on
         ]
 

--- a/tests/integration/sequencer/test_sequencer.py
+++ b/tests/integration/sequencer/test_sequencer.py
@@ -170,8 +170,9 @@ class TestSequencerPlan:
             Action("bar", Step.PRIME, action_type=ActionType.RUN),
         ]
 
+    @pytest.mark.parametrize("rerun", [False, True])
     @pytest.mark.usefixtures("pull_state")
-    def test_plan_requested_part_step(self, partitions):
+    def test_plan_requested_part_step(self, partitions, rerun):
         p1 = Part("foo", {"plugin": "nil"}, partitions=partitions)
 
         seq = sequencer.Sequencer(
@@ -179,13 +180,20 @@ class TestSequencerPlan:
             project_info=self._project_info,
         )
 
-        actions = seq.plan(Step.PULL, part_names=["foo"])
+        actions = seq.plan(Step.PULL, part_names=["foo"], rerun=rerun)
 
-        assert actions == [
-            Action(
-                "foo", Step.PULL, action_type=ActionType.RERUN, reason="requested step"
-            ),
-        ]
+        if rerun:
+            assert actions == [
+                Action(
+                    "foo", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"
+                ),
+            ]
+        else:
+            assert actions == [
+                Action(
+                    "foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"
+                ),
+            ]
 
     @pytest.mark.usefixtures("pull_state")
     def test_plan_dirty_step(self, partitions):

--- a/tests/integration/sequencer/test_sequencer_overlay.py
+++ b/tests/integration/sequencer/test_sequencer_overlay.py
@@ -174,8 +174,9 @@ class TestSequencerPlan:
             Action("bar", Step.PRIME, action_type=ActionType.RUN),
         ]
 
+    @pytest.mark.parametrize("rerun", [False, True])
     @pytest.mark.usefixtures("pull_state")
-    def test_plan_requested_part_step(self):
+    def test_plan_requested_part_step(self, rerun):
         p1 = Part("foo", {"plugin": "nil"})
 
         seq = sequencer.Sequencer(
@@ -183,13 +184,20 @@ class TestSequencerPlan:
             project_info=ProjectInfo(application_name="test", cache_dir=Path()),
         )
 
-        actions = seq.plan(Step.PULL, part_names=["foo"])
+        actions = seq.plan(Step.PULL, part_names=["foo"], rerun=rerun)
 
-        assert actions == [
-            Action(
-                "foo", Step.PULL, action_type=ActionType.RERUN, reason="requested step"
-            ),
-        ]
+        if rerun:
+            assert actions == [
+                Action(
+                    "foo", Step.PULL, action_type=ActionType.RERUN, reason="rerun step"
+                ),
+            ]
+        else:
+            assert actions == [
+                Action(
+                    "foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"
+                ),
+            ]
 
     @pytest.mark.usefixtures("pull_state")
     def test_plan_dirty_step(self):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -370,7 +370,6 @@ def test_main_step_specify_part_dry_run(mocker, capfd):
                 "Build foo\n"
                 "Stage foo (required to build 'bar')\n"
                 "Build bar\n"
-                "Restage foo (requested step)\n"
                 "Stage bar\n"
             ),
         ),

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -28,9 +28,9 @@ from craft_parts.steps import Step
 
 @pytest.mark.parametrize(
     ("rerun", "action", "reason"),
-    ((False, ActionType.SKIP, "already ran"), (True, ActionType.RERUN, "rerun step")),
+    [(False, ActionType.SKIP, "already ran"), (True, ActionType.RERUN, "rerun step")],
 )
-@pytest.mark.parametrize(("step"), (Step.PULL, Step.BUILD, Step.STAGE, Step.PRIME))
+@pytest.mark.parametrize(("step"), [Step.PULL, Step.BUILD, Step.STAGE, Step.PRIME])
 def test_sequencer_plan(step, action, reason, rerun, mocker, new_dir):
     mocker.patch(
         "craft_parts.state_manager.state_manager.StateManager.has_step_run",

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -26,6 +26,29 @@ from craft_parts.state_manager import states
 from craft_parts.steps import Step
 
 
+@pytest.mark.parametrize(
+    ("rerun", "action", "reason"),
+    ((False, ActionType.SKIP, "already ran"), (True, ActionType.RERUN, "rerun step")),
+)
+@pytest.mark.parametrize(("step"), (Step.PULL, Step.BUILD, Step.STAGE, Step.PRIME))
+def test_sequencer_plan(step, action, reason, rerun, mocker, new_dir):
+    mocker.patch(
+        "craft_parts.state_manager.state_manager.StateManager.has_step_run",
+        new=lambda _, x, y: y == step,
+    )
+    info = ProjectInfo(application_name="test", cache_dir=new_dir)
+    p1 = Part("p1", {})
+    seq = Sequencer(part_list=[p1], project_info=info)
+
+    seq.plan(step, part_names=["p1"], rerun=rerun)
+    actions = [
+        Action(part_name="p1", step=s, action_type=ActionType.RUN)
+        for s in step.previous_steps()
+    ]
+    actions.append(Action(part_name="p1", step=step, action_type=action, reason=reason))
+    assert seq._actions == actions
+
+
 def test_sequencer_add_actions(new_dir):
     info = ProjectInfo(application_name="test", cache_dir=new_dir)
     p1 = Part("p1", {})


### PR DESCRIPTION
Instead of implicitly cleaning and re-executing steps when a part name
is specified, only do it when explicitly requested by the user.
Applications must set the `rerun` argument accordingly when planning
the lifecycle execution.

Fixes canonical/snapcraft#4806

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
