### PR TITLE
feat(deb): Don't run apt-get update as non-root user

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -411,6 +411,10 @@ class Ubuntu(BaseRepository):
         if os.getenv("CRAFT_PARTS_PACKAGE_REFRESH", "1") == "0":
             return
 
+        # Skip when running as non-root user.
+        if os.geteuid() != 0:
+            return
+
         try:
             cmd = ["apt-get", "update"]
             logger.debug("Executing: %s", cmd)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

`apt-get update` will fail as non-root user. It is only needed when some build-dependencies are not installed yet. If all build dependencies are installed, craft-parts can be run without root permissions. This was previously only possible by setting the environment variable `CRAFT_PARTS_PACKAGE_REFRESH=0`.