### PR TITLE
Release 1.31.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.30.0
+current_version = 1.31.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,10 +3,6 @@ current_version = 1.30.0
 commit = True
 tag = True
 
-[bumpversion:file:docs/conf.py]
-search = release = "{current_version}"
-replace = release = "{new_version}"
-
 [bumpversion:file:setup.py]
 search = VERSION = "{current_version}"
 replace = VERSION = "{new_version}"

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft a project from several parts."""
 
-__version__ = "1.30.0"
+__version__ = "1.31.0"
 
 from . import plugins
 from .actions import Action, ActionProperties, ActionType

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ Changelog
 - New and improved documentation
   - Add go plugin reference
   - Add nil plugin reference
-  - Add make pliugin reference
+  - Add make plugin reference
   - Add autotools plugin reference
   - Add cmake plugin reference
   - Add scons plugin reference

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,30 @@
 Changelog
 *********
 
+1.31.0 (2024-05-16)
+-------------------
+
+- Refactored npm plugin
+  - npm-node-version option now accepts a NVM-style version identifier
+  - Move Node.js download to pull commands
+  - Verify SHA256 checksums after node.js download
+  - Use new-style npm-install commands if npm version is newer than 8.x
+  - Set NODE_ENV to production by default
+- New and improved documentation
+  - Add go plugin reference
+  - Add nil plugin reference
+  - Add make pliugin reference
+  - Add autotools plugin reference
+  - Add cmake plugin reference
+  - Add scons plugin reference
+  - Add ant plugin reference
+  - Add dotnet plugin reference
+  - Add meson plugin reference
+  - Documentation fixes
+
 1.30.0 (2024-05-16)
 -------------------
+
 - Add support for armv8l
 - Add support for unregistering plugins
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import re
 
 from setuptools import find_packages, setup
 
-VERSION = "1.30.0"
+VERSION = "1.31.0"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
## Changelog

- Refactored npm plugin
  - npm-node-version option now accepts a NVM-style version identifier
  - Move Node.js download to pull commands
  - Verify SHA256 checksums after node.js download
  - Use new-style npm-install commands if npm version is newer than 8.x
  - Set NODE_ENV to production by default
- New and improved documentation
  - Add go plugin reference
  - Add nil plugin reference
  - Add make pliugin reference
  - Add autotools plugin reference
  - Add cmake plugin reference
  - Add scons plugin reference
  - Add ant plugin reference
  - Add dotnet plugin reference
  - Add meson plugin reference
  - Documentation fixes