### PR TITLE
feat(deb): only run apt update as superuser

### DIFF
--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -464,7 +464,7 @@ class StepInfo:
         self._part_info = part_info
         self.step = step
         self.step_environment: Dict[str, str] = {}
-        self.state: "Optional[states.StepState]" = None
+        self.state: Optional[states.StepState] = None
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
         if hasattr(self._part_info, name):

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -408,7 +408,8 @@ class Ubuntu(BaseRepository):
     ) -> None:
         """Refresh the list of packages available in the repository."""
         # Return early when testing.
-        if os.getenv("CRAFT_PARTS_PACKAGE_REFRESH", "1") == "0":
+        if os.geteuid() != 0:
+            logger.debug("cannot refresh packages list, EUID is not 0")
             return
 
         try:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -409,7 +409,7 @@ class Ubuntu(BaseRepository):
         """Refresh the list of packages available in the repository."""
         # Return early when testing.
         if os.geteuid() != 0:
-            logger.debug("cannot refresh packages list, EUID is not 0")
+            logger.warning("Packages list not refreshed, not running as superuser.")
             return
 
         try:

--- a/tests/integration/plugins/test_ant.py
+++ b/tests/integration/plugins/test_ant.py
@@ -22,8 +22,7 @@ import yaml
 from craft_parts import LifecycleManager, Step
 
 
-def test_ant_plugin(new_dir, partitions, monkeypatch):
-    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
+def test_ant_plugin(new_dir, partitions):
     source_location = Path(__file__).parent / "test_ant"
 
     parts_yaml = textwrap.dedent(

--- a/tests/integration/plugins/test_autotools.py
+++ b/tests/integration/plugins/test_autotools.py
@@ -22,9 +22,7 @@ import yaml
 from craft_parts import LifecycleManager, Step
 
 
-def test_autotools_plugin(new_dir, partitions, monkeypatch):
-    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
-
+def test_autotools_plugin(new_dir, partitions):
     parts_yaml = textwrap.dedent(
         """
         parts:

--- a/tests/integration/plugins/test_maven.py
+++ b/tests/integration/plugins/test_maven.py
@@ -22,8 +22,7 @@ import yaml
 from craft_parts import LifecycleManager, Step
 
 
-def test_maven_plugin(new_dir, partitions, monkeypatch):
-    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
+def test_maven_plugin(new_dir, partitions):
     source_location = Path(__file__).parent / "test_maven"
 
     parts_yaml = textwrap.dedent(

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -50,7 +50,6 @@ def test_logging_info(new_dir, caplog, monkeypatch):
     Path("parts.yaml").write_text(parts_yaml)
 
     monkeypatch.setattr(sys, "argv", ["build"])
-    monkeypatch.setenv("CRAFT_PARTS_PACKAGE_REFRESH", "0")
 
     main.main()
 

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -112,6 +112,7 @@ def test_fake_wrapper_apt_unavailable(monkeypatch):
 class TestPackages:
     def test_fetch_stage_packages(self, mocker, tmpdir, fake_apt_cache, fake_deb_run):
         # pylint: disable=unnecessary-dunder-call
+        mocker.patch("os.geteuid", return_value=0)
         mocker.patch(
             "craft_parts.packages.deb._DEFAULT_FILTERED_STAGE_PACKAGES",
             {"filtered-pkg-1", "filtered-pkg-2"},
@@ -144,7 +145,8 @@ class TestPackages:
 
         assert fetched_packages == ["fake-package=1.0"]
 
-    def test_fetch_virtual_stage_package(self, tmpdir, fake_apt_cache, fake_deb_run):
+    def test_fetch_virtual_stage_package(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+        mocker.patch("os.geteuid", return_value=0)
         _, debs_path = deb.get_cache_dirs(tmpdir)
         fake_package = debs_path / "fake-package_1.0_all.deb"
         fake_package.touch()
@@ -163,7 +165,8 @@ class TestPackages:
         assert fake_deb_run.mock_calls == [call(["apt-get", "update"])]
         assert fetched_packages == ["fake-package=1.0"]
 
-    def test_fetch_stage_package_with_deps(self, tmpdir, fake_apt_cache, fake_deb_run):
+    def test_fetch_stage_package_with_deps(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+        mocker.patch("os.geteuid", return_value=0)
         _, debs_path = deb.get_cache_dirs(tmpdir)
         fake_package = debs_path / "fake-package_1.0_all.deb"
         fake_package.touch()
@@ -191,6 +194,7 @@ class TestPackages:
         self, mocker, tmpdir, fake_apt_cache, fake_deb_run
     ):
         # pylint: disable=unnecessary-dunder-call
+        mocker.patch("os.geteuid", return_value=0)
         mocker.patch(
             "craft_parts.packages.deb._DEFAULT_FILTERED_STAGE_PACKAGES",
             {"filtered-pkg-1"},
@@ -248,7 +252,8 @@ class TestPackages:
 
         assert fetched_packages == []
 
-    def test_get_package_fetch_error(self, tmpdir, fake_apt_cache, fake_deb_run):
+    def test_get_package_fetch_error(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.fetch_archives.side_effect = errors.PackageFetchError(
             "foo"
         )
@@ -281,7 +286,8 @@ class TestPackages:
 
         assert mock_normalize.mock_calls == []
 
-    def test_download_packages(self, fake_apt_cache, fake_deb_run):
+    def test_download_packages(self, fake_apt_cache, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         deb.Ubuntu.refresh_packages_list()
         deb.Ubuntu.download_packages(["package", "versioned-package=2.0"])
 
@@ -310,7 +316,8 @@ class TestPackages:
 
 class TestBuildPackages:
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_install_build_packages(self, fake_apt_cache, fake_deb_run):
+    def test_install_build_packages(self, fake_apt_cache, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0"),
             ("package-installed", "1.0"),
@@ -364,7 +371,8 @@ class TestBuildPackages:
         assert fake_deb_run.mock_calls == []
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_already_installed_no_specified_version(self, fake_apt_cache, fake_deb_run):
+    def test_already_installed_no_specified_version(self, fake_apt_cache, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "1.0")
         ]
@@ -395,8 +403,9 @@ class TestBuildPackages:
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_already_installed_with_specified_version(
-        self, fake_apt_cache, fake_deb_run
+        self, fake_apt_cache, fake_deb_run, mocker
     ):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "1.0")
         ]
@@ -427,8 +436,9 @@ class TestBuildPackages:
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
     def test_already_installed_with_different_version(
-        self, fake_apt_cache, fake_deb_run
+        self, fake_apt_cache, fake_deb_run, mocker
     ):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("new-version", "3.0")
         ]
@@ -460,7 +470,8 @@ class TestBuildPackages:
         ]
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_install_virtual_build_package(self, fake_apt_cache, fake_deb_run):
+    def test_install_virtual_build_package(self, fake_apt_cache, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("resolved-virtual-package", "1.0")
         ]
@@ -492,7 +503,8 @@ class TestBuildPackages:
         ]
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_smart_terminal(self, fake_apt_cache, fake_deb_run, fake_dumb_terminal):
+    def test_smart_terminal(self, fake_apt_cache, fake_deb_run, fake_dumb_terminal, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         fake_dumb_terminal.return_value = False
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package", "1.0")
@@ -544,12 +556,14 @@ class TestBuildPackages:
             deb.Ubuntu.install_packages(["package=1.0"])
         assert raised.value.packages == ["package=1.0"]
 
-    def test_refresh_packages_list(self, fake_deb_run):
+    def test_refresh_packages_list(self, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         deb.Ubuntu.refresh_packages_list()
 
         assert fake_deb_run.mock_calls == [call(["apt-get", "update"])]
 
-    def test_refresh_packages_list_fails(self, fake_deb_run):
+    def test_refresh_packages_list_fails(self, fake_deb_run, mocker):
+        mocker.patch("os.geteuid", return_value=0)
         fake_deb_run.side_effect = CalledProcessError(
             returncode=1, cmd=["apt-get", "update"]
         )
@@ -667,6 +681,7 @@ class TestStagePackagesFilters:
     def test_fetch_stage_packages_with_filtering(
         self, mocker, tmpdir, fake_apt_cache, fake_deb_run
     ):
+        mocker.patch("os.geteuid", return_value=0)
         callbacks.register_stage_packages_filter(lambda x: ["base-pkg-1"])
         callbacks.register_stage_packages_filter(lambda x: ["base-pkg-2", "base-pkg-3"])
 

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -145,7 +145,9 @@ class TestPackages:
 
         assert fetched_packages == ["fake-package=1.0"]
 
-    def test_fetch_virtual_stage_package(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+    def test_fetch_virtual_stage_package(
+        self, tmpdir, mocker, fake_apt_cache, fake_deb_run
+    ):
         mocker.patch("os.geteuid", return_value=0)
         _, debs_path = deb.get_cache_dirs(tmpdir)
         fake_package = debs_path / "fake-package_1.0_all.deb"
@@ -165,7 +167,9 @@ class TestPackages:
         assert fake_deb_run.mock_calls == [call(["apt-get", "update"])]
         assert fetched_packages == ["fake-package=1.0"]
 
-    def test_fetch_stage_package_with_deps(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+    def test_fetch_stage_package_with_deps(
+        self, tmpdir, mocker, fake_apt_cache, fake_deb_run
+    ):
         mocker.patch("os.geteuid", return_value=0)
         _, debs_path = deb.get_cache_dirs(tmpdir)
         fake_package = debs_path / "fake-package_1.0_all.deb"
@@ -252,7 +256,9 @@ class TestPackages:
 
         assert fetched_packages == []
 
-    def test_get_package_fetch_error(self, tmpdir, mocker, fake_apt_cache, fake_deb_run):
+    def test_get_package_fetch_error(
+        self, tmpdir, mocker, fake_apt_cache, fake_deb_run
+    ):
         mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.fetch_archives.side_effect = errors.PackageFetchError(
             "foo"
@@ -371,7 +377,9 @@ class TestBuildPackages:
         assert fake_deb_run.mock_calls == []
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_already_installed_no_specified_version(self, fake_apt_cache, fake_deb_run, mocker):
+    def test_already_installed_no_specified_version(
+        self, fake_apt_cache, fake_deb_run, mocker
+    ):
         mocker.patch("os.geteuid", return_value=0)
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [
             ("package-installed", "1.0")
@@ -503,7 +511,9 @@ class TestBuildPackages:
         ]
 
     @pytest.mark.usefixtures("fake_all_packages_installed")
-    def test_smart_terminal(self, fake_apt_cache, fake_deb_run, fake_dumb_terminal, mocker):
+    def test_smart_terminal(
+        self, fake_apt_cache, fake_deb_run, fake_dumb_terminal, mocker
+    ):
         mocker.patch("os.geteuid", return_value=0)
         fake_dumb_terminal.return_value = False
         fake_apt_cache.return_value.__enter__.return_value.get_packages_marked_for_installation.return_value = [

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -105,7 +105,7 @@ def test_part_specification_error():
 
 
 def test_part_specification_error_from_validation_error() -> None:
-    error_list: List["ErrorDict"] = [
+    error_list: List[ErrorDict] = [
         {"loc": ("field-1", 0), "msg": "something is wrong", "type": "value_error"},
         {"loc": ("field-2",), "msg": "field required", "type": "value_error"},
         {


### PR DESCRIPTION
Instead of relying on a user-supplied environment variable, check for
the user id and skip running ``apt update`` if not running as root.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
