### PR TITLE
build: bump version to 1.31.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.0
+current_version = 1.31.1
 commit = True
 tag = True
 

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft a project from several parts."""
 
-__version__ = "1.31.0"
+__version__ = "1.31.1"
 
 from . import plugins
 from .actions import Action, ActionProperties, ActionType

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 *********
 
+1.31.1 (2024-06-24)
+-------------------
+
+- Fix list of ignored packages in core24 bases when fetching stage-packages
+
 1.31.0 (2024-05-16)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import re
 
 from setuptools import find_packages, setup
 
-VERSION = "1.31.0"
+VERSION = "1.31.1"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

New 1.31.x release to pull in the stage-packaging hotfix from 1.30.1.

I need this for snapcraft 8.3, which uses craft-parts 1.31