### PR TITLE
docs: add labels for overlay step

### DIFF
--- a/docs/common/craft-parts/explanation/how_parts_are_built.rst
+++ b/docs/common/craft-parts/explanation/how_parts_are_built.rst
@@ -33,11 +33,15 @@ number of subdirectories:
 The standard actions for the *pull* step can be overridden or extended by
 using the :ref:`override_pull` key to describe a series of actions.
 
+.. _overlay-step-begin:
+
 The overlay step
 ~~~~~~~~~~~~~~~~
 
 The *overlay* step is used in some Craft tools to provide an additional layer that
 overlays the base filesystem layer. Check :ref:`Overlay step explanation <overlays>` for more details.
+
+.. _overlay-step-end:
 
 The build step
 ~~~~~~~~~~~~~~

--- a/docs/common/craft-parts/explanation/parts.rst
+++ b/docs/common/craft-parts/explanation/parts.rst
@@ -183,4 +183,7 @@ The parts in the list will be *built and staged* before the part is built.
 
 This is covered in detail in :ref:`part_processing_order`.
 
+
+.. _include-how-parts-are-built:
+
 .. include:: how_parts_are_built.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ exclude_patterns = [
     # other files - without this exclusion, Sphinx will complain about duplicate
     # labels.
     "common/craft-parts/explanation/overlay_parameters.rst",
+    "common/craft-parts/explanation/how_parts_are_built.rst",
     "common/craft-parts/reference/parts_steps.rst",
     "common/craft-parts/reference/step_execution_environment.rst",
     "common/craft-parts/reference/step_output_directories.rst",


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The reference to the overlay explanation added in #765 is a problem for applications that exclude the overlay explanation page.

See downstream usage: https://github.com/canonical/snapcraft/pull/4948