### PR TITLE
build: bump version to 1.32.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.31.1
+current_version = 1.32.0
 commit = True
 tag = True
 

--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft a project from several parts."""
 
-__version__ = "1.31.1"
+__version__ = "1.32.0"
 
 from . import plugins
 from .actions import Action, ActionProperties, ActionType

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,10 +2,16 @@
 Changelog
 *********
 
-1.31.1 (2024-06-24)
+1.32.0 (2024-06-24)
 -------------------
 
-- Fix list of ignored packages in core24 bases when fetching stage-packages
+- Adds support for 7z sources
+- Adds reference documentation for the qmake plugin
+- Improves logging output when fetching packages
+- Improves errors for when sources cannot be fetched
+- Fixes a behavior where apt packages would be fetched when the user was
+  not a superuser
+- Fixes list of ignored packages in core24 bases when fetching stage-packages
 
 1.31.0 (2024-05-16)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import re
 
 from setuptools import find_packages, setup
 
-VERSION = "1.31.1"
+VERSION = "1.32.0"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

I landed a PR for 1.31.1 before realizing there were commits on `main` that had new features.  

This PR bumps to 1.32.0 and removes 1.31.1 from the changelog since it was never tagged or released.