### PR TITLE
chore(ci): install rust plugin dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -146,7 +146,8 @@ jobs:
         run: |
 
           sudo apt install -y ninja-build cmake scons qt5-qmake p7zip \
-                              autoconf automake autopoint gcc git gperf help2man libtool texinfo
+                              autoconf automake autopoint gcc git gperf help2man libtool texinfo \
+                              curl findutils pkg-config
           # Build Chisel: needs a newer version of go than is available in Ubuntu 20.04
           # note: we can't use the snap here because it has strict confinement and can't access
           # the test files in /tmp/pytest-*


### PR DESCRIPTION
I don't know why this started happening just recently, but it looks like the CI
runner does not have the `pkg-config` (a rust plugin dep) package installed.
Instead, it looks like it has `pkgconf`, pulled in by `r-base-dev`. I say this
because those get removed when we explicitly install `pkg-config`:

```
...
 The following packages will be REMOVED:
   pkgconf r-base-dev
 The following NEW packages will be installed:
   autopoint cmake cmake-data dh-elpa-helper gperf help2man libjsoncpp25
   librhash0 ninja-build pkg-config qt5-qmake qt5-qmake-bin qtchooser scons
 0 upgraded, 14 newly installed, 2 to remove and 41 not upgraded.
...
```
