### PR TITLE
 fix: add list of ignore packages in core24

### DIFF
--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -249,6 +249,46 @@ _IGNORE_FILTERS: Dict[str, Set[str]] = {
         "python3-yaml",
         "python3-zipp",
     },
+    "core24": {
+        "python3-attr",
+        "python3-blinker",
+        "python3-certifi",
+        "python3-cffi-backend",
+        "python3-chardet",
+        "python3-configobj",
+        "python3-cryptography",
+        # Rely on setuptools installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-distutils"
+        "python3-idna",
+        "python3-importlib-metadata",
+        "python3-jinja2",
+        "python3-json-pointer",
+        "python3-jsonpatch",
+        "python3-jsonschema",
+        "python3-jwt",
+        "python3-markupsafe",
+        # Provides /usr/bin/python3, don't bring in unless explicitly requested.
+        # "python3-minimal"
+        "python3-more-itertools",
+        "python3-netifaces",
+        "python3-oauthlib",
+        # Rely on version brought in by setuptools, unless explicitly requested.
+        # "python3-pkg-resources"
+        "python3-pyrsistent",
+        "python3-pyudev",
+        "python3-requests",
+        "python3-requests-unixsocket",
+        "python3-serial",
+        # Rely on version installed by plugin or found in base, unless
+        # explicitly requested.
+        # "python3-setuptools"
+        "python3-six",
+        "python3-urllib3",
+        "python3-urwid",
+        "python3-yaml",
+        "python3-zipp",
+    },
 }
 
 

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -257,11 +257,9 @@ _IGNORE_FILTERS: Dict[str, Set[str]] = {
         "python3-chardet",
         "python3-configobj",
         "python3-cryptography",
-        # Rely on setuptools installed by plugin or found in base, unless
-        # explicitly requested.
-        # "python3-distutils"
+        "python3-dbus",
+        "python3-debconf",
         "python3-idna",
-        "python3-importlib-metadata",
         "python3-jinja2",
         "python3-json-pointer",
         "python3-jsonpatch",
@@ -270,24 +268,16 @@ _IGNORE_FILTERS: Dict[str, Set[str]] = {
         "python3-markupsafe",
         # Provides /usr/bin/python3, don't bring in unless explicitly requested.
         # "python3-minimal"
-        "python3-more-itertools",
         "python3-netifaces",
+        "python3-netplan",
         "python3-oauthlib",
         # Rely on version brought in by setuptools, unless explicitly requested.
         # "python3-pkg-resources"
         "python3-pyrsistent",
-        "python3-pyudev",
         "python3-requests",
-        "python3-requests-unixsocket",
         "python3-serial",
-        # Rely on version installed by plugin or found in base, unless
-        # explicitly requested.
-        # "python3-setuptools"
-        "python3-six",
         "python3-urllib3",
-        "python3-urwid",
         "python3-yaml",
-        "python3-zipp",
     },
 }
 

--- a/tests/unit/packages/test_deb.py
+++ b/tests/unit/packages/test_deb.py
@@ -769,3 +769,27 @@ def test_get_filtered_stage_package_empty_ignore_filter(mocker):
     )
 
     assert filtered_names == {"some-base-pkg", "some-other-base-pkg"}
+
+
+def test_get_filtered_stage_package_core24(mocker):
+    mock_get_packages_in_base = mocker.patch.object(deb, "get_packages_in_base")
+    mock_get_packages_in_base.return_value = [
+        DebPackage(name="some-package"),
+        DebPackage(name="python3-cffi"),
+        DebPackage(name="python3-cffi-backend"),
+        DebPackage(name="python3-jsonschema"),
+        DebPackage(name="python3-attr"),
+    ]
+
+    filtered_names = deb._get_filtered_stage_package_names(
+        base="core24",
+        package_list=[
+            DebPackage(name="python3-cffi"),
+            DebPackage(name="python3-jsonschema"),
+        ],
+        base_package_names=None,
+    )
+
+    # python3-cffi-backend and python3-attr must NOT be on the list of filtered
+    # names, even though they are present in the core24 base.
+    assert filtered_names == {"some-package"}


### PR DESCRIPTION
**Note:** This PR has 2 commits, but that's only to make the review easier: the first commit copies the list of core22 ignored packages into core24's, and then the second commit updates that list to reflect the contents of core24. So if you look at the second commit only you'll see just the diff.

---------

This list is updated based on the packages currently present on
/snap/core24/current/usr/share/snappy/dpkg.list. Note that some
packages are added, but mostly these are removals.