### PR TITLE
fix(setup.py): temporarily limits `requests` version to fix CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     "pydantic>=1.9.0,<2.0.0",
     "pydantic-yaml[pyyaml]>=0.11.0,<1.0.0",
     "pyxdg",
-    "requests",
+    "requests<2.32.0",
     "requests-unixsocket",
     # See: https://github.com/msabramo/requests-unixsocket/pull/69
     # When updating to urllib3 v2, also remove the constraint on types-requests.


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request temporarily limits `requests` version to avoid a breaking change in the behaviour that renders craft_parts unusable.

See also:

- https://github.com/psf/requests/issues/6707
- https://github.com/canonical/pylxd/issues/579
- https://github.com/docker/docker-py/issues/3256