### PR TITLE
chore!: restructure plugin models

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -212,7 +212,7 @@ class Part:
             project_dirs = ProjectDirs(partitions=partitions)
 
         if not plugin_properties:
-            plugin_properties = PluginProperties()
+            plugin_properties = PluginProperties.unmarshal(data)
 
         plugin_name: str = data.get("plugin", "")
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -212,7 +212,12 @@ class Part:
             project_dirs = ProjectDirs(partitions=partitions)
 
         if not plugin_properties:
-            plugin_properties = PluginProperties.unmarshal(data)
+            try:
+                plugin_properties = PluginProperties.unmarshal(data)
+            except ValidationError as err:
+                raise errors.PartSpecificationError.from_validation_error(
+                    part_name=name, error_list=err.errors()
+                ) from err
 
         plugin_name: str = data.get("plugin", "")
 

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft Parts plugins subsystem."""
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .plugins import (
     PluginProperties,
     extract_part_properties,
@@ -32,7 +32,6 @@ from .validator import PluginEnvironmentValidator
 __all__ = [
     "Plugin",
     "PluginEnvironmentValidator",
-    "PluginModel",
     "PluginProperties",
     "extract_part_properties",
     "extract_plugin_properties",

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -18,7 +18,6 @@
 
 from .base import Plugin, extract_plugin_properties
 from .plugins import (
-    PluginProperties,
     extract_part_properties,
     get_plugin,
     get_plugin_class,
@@ -27,6 +26,7 @@ from .plugins import (
     unregister,
     unregister_all,
 )
+from .properties import PluginProperties
 from .validator import PluginEnvironmentValidator
 
 __all__ = [

--- a/craft_parts/plugins/__init__.py
+++ b/craft_parts/plugins/__init__.py
@@ -16,7 +16,7 @@
 
 """Craft Parts plugins subsystem."""
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .plugins import (
     extract_part_properties,
     get_plugin,
@@ -34,7 +34,6 @@ __all__ = [
     "PluginEnvironmentValidator",
     "PluginProperties",
     "extract_part_properties",
-    "extract_plugin_properties",
     "get_plugin",
     "get_plugin_class",
     "get_registered_plugins",

--- a/craft_parts/plugins/ant_plugin.py
+++ b/craft_parts/plugins/ant_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,7 @@ import logging
 import os
 import shlex
 from collections.abc import Iterator
-from typing import Any, cast
+from typing import Literal, cast
 from urllib.parse import urlsplit
 
 from overrides import override
@@ -28,36 +28,22 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import JavaPlugin, extract_plugin_properties
+from .base import JavaPlugin
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class AntPluginProperties(PluginProperties):
+class AntPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the Ant plugin."""
+
+    plugin: Literal["ant"] = "ant"
 
     ant_build_targets: list[str] = []
     ant_build_file: str | None = None
     ant_properties: dict[str, str] = {}
 
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "AntPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="ant", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class AntPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/ant_plugin.py
+++ b/craft_parts/plugins/ant_plugin.py
@@ -28,13 +28,13 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import JavaPlugin, PluginModel, extract_plugin_properties
+from .base import JavaPlugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class AntPluginProperties(PluginProperties, PluginModel):
+class AntPluginProperties(PluginProperties):
     """The part properties used by the Ant plugin."""
 
     ant_build_targets: list[str] = []

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -20,11 +20,11 @@ from typing import Any, cast
 
 from overrides import override
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class AutotoolsPluginProperties(PluginProperties, PluginModel):
+class AutotoolsPluginProperties(PluginProperties):
     """The part properties used by the autotools plugin."""
 
     autotools_configure_parameters: list[str] = []

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,38 +16,24 @@
 
 """The autotools plugin implementation."""
 
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class AutotoolsPluginProperties(PluginProperties):
+class AutotoolsPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the autotools plugin."""
+
+    plugin: Literal["autotools"] = "autotools"
 
     autotools_configure_parameters: list[str] = []
     autotools_bootstrap_parameters: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "AutotoolsPluginProperties":
-        """Populate autotools properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="autotools", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class AutotoolsPlugin(Plugin):

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -123,28 +123,3 @@ class JavaPlugin(Plugin):
         # pylint: enable=line-too-long
 
         return link_java + link_jars
-
-
-def extract_plugin_properties(
-    data: dict[str, Any], *, plugin_name: str, required: Collection[str] | None = None
-) -> dict[str, Any]:
-    """Obtain plugin-specific entries from part properties.
-
-    Plugin-specific properties must be prefixed with the name of the plugin.
-
-    :param data: A dictionary containing all part properties.
-    :plugin_name: The name of the plugin.
-
-    :return: A dictionary with plugin properties.
-    """
-    if required is None:
-        required = []
-
-    plugin_data: dict[str, Any] = {}
-    prefix = f"{plugin_name}-"
-
-    for key, value in data.items():
-        if key.startswith(prefix) or key in required:
-            plugin_data[key] = value
-
-    return plugin_data

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -19,9 +19,8 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Collection
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from craft_parts.actions import ActionProperties
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2023 Canonical Ltd.
+# Copyright 2020-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,10 @@
 
 """Plugin base class and definitions."""
 
+from __future__ import annotations
+
 import abc
+from collections.abc import Collection
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
@@ -47,7 +50,7 @@ class Plugin(abc.ABC):
     """Plugins that can run in 'strict' mode must set this classvar to True."""
 
     def __init__(
-        self, *, properties: PluginProperties, part_info: "infos.PartInfo"
+        self, *, properties: PluginProperties, part_info: infos.PartInfo
     ) -> None:
         self._options = properties
         self._part_info = part_info
@@ -123,7 +126,7 @@ class JavaPlugin(Plugin):
 
 
 def extract_plugin_properties(
-    data: dict[str, Any], *, plugin_name: str, required: list[str] | None = None
+    data: dict[str, Any], *, plugin_name: str, required: Collection[str] | None = None
 ) -> dict[str, Any]:
     """Obtain plugin-specific entries from part properties.
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from craft_parts.actions import ActionProperties
 
-from .properties import PluginProperties, PluginPropertiesModel
+from .properties import PluginProperties
 from .validator import PluginEnvironmentValidator
 
 if TYPE_CHECKING:
@@ -120,15 +120,6 @@ class JavaPlugin(Plugin):
         # pylint: enable=line-too-long
 
         return link_java + link_jars
-
-
-class PluginModel(PluginPropertiesModel):
-    """Model for plugins using pydantic validation.
-
-    Plugins with configuration properties can use pydantic validation to unmarshal
-    data from part specs. In this case, extract plugin-specific properties using
-    the :func:`extract_plugin_properties` helper.
-    """
 
 
 def extract_plugin_properties(

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -20,11 +20,11 @@ from typing import Any, cast
 
 from overrides import override
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class CMakePluginProperties(PluginProperties, PluginModel):
+class CMakePluginProperties(PluginProperties):
     """The part properties used by the cmake plugin."""
 
     cmake_parameters: list[str] = []

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2022 Canonical Ltd.
+# Copyright 2020-2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,38 +16,24 @@
 
 """The cmake plugin."""
 
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class CMakePluginProperties(PluginProperties):
+class CMakePluginProperties(PluginProperties, frozen=True):
     """The part properties used by the cmake plugin."""
+
+    plugin: Literal["cmake"] = "cmake"
 
     cmake_parameters: list[str] = []
     cmake_generator: str = "Unix Makefiles"
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "CMakePluginProperties":
-        """Populate class attributes from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="cmake", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class CMakePlugin(Plugin):

--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -22,13 +22,13 @@ from typing import Any, cast
 from overrides import override
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class DotnetPluginProperties(PluginProperties, PluginModel):
+class DotnetPluginProperties(PluginProperties):
     """The part properties used by the Dotnet plugin."""
 
     dotnet_build_configuration: str = "Release"

--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021 Canonical Ltd.
+# Copyright 2021,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,41 +17,27 @@
 """The Dotnet plugin."""
 
 import logging
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
 from . import validator
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class DotnetPluginProperties(PluginProperties):
+class DotnetPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the Dotnet plugin."""
+
+    plugin: Literal["dotnet"] = "dotnet"
 
     dotnet_build_configuration: str = "Release"
     dotnet_self_contained_runtime_identifier: str | None = None
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "DotnetPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="dotnet", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class DotPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/dump_plugin.py
+++ b/craft_parts/plugins/dump_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,7 +19,7 @@
 This plugin just dumps the content from a specified part source.
 """
 
-from typing import Any
+from typing import Literal
 
 from overrides import override
 
@@ -27,25 +27,11 @@ from .base import Plugin
 from .properties import PluginProperties
 
 
-class DumpPluginProperties(PluginProperties):
+class DumpPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the dump plugin."""
 
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "DumpPluginProperties":
-        """Populate dump properties from the part specification.
-
-        'source' is a required part property.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise ValueError: If a required property is not found.
-        """
-        if "source" not in data:
-            raise ValueError("'source' is required by the dump plugin")
-        return cls()
+    plugin: Literal["dump"] = "dump"
+    source: str
 
 
 class DumpPlugin(Plugin):

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2021,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,43 +17,29 @@
 """The Go plugin."""
 
 import logging
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
 from craft_parts import errors
 
 from . import validator
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class GoPluginProperties(PluginProperties):
+class GoPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the Go plugin."""
+
+    plugin: Literal["go"] = "go"
 
     go_buildtags: list[str] = []
     go_generate: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "GoPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="go", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class GoPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -24,13 +24,13 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class GoPluginProperties(PluginProperties, PluginModel):
+class GoPluginProperties(PluginProperties):
     """The part properties used by the Go plugin."""
 
     go_buildtags: list[str] = []

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2021 Canonical Ltd.
+# Copyright 2020-2021,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,37 +16,23 @@
 
 """The make plugin implementation."""
 
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class MakePluginProperties(PluginProperties):
+class MakePluginProperties(PluginProperties, frozen=True):
     """The part properties used by the make plugin."""
+
+    plugin: Literal["make"] = "make"
 
     make_parameters: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "MakePluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="make", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class MakePlugin(Plugin):

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -20,11 +20,11 @@ from typing import Any, cast
 
 from overrides import override
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class MakePluginProperties(PluginProperties, PluginModel):
+class MakePluginProperties(PluginProperties):
     """The part properties used by the make plugin."""
 
     make_parameters: list[str] = []

--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2015-2023 Canonical Ltd.
+# Copyright 2015-2023,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,7 +19,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Any, cast
+from typing import Literal, cast
 from urllib.parse import urlparse
 from xml.etree import ElementTree
 
@@ -28,33 +28,19 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import JavaPlugin, extract_plugin_properties
+from .base import JavaPlugin
 from .properties import PluginProperties
 
 
-class MavenPluginProperties(PluginProperties):
+class MavenPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the maven plugin."""
+
+    plugin: Literal["maven"] = "maven"
 
     maven_parameters: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "MavenPluginProperties":
-        """Populate class attributes from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="maven", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class MavenPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -28,11 +28,11 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import JavaPlugin, PluginModel, extract_plugin_properties
+from .base import JavaPlugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class MavenPluginProperties(PluginProperties, PluginModel):
+class MavenPluginProperties(PluginProperties):
     """The part properties used by the maven plugin."""
 
     maven_parameters: list[str] = []

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -24,13 +24,13 @@ from typing import Any, cast
 from overrides import override
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class MesonPluginProperties(PluginProperties, PluginModel):
+class MesonPluginProperties(PluginProperties):
     """The part properties used by the Meson plugin."""
 
     meson_parameters: list[str] = []

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -19,40 +19,26 @@
 
 import logging
 import shlex
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
 from . import validator
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
 
 
-class MesonPluginProperties(PluginProperties):
+class MesonPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the Meson plugin."""
+
+    plugin: Literal["meson"] = "meson"
 
     meson_parameters: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "MesonPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="meson", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class MesonPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -20,12 +20,11 @@ Using this, parts can be defined purely by utilizing properties that are
 automatically included, e.g. stage-packages.
 """
 
-from typing import Any, Literal
+from typing import Literal
 
 from overrides import override
-from typing_extensions import Self
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
@@ -33,23 +32,6 @@ class NilPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the nil plugin."""
 
     plugin: Literal["nil"] = "nil"
-
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]) -> Self:
-        """Populate class attributes from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-        """
-        required = ["source"] if "source" in data else []
-        return cls.model_validate(
-            extract_plugin_properties(
-                data,
-                plugin_name="nil",
-                required=cls._required_fields,
-            )
-        )
 
 
 class NilPlugin(Plugin):

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -20,12 +20,12 @@ Using this, parts can be defined purely by utilizing properties that are
 automatically included, e.g. stage-packages.
 """
 
-from collections.abc import Collection
-from typing import ClassVar, Literal
+from typing import Any, Literal
 
 from overrides import override
+from typing_extensions import Self
 
-from .base import Plugin
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
@@ -34,7 +34,22 @@ class NilPluginProperties(PluginProperties, frozen=True):
 
     plugin: Literal["nil"] = "nil"
 
-    _required_fields: ClassVar[Collection[str]] = ()
+    @classmethod
+    def unmarshal(cls, data: dict[str, Any]) -> Self:
+        """Populate class attributes from the part specification.
+
+        :param data: A dictionary containing part properties.
+
+        :return: The populated plugin properties data object.
+        """
+        required = ["source"] if "source" in data else []
+        return cls.model_validate(
+            extract_plugin_properties(
+                data,
+                plugin_name="nil",
+                required=cls._required_fields,
+            )
+        )
 
 
 class NilPlugin(Plugin):

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020 Canonical Ltd.
+# Copyright 2020,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,8 @@ Using this, parts can be defined purely by utilizing properties that are
 automatically included, e.g. stage-packages.
 """
 
-from typing import Any
+from collections.abc import Collection
+from typing import ClassVar, Literal
 
 from overrides import override
 
@@ -28,19 +29,12 @@ from .base import Plugin
 from .properties import PluginProperties
 
 
-class NilPluginProperties(PluginProperties):
+class NilPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the nil plugin."""
 
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "NilPluginProperties":  # noqa: ARG003
-        """Populate class attributes from the part specification.
+    plugin: Literal["nil"] = "nil"
 
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-        """
-        return cls()
+    _required_fields: ClassVar[Collection[str]] = ()
 
 
 class NilPlugin(Plugin):

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,7 +21,7 @@ import os
 import platform
 import re
 from textwrap import dedent
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import requests
 from overrides import override
@@ -31,7 +31,7 @@ from typing_extensions import Self
 from craft_parts.errors import InvalidArchitecture
 
 from . import validator
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
@@ -47,8 +47,10 @@ _NODE_ARCH_FROM_SNAP_ARCH = {
 _NODE_ARCH_FROM_PLATFORM = {"x86_64": {"32bit": "x86", "64bit": "x64"}}
 
 
-class NpmPluginProperties(PluginProperties):
+class NpmPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the npm plugin."""
+
+    plugin: Literal["npm"] = "npm"
 
     # part properties required by the plugin
     npm_include_node: bool = False
@@ -65,22 +67,6 @@ class NpmPluginProperties(PluginProperties):
                 "npm-node-version has no effect if npm-include-node is false"
             )
         return self
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "NpmPluginProperties":
-        """Populate class attributes from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="npm", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class NpmPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -31,7 +31,7 @@ from typing_extensions import Self
 from craft_parts.errors import InvalidArchitecture
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ _NODE_ARCH_FROM_SNAP_ARCH = {
 _NODE_ARCH_FROM_PLATFORM = {"x86_64": {"32bit": "x86", "64bit": "x64"}}
 
 
-class NpmPluginProperties(PluginProperties, PluginModel):
+class NpmPluginProperties(PluginProperties):
     """The part properties used by the npm plugin."""
 
     # part properties required by the plugin

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -46,7 +46,7 @@ class PluginProperties(pydantic.BaseModel, frozen=True):  # type: ignore[misc]
         validate_assignment=True,
     )
 
-    plugin: Any = ""
+    plugin: str = ""
     source: str | None = None
 
     _required_fields: ClassVar[Collection[str]] = ("plugin", "source")

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -69,6 +69,8 @@ class PluginProperties(pydantic.BaseModel, frozen=True):  # type: ignore[misc]
         plugin_data = {
             key: value
             for key, value in data.items()
+            # Note: We also use startswith here in order to have the Properties object
+            # provide an "extra inputs are not permitted" error message.
             if key in properties or key.startswith(f"{plugin_name}-")
         }
 

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -17,8 +17,7 @@
 """Definitions and helpers for plugin options."""
 
 import functools
-from collections.abc import Collection
-from typing import Any, ClassVar
+from typing import Any, cast
 
 import pydantic
 from typing_extensions import Self
@@ -52,7 +51,9 @@ class PluginProperties(pydantic.BaseModel, frozen=True):  # type: ignore[misc]
     @functools.lru_cache(maxsize=1)
     def model_properties(cls) -> dict[str, dict[str, Any]]:
         """Get the properties for this model from the JSON schema."""
-        return cls.model_json_schema().get("properties", {})
+        return cast(
+            dict[str, dict[str, Any]], cls.model_json_schema().get("properties", {})
+        )
 
     @classmethod
     def unmarshal(cls, data: dict[str, Any]) -> Self:

--- a/craft_parts/plugins/properties.py
+++ b/craft_parts/plugins/properties.py
@@ -80,8 +80,5 @@ class PluginProperties(pydantic.BaseModel, frozen=True):  # type: ignore[misc]
     @classmethod
     def get_build_properties(cls) -> list[str]:
         """Obtain the list of properties affecting the build stage."""
-        properties = cls.schema(by_alias=True).get("properties")
-        if properties:
-            del properties["plugin"]
-            return list(properties)
-        return []
+        properties = cls.schema(by_alias=True).get("properties", [])
+        return [p for p in properties if p != "plugin"]

--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -22,11 +22,11 @@ from typing import Any, cast
 
 from overrides import override
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class PythonPluginProperties(PluginProperties, PluginModel):
+class PythonPluginProperties(PluginProperties):
     """The part properties used by the python plugin."""
 
     python_requirements: list[str] = []

--- a/craft_parts/plugins/python_plugin.py
+++ b/craft_parts/plugins/python_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2023 Canonical Ltd.
+# Copyright 2020-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,18 @@
 
 import shlex
 from textwrap import dedent
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class PythonPluginProperties(PluginProperties):
+class PythonPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the python plugin."""
+
+    plugin: Literal["python"] = "python"
 
     python_requirements: list[str] = []
     python_constraints: list[str] = []
@@ -35,22 +37,6 @@ class PythonPluginProperties(PluginProperties):
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "PythonPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="python", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class PythonPlugin(Plugin):

--- a/craft_parts/plugins/qmake_plugin.py
+++ b/craft_parts/plugins/qmake_plugin.py
@@ -23,11 +23,11 @@ from typing import Any, cast
 from overrides import override
 from typing_extensions import Self
 
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class QmakePluginProperties(PluginProperties, PluginModel):
+class QmakePluginProperties(PluginProperties):
     """The part properties used by the qmake plugin."""
 
     qmake_parameters: list[str] = []

--- a/craft_parts/plugins/qmake_plugin.py
+++ b/craft_parts/plugins/qmake_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023,2024 Canonical Ltd.
 # Copyright 2023 Scarlett Moore <sgmoore@kde.org>.
 #
 # This program is free software; you can redistribute it and/or
@@ -18,17 +18,18 @@
 
 """The qmake plugin."""
 
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
-from typing_extensions import Self
 
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class QmakePluginProperties(PluginProperties):
+class QmakePluginProperties(PluginProperties, frozen=True):
     """The part properties used by the qmake plugin."""
+
+    plugin: Literal["qmake"] = "qmake"
 
     qmake_parameters: list[str] = []
     qmake_project_file: str = ""
@@ -36,21 +37,6 @@ class QmakePluginProperties(PluginProperties):
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]) -> Self:
-        """Populate class attributes from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="qmake", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class QmakePlugin(Plugin):

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -29,7 +29,7 @@ from pydantic import AfterValidator
 from pydantic import validator as pydantic_validator
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def _validate_list_is_unique(value: list) -> list:
 UniqueStrList = Annotated[list[str], AfterValidator(_validate_list_is_unique)]
 
 
-class RustPluginProperties(PluginProperties, PluginModel):
+class RustPluginProperties(PluginProperties):
     """The part properties used by the Rust plugin."""
 
     # part properties required by the plugin

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -23,11 +23,11 @@ from overrides import override
 from craft_parts import errors
 
 from . import validator
-from .base import Plugin, PluginModel, extract_plugin_properties
+from .base import Plugin, extract_plugin_properties
 from .properties import PluginProperties
 
 
-class SConsPluginProperties(PluginProperties, PluginModel):
+class SConsPluginProperties(PluginProperties):
     """The part properties used by the SCons plugin."""
 
     scons_parameters: list[str] = []

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,40 +16,26 @@
 
 """The SCons plugin."""
 
-from typing import Any, cast
+from typing import Literal, cast
 
 from overrides import override
 
 from craft_parts import errors
 
 from . import validator
-from .base import Plugin, extract_plugin_properties
+from .base import Plugin
 from .properties import PluginProperties
 
 
-class SConsPluginProperties(PluginProperties):
+class SConsPluginProperties(PluginProperties, frozen=True):
     """The part properties used by the SCons plugin."""
+
+    plugin: Literal["scons"] = "scons"
 
     scons_parameters: list[str] = []
 
     # part properties required by the plugin
     source: str
-
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "SConsPluginProperties":
-        """Populate make properties from the part specification.
-
-        :param data: A dictionary containing part properties.
-
-        :return: The populated plugin properties data object.
-
-        :raise pydantic.ValidationError: If validation fails.
-        """
-        plugin_data = extract_plugin_properties(
-            data, plugin_name="scons", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class SConsPluginEnvironmentValidator(validator.PluginEnvironmentValidator):

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -89,6 +89,7 @@ InvalidSourceOptions
 InvalidSourceType
 Iterable
 JavaPlugin
+JSON
 LDFLAGS
 LLVM
 LTO

--- a/tests/integration/lifecycle/test_plugin_changesets.py
+++ b/tests/integration/lifecycle/test_plugin_changesets.py
@@ -31,7 +31,7 @@ def teardown_module():
     plugins.unregister_all()
 
 
-class ExamplePluginProperties(plugins.PluginProperties, plugins.PluginModel):
+class ExamplePluginProperties(plugins.PluginProperties):
     """The application-defined plugin properties."""
 
     @classmethod

--- a/tests/integration/lifecycle/test_plugin_changesets.py
+++ b/tests/integration/lifecycle/test_plugin_changesets.py
@@ -16,7 +16,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Literal
 
 import craft_parts
 import yaml
@@ -31,12 +31,10 @@ def teardown_module():
     plugins.unregister_all()
 
 
-class ExamplePluginProperties(plugins.PluginProperties):
+class ExamplePluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]):
-        return cls()
+    plugin: Literal["example"] = "example"
 
 
 class ExamplePlugin(plugins.Plugin):

--- a/tests/integration/lifecycle/test_plugin_property_state.py
+++ b/tests/integration/lifecycle/test_plugin_property_state.py
@@ -16,7 +16,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import craft_parts
 import pytest

--- a/tests/integration/lifecycle/test_plugin_property_state.py
+++ b/tests/integration/lifecycle/test_plugin_property_state.py
@@ -163,12 +163,6 @@ class Example2PluginProperties(plugins.PluginProperties, frozen=True):
 
     @classmethod
     @override
-    def unmarshal(cls, data: dict[str, Any]) -> "Example2PluginProperties":
-        plugin_data = plugins.extract_plugin_properties(data, plugin_name="example")
-        return cls(**plugin_data)
-
-    @classmethod
-    @override
     def get_pull_properties(cls) -> list[str]:
         return ["example-property"]
 

--- a/tests/integration/lifecycle/test_plugin_property_state.py
+++ b/tests/integration/lifecycle/test_plugin_property_state.py
@@ -16,7 +16,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import craft_parts
 import pytest
@@ -34,16 +34,12 @@ def teardown_module():
     plugins.unregister_all()
 
 
-class ExamplePluginProperties(plugins.PluginProperties):
+class ExamplePluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
-    example_property: int | None
+    plugin: Literal["example"] = "example"
 
-    @classmethod
-    @override
-    def unmarshal(cls, data: dict[str, Any]) -> "ExamplePluginProperties":
-        plugin_data = plugins.extract_plugin_properties(data, plugin_name="example")
-        return cls(**plugin_data)
+    example_property: int | None
 
 
 class ExamplePlugin(plugins.Plugin):
@@ -160,7 +156,7 @@ def test_plugin_property_build_dirty(new_dir):
     ]
 
 
-class Example2PluginProperties(plugins.PluginProperties):
+class Example2PluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
     example_property: int | None

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -27,7 +27,7 @@ from craft_parts import Action, ActionType, Step, errors, plugins
 class AppPluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
-    plugin: Literal["app-plugin"] = "app-plugin"
+    plugin: Literal["app"] = "app"
     app_stuff: list[str]
     source: str
 

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -16,7 +16,7 @@
 
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Literal
 
 import craft_parts
 import pytest
@@ -24,18 +24,12 @@ import yaml
 from craft_parts import Action, ActionType, Step, errors, plugins
 
 
-class AppPluginProperties(plugins.PluginProperties):
+class AppPluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
+    plugin: Literal["app-plugin"] = "app-plugin"
     app_stuff: list[str]
     source: str
-
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]):
-        plugin_data = plugins.extract_plugin_properties(
-            data, plugin_name="app", required=["source"]
-        )
-        return cls(**plugin_data)
 
 
 class AppPlugin(plugins.Plugin):

--- a/tests/integration/plugins/test_application_plugin.py
+++ b/tests/integration/plugins/test_application_plugin.py
@@ -24,7 +24,7 @@ import yaml
 from craft_parts import Action, ActionType, Step, errors, plugins
 
 
-class AppPluginProperties(plugins.PluginProperties, plugins.PluginModel):
+class AppPluginProperties(plugins.PluginProperties):
     """The application-defined plugin properties."""
 
     app_stuff: list[str]

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -52,7 +52,7 @@ def mytool_error(new_dir):
     return tool
 
 
-class AppPluginProperties(plugins.PluginProperties, plugins.PluginModel):
+class AppPluginProperties(plugins.PluginProperties):
     """The application-defined plugin properties."""
 
     @classmethod

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -17,7 +17,7 @@
 import subprocess
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Literal
 
 import craft_parts
 import pytest
@@ -52,12 +52,10 @@ def mytool_error(new_dir):
     return tool
 
 
-class AppPluginProperties(plugins.PluginProperties):
+class AppPluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]):
-        return cls()
+    plugin: Literal["app-plugin"] = "app-plugin"
 
 
 class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):

--- a/tests/integration/plugins/test_validate_environment.py
+++ b/tests/integration/plugins/test_validate_environment.py
@@ -55,7 +55,7 @@ def mytool_error(new_dir):
 class AppPluginProperties(plugins.PluginProperties, frozen=True):
     """The application-defined plugin properties."""
 
-    plugin: Literal["app-plugin"] = "app-plugin"
+    plugin: Literal["app"] = "app"
 
 
 class AppPluginEnvironmentValidator(plugins.PluginEnvironmentValidator):

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, cast
+from typing import Literal, cast
 
 import pytest
 from craft_parts.infos import PartInfo, ProjectInfo
@@ -23,14 +23,12 @@ from craft_parts.plugins import Plugin, PluginProperties
 from craft_parts.plugins.base import extract_plugin_properties
 
 
-class FooPluginProperties(PluginProperties):
+class FooPluginProperties(PluginProperties, frozen=True):
     """Test plugin properties."""
 
-    name: str
+    plugin: Literal["foo"] = "foo"
 
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]):
-        return cls(name=data.get("foo-name", "nothing"))
+    foo_name: str
 
 
 class FooPlugin(Plugin):
@@ -49,7 +47,7 @@ class FooPlugin(Plugin):
 
     def get_build_commands(self) -> list[str]:
         options = cast(FooPluginProperties, self._options)
-        return ["hello", options.name]
+        return ["hello", options.foo_name]
 
 
 def test_plugin(new_dir):

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -20,7 +20,6 @@ import pytest
 from craft_parts.infos import PartInfo, ProjectInfo
 from craft_parts.parts import Part
 from craft_parts.plugins import Plugin, PluginProperties
-from craft_parts.plugins.base import extract_plugin_properties
 
 
 class FooPluginProperties(PluginProperties, frozen=True):
@@ -84,16 +83,3 @@ def test_abstract_methods(new_dir):
 
     with pytest.raises(TypeError, match=expected):
         FaultyPlugin(properties=None, part_info=part_info)  # type: ignore[reportGeneralTypeIssues]
-
-
-def test_extract_plugin_properties():
-    data = {
-        "foo": True,
-        "test": "yes",
-        "test-one": 1,
-        "test-two": 2,
-        "not-test-three": 3,
-    }
-
-    plugin_data = extract_plugin_properties(data, plugin_name="test")
-    assert plugin_data == {"test-one": 1, "test-two": 2}

--- a/tests/unit/plugins/test_dump_plugin.py
+++ b/tests/unit/plugins/test_dump_plugin.py
@@ -40,9 +40,8 @@ class TestPluginDump:
         self._plugin = DumpPlugin(properties=properties, part_info=part_info)
 
     def test_unmarshal_error(self):
-        with pytest.raises(ValueError) as raised:  # noqa: PT011
+        with pytest.raises(ValueError, match=r"source\n\s+Field required"):
             DumpPlugin.properties_class.unmarshal({})
-        assert str(raised.value) == "'source' is required by the dump plugin"
 
     def test_get_build_packages(self):
         assert self._plugin.get_build_packages() == set()

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -54,6 +54,7 @@ class TestGetPlugin:
             ("make", MakePlugin, {"source": "."}),
             ("meson", MesonPlugin, {"source": "."}),
             ("nil", NilPlugin, {}),
+            ("nil", NilPlugin, {"source": "."}),
             ("npm", NpmPlugin, {"source": "."}),
             ("python", PythonPlugin, {"source": "."}),
             ("qmake", QmakePlugin, {"source": "."}),

--- a/tests/unit/plugins/test_properties.py
+++ b/tests/unit/plugins/test_properties.py
@@ -14,30 +14,27 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
+from typing import Literal
 
 from craft_parts.plugins import PluginProperties
 
 
-def test_properties_unmarshal():
-    prop = PluginProperties.unmarshal({})
-    assert isinstance(prop, PluginProperties)
-
-
-class FooProperties(PluginProperties):
+class FooProperties(PluginProperties, frozen=True):
+    plugin: Literal["foo"] = "foo"
     foo_parameters: list[str] | None = None
 
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]) -> "FooProperties":
-        return cls(**data)
+
+def test_properties_unmarshal():
+    prop = FooProperties.unmarshal({})
+    assert isinstance(prop, PluginProperties)
 
 
 def test_properties_marshal():
     prop = FooProperties.unmarshal({"foo-parameters": ["foo", "bar"]})
-    assert prop.marshal() == {"foo-parameters": ["foo", "bar"]}
+    assert prop.marshal() == {"source": None, "foo-parameters": ["foo", "bar"]}
 
 
 def test_properties_defaults():
     prop = FooProperties.unmarshal({})
     assert prop.get_pull_properties() == []
-    assert prop.get_build_properties() == ["foo-parameters"]
+    assert prop.get_build_properties() == ["source", "foo-parameters"]

--- a/tests/unit/plugins/test_validator.py
+++ b/tests/unit/plugins/test_validator.py
@@ -15,9 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Literal
 
 import pytest
 from craft_parts import errors
@@ -48,17 +47,14 @@ def empty_foo_exe(new_dir):
 def part_info(new_dir):
     return PartInfo(
         project_info=ProjectInfo(application_name="test", cache_dir=new_dir),
-        part=Part("my-part", {}),
+        part=Part("my-part", {"plugin": "foo"}),
     )
 
 
-@dataclass
-class FooPluginProperties(PluginProperties):
+class FooPluginProperties(PluginProperties, frozen=True):
     """Test plugin properties."""
 
-    @classmethod
-    def unmarshal(cls, data: dict[str, Any]):
-        return cls()
+    plugin: Literal["foo"] = "foo"
 
 
 class FooPluginEnvironmentValidator(PluginEnvironmentValidator):


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This does several related things:

1. Removes the vestigial `PluginModel` from `craft_parts.plugins.base`
2. Combines `PluginPropertiesModel` and `PluginProperties` (which didn't need separation anymore)
3. Makes the `unmarshal` method of `PluginProperties` usable by all plugins (and deletes the unnecessary overrides)