### PR TITLE
feat: allow numbers in partition names and namespaces

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -76,8 +76,11 @@ class LifecycleManager:
         matching this name.
     :param project_vars: A dictionary containing project variables.
     :param partitions: A list of partitions to use when the partitions feature is
-        enabled. The first partition must be "default" and all partitions must be
-        lowercase alphabetical.
+        enabled. The first partition must be "default" and partitions must contain only
+        lowercase alphabetical and numbers. Partitions may have an optional namespace
+        prefix separated by a forward slash. Namespaces must contain only lowercase
+        alphabetical and numbers and namespaced partitions must only contain lowercase
+        alphabetical, numbers, and hyphens.
     :param custom_args: Any additional arguments that will be passed directly
         to callbacks.
     """

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -76,11 +76,11 @@ class LifecycleManager:
         matching this name.
     :param project_vars: A dictionary containing project variables.
     :param partitions: A list of partitions to use when the partitions feature is
-        enabled. The first partition must be "default" and partitions must contain only
-        lowercase alphabetical and numbers. Partitions may have an optional namespace
-        prefix separated by a forward slash. Namespaces must contain only lowercase
-        alphabetical and numbers and namespaced partitions must only contain lowercase
-        alphabetical, numbers, and hyphens.
+        enabled. The first partition must be "default" Partitions must contain only
+        lowercase alphanumeric characters. Partitions may have an optional namespace
+        prefix separated by a forward slash, which must contain only lowercase
+        alphanumeric characters. Namespaced partitions must only contain lowercase
+        alphanumeric characters and hyphens.
     :param custom_args: Any additional arguments that will be passed directly
         to callbacks.
     """

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -35,15 +35,15 @@ def validate_partition_names(partitions: Optional[Sequence[str]]) -> None:
 
     If the partition feature is enabled, then:
       - the first partition must be "default"
-      - each partition must contain only lowercase alphabetical characters and numbers
+      - each partition must contain only lowercase alphanumeric characters
       - partitions are unique
 
     Namespaced partitions can also be validated in addition to regular (or
     'non-namespaced') partitions. The format is `<namespace>/<partition>`.
 
     Namespaced partitions have the following naming convention:
-      - the namespace must contain only lowercase alphabetical characters and numbers
-      - the partition must contain only lowercase alphabetical characters, numbers, and hyphens
+      - the namespace must contain only lowercase alphanumeric characters
+      - the partition must contain only lowercase alphanumeric characters and hyphens
       - the partition cannot begin or end with a hyphen
 
     :param partitions: Partition data to verify.

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -22,10 +22,12 @@ from typing import Dict, Iterable, Optional, Sequence, Set
 from craft_parts import errors, features
 
 # regex for a valid partition name
-_VALID_PARTITION_REGEX = re.compile(r"[a-z]+", re.ASCII)
+_VALID_PARTITION_REGEX = re.compile(r"[a-z0-9]+", re.ASCII)
 
 # regex for a valid namespaced partition name
-_VALID_NAMESPACED_PARTITION_REGEX = re.compile(r"[a-z]+/(?!-)[a-z\-]+(?<!-)", re.ASCII)
+_VALID_NAMESPACED_PARTITION_REGEX = re.compile(
+    r"[a-z0-9]+/(?!-)[a-z0-9\-]+(?<!-)", re.ASCII
+)
 
 
 def validate_partition_names(partitions: Optional[Sequence[str]]) -> None:
@@ -33,15 +35,15 @@ def validate_partition_names(partitions: Optional[Sequence[str]]) -> None:
 
     If the partition feature is enabled, then:
       - the first partition must be "default"
-      - each partition must contain only lowercase alphabetical characters
+      - each partition must contain only lowercase alphabetical characters and numbers
       - partitions are unique
 
     Namespaced partitions can also be validated in addition to regular (or
     'non-namespaced') partitions. The format is `<namespace>/<partition>`.
 
     Namespaced partitions have the following naming convention:
-      - the namespace must contain only lowercase alphabetical characters
-      - the partition must contain only lowercase alphabetical characters and hyphens
+      - the namespace must contain only lowercase alphabetical characters and numbers
+      - the partition must contain only lowercase alphabetical characters, numbers, and hyphens
       - the partition cannot begin or end with a hyphen
 
     :param partitions: Partition data to verify.
@@ -109,15 +111,16 @@ def _validate_partition_naming_convention(partitions: Sequence[str]) -> None:
                 message=f"Namespaced partition {partition!r} is invalid.",
                 details=(
                     "Namespaced partitions are formatted as `<namespace>/"
-                    "<partition>`. Namespaces must only contain lowercase letters. "
-                    "Namespaced partitions must only contain lowercase letters and "
-                    "hyphens and cannot start or end with a hyphen."
+                    "<partition>`. Namespaces must only contain lowercase letters "
+                    "and numbers. Namespaced partitions must only contain lowercase "
+                    "letters, numbers, and hyphens and cannot start or end with a "
+                    "hyphen."
                 ),
             )
 
         raise errors.FeatureError(
             message=f"Partition {partition!r} is invalid.",
-            details="Partitions must only contain lowercase letters.",
+            details="Partitions must only contain lowercase letters and numbers.",
         )
 
 
@@ -126,6 +129,8 @@ def _validate_namespace_conflicts(partitions: Sequence[str]) -> None:
 
     For example, `foo` conflicts in ['default', 'foo', 'foo/bar'].
     Assumes partition names are valid.
+
+    This does not catch conflicts with hyphens in partitions (#789).
 
     :raises FeatureError: for namespace conflicts
     """

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -113,6 +113,7 @@ Multipass
 NOOP
 NPM
 NVM
+Namespaces
 Namespaced
 NetworkRequestError
 NilPlugin

--- a/tests/unit/features/partitions/executor/test_environment.py
+++ b/tests/unit/features/partitions/executor/test_environment.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,14 +23,15 @@ from craft_parts.executor import environment
     [
         (["default"], {"CRAFT_DEFAULT_STAGE", "CRAFT_DEFAULT_PRIME"}),
         (
-            ["default", "abc", "foo/bar-baz"],
+            # exercise lowercase alphabetical, numbers, and hyphens
+            ["default", "abc123", "foo1/bar-baz2"],
             {
                 "CRAFT_DEFAULT_STAGE",
                 "CRAFT_DEFAULT_PRIME",
-                "CRAFT_ABC_STAGE",
-                "CRAFT_ABC_PRIME",
-                "CRAFT_FOO_BAR_BAZ_STAGE",
-                "CRAFT_FOO_BAR_BAZ_PRIME",
+                "CRAFT_ABC123_STAGE",
+                "CRAFT_ABC123_PRIME",
+                "CRAFT_FOO1_BAR_BAZ2_STAGE",
+                "CRAFT_FOO1_BAR_BAZ2_PRIME",
             },
         ),
     ],

--- a/tests/unit/features/partitions/test_lifecycle_manager.py
+++ b/tests/unit/features/partitions/test_lifecycle_manager.py
@@ -16,7 +16,7 @@
 """Unit tests for the lifecycle manager with the partitions feature."""
 import sys
 import textwrap
-from string import ascii_lowercase
+from string import ascii_lowercase, digits
 from textwrap import dedent
 from typing import Any, Dict
 
@@ -33,7 +33,9 @@ mock_available_plugins = test_lifecycle_manager.mock_available_plugins
 
 def valid_non_namespaced_partition_strategy():
     """A strategy for a list of valid non-namespaced partitions."""
-    return strategies.text(strategies.sampled_from(ascii_lowercase), min_size=1)
+    return strategies.text(
+        strategies.sampled_from(ascii_lowercase + digits), min_size=1
+    )
 
 
 @strategies.composite
@@ -44,7 +46,7 @@ def valid_namespaced_partition_strategy(draw):
     )
 
     partition_strategy = strategies.text(
-        strategies.sampled_from(ascii_lowercase + "-"), min_size=1
+        strategies.sampled_from(ascii_lowercase + digits + "-"), min_size=1
     ).filter(
         lambda partition: (
             not partition.startswith("-")
@@ -197,7 +199,6 @@ class TestPartitionsSupport:
             ["default", "-"],
             ["default", "Test"],
             ["default", "TEST"],
-            ["default", "test1"],
             ["default", "te-st"],
             pytest.param(
                 ["default", "tеst"],  # noqa: RUF001 (ambiguous character)
@@ -244,10 +245,8 @@ class TestPartitionsSupport:
             ["default", "-a-/b"],
             ["default", "a/Test"],
             ["default", "a/TEST"],
-            ["default", "a/test1"],
             ["default", "Test/a"],
             ["default", "TEST/a"],
-            ["default", "test1/a"],
             ["default", "te-st/a"],
             pytest.param(
                 ["default", "test/ο"],  # noqa: RUF001 (ambiguous character)

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -219,9 +219,9 @@ class TestPartPartitionUsage:
         """Return a fileset of invalid uses of partition names.
 
         These filepaths are not necessarily violating the naming convention for
-        partitions, but the partitions here are unknown (and thus invalid) to a
-        LifecycleManager was created with the partitions "default", "a/b", "a/c-d",
-        and "kernel".
+        partitions, but the partitions here are unknown and thus invalid to a
+        LifecycleManager that was created with the partitions "default", "a/b",
+        "a/c-d", and "kernel".
         """
         return [
             # unknown partition names

--- a/tests/unit/utils/test_partition_utils.py
+++ b/tests/unit/utils/test_partition_utils.py
@@ -48,11 +48,15 @@ def test_validate_partitions_failure_feature_disabled(partitions, message):
     [
         ["default"],
         ["default", "mypart"],
+        ["default", "mypart1"],
         ["default", "mypart", "test/foo"],
+        ["default", "mypart", "test1/foo2"],
         ["default", "mypart", "test/foo-bar"],
+        ["default", "mypart", "test1/foo-bar2"],
     ],
 )
 def test_validate_partitions_success_feature_enabled(partitions):
+    """Test validation of partition names."""
     partition_utils.validate_partition_names(partitions)
 
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Allow hyphens in partitions, partition namespaces, and namespaced partitions.

Unblocks [LP#2069783](https://bugs.launchpad.net/snapcraft/+bug/2069783)
(CRAFT-3043)