### PR TITLE
ci fixes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,28 +81,32 @@ jobs:
           sudo apt install -y libapt-pkg-dev intltool fuse-overlayfs python3-apt
       - name: Install additional test dependencies
         run: |
+          echo "::group::snap install"
+          sudo snap install chisel --channel latest/candidate --no-wait
+          echo "::endgroup::"
+          echo "::group::apt install"
           sudo apt install -y ninja-build cmake scons \
                               autoconf automake autopoint gcc git gperf help2man libtool texinfo
-          python -m pip install tox
-          # Build Chisel: needs a newer version of go than is available in Ubuntu 20.04
-          sudo snap install --classic --channel=latest/stable go
-          git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout v0.9.1
-          go mod download
-          sudo go build -o /usr/bin ./...
-          chisel --help
           # Remove newer go and install regular version for 20.04
-          sudo snap remove go
           sudo apt install -y golang
           # Install RPM dependencies for RPM tests
           sudo apt install rpm
           # Ensure we don't have dotnet installed, to properly test dotnet-deps
           # Based on https://github.com/actions/runner-images/blob/main/images/linux/scripts/installers/dotnetcore-sdk.sh
           sudo apt remove -y dotnet-* || true
+          echo "::endgroup::"
+          echo "::group::pip install"
+          python -m pip install tox
+          echo "::endgroup::"
+          echo "::group::dotnet removal"
           # Remove manually-installed dotnet from tarballs
           sudo rm -rf /usr/share/dotnet
           # Remove dotnet tools
           rm -rf $HOME/.dotnet
+          echo "::endgroup::"
+          echo "::group::Wait for snap to complete"
+          snap watch --last=install
+          echo "::endgroup::"
       - name: specify node version
         uses: actions/setup-node@v4
         with:
@@ -144,24 +148,15 @@ jobs:
           pip install -e .[dev]
       - name: Install additional test dependencies
         run: |
-
+          echo "::group::snap install"
+          sudo snap install chisel --channel latest/candidate --no-wait
+          echo "::endgroup::"
+          echo "::group::apt install"
           sudo apt install -y ninja-build cmake scons qt5-qmake p7zip \
                               autoconf automake autopoint gcc git gperf help2man libtool texinfo \
-                              curl findutils pkg-config
-          # Build Chisel: needs a newer version of go than is available in Ubuntu 20.04
-          # note: we can't use the snap here because it has strict confinement and can't access
-          # the test files in /tmp/pytest-*
-          sudo snap install --classic --channel=latest/stable go
-          git clone https://github.com/canonical/chisel.git chisel-tmp
-          cd chisel-tmp && git checkout v0.9.1
-          go mod download
-          sudo go build -o /usr/bin ./...
-          chisel --help
-          # Remove newer go and install regular version for 20.04
-          sudo snap remove go
-          sudo apt install -y golang
-          # Install RPM dependencies for RPM tests
-          sudo apt install rpm
+                              curl findutils pkg-config golang rpm
+          echo "::endgroup::"
+          echo "::group::dotnet removal"
           # Ensure we don't have dotnet installed, to properly test dotnet-deps
           # Based on https://github.com/actions/runner-images/blob/main/images/linux/scripts/installers/dotnetcore-sdk.sh
           sudo apt remove -y dotnet-* || true
@@ -169,6 +164,10 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           # Remove dotnet tools
           rm -rf $HOME/.dotnet
+          echo "::endgroup::"
+          echo "::group::Wait for snap to complete"
+          snap watch --last=install
+          echo "::endgroup::"
       - name: specify node version
         uses: actions/setup-node@v4
         with:

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -54,7 +54,7 @@ class Executor:
     :param ignore_patterns: File patterns to ignore when pulling local sources.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         *,
         part_list: List[Part],

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -65,7 +65,7 @@ class StepHandler:
     the running instance.
     """
 
-    def __init__(  # noqa: PLR0913 (too many arguments)
+    def __init__(
         self,
         part: Part,
         *,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,12 +47,13 @@ def new_dir(monkeypatch, tmpdir):
 
 @pytest.fixture()
 def tmp_homedir_path():
-    """A temporary directory in the user's home directory.
+    """A non-hidden temporary directory in the user's home directory.
 
-    This generally works around temporary directories being on tmpfs.
+    This works around temporary directories being of tmpfs and is an accessible
+    location for snaps with the 'home' plug like chisel.
     """
     with tempfile.TemporaryDirectory(
-        prefix="craft-parts-tests", dir=pathlib.Path.home() / ".cache"
+        prefix="craft-parts-tests", dir=pathlib.Path.home()
     ) as tmp_dir:
         yield pathlib.Path(tmp_dir)
 

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -42,7 +42,7 @@ def _current_release_supported() -> bool:
 @pytest.mark.skipif(
     not _current_release_supported(), reason="Test needs Chisel support"
 )
-def test_chisel_lifecycle(new_dir, partitions):
+def test_chisel_lifecycle(new_homedir_path, partitions):
     """Integrated test for Chisel support.
 
     Note that since this test needs the "chisel" binary.
@@ -61,8 +61,8 @@ def test_chisel_lifecycle(new_dir, partitions):
     lf = craft_parts.LifecycleManager(
         parts,
         application_name="test_slice",
-        cache_dir=new_dir,
-        work_dir=new_dir,
+        cache_dir=new_homedir_path,
+        work_dir=new_homedir_path,
         partitions=partitions,
     )
 
@@ -71,7 +71,7 @@ def test_chisel_lifecycle(new_dir, partitions):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    root = Path(new_dir) / "prime"
+    root = Path(new_homedir_path) / "prime"
     assert (root / "etc/ssl/certs/ca-certificates.crt").is_file()
     assert (root / "usr/share/ca-certificates").is_dir()
 
@@ -79,10 +79,10 @@ def test_chisel_lifecycle(new_dir, partitions):
 @pytest.mark.skipif(
     not _current_release_supported(), reason="Test needs Chisel support"
 )
-def test_chisel_error(tmp_path, caplog):
+def test_chisel_error(new_homedir_path, caplog):
     """Test that the error that is raised when Chisel fails contains the expected information."""
     caplog.set_level(logging.DEBUG)
-    install_path = tmp_path / "install"
+    install_path = new_homedir_path / "install"
     with pytest.raises(errors.ChiselError) as exc:
         deb.Ubuntu.unpack_stage_packages(
             stage_packages_path=Path("unused"),
@@ -105,7 +105,7 @@ def test_chisel_error(tmp_path, caplog):
 @pytest.mark.skipif(
     not _current_release_supported(), reason="Test needs Chisel support"
 )
-def test_chisel_normalize_paths(new_dir, partitions):
+def test_chisel_normalize_paths(new_homedir_path, partitions):
     """Check that the contents of cut chisel slices are "normalized" just like
     staged debs.
     """
@@ -126,8 +126,8 @@ def test_chisel_normalize_paths(new_dir, partitions):
     lf = craft_parts.LifecycleManager(
         parts,
         application_name="test_slice",
-        cache_dir=new_dir,
-        work_dir=new_dir,
+        cache_dir=new_homedir_path,
+        work_dir=new_homedir_path,
         partitions=partitions,
     )
 
@@ -136,7 +136,7 @@ def test_chisel_normalize_paths(new_dir, partitions):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    root = Path(new_dir) / "prime"
+    root = Path(new_homedir_path) / "prime"
     link = root / "usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.policy"
     assert link.is_symlink()
     # Symlink must point to the file in the prime dir


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

1. drop `noqa`s that are no longer needed with the newest version of the ruff snap
2. update chisel by means of using the chisel snap:
3. update homedir fixture to use a non-hidden directory so the chisel snap can access it ([docs](https://snapcraft.io/docs/home-interface))

Fixes #746