### PR TITLE
build: define readme type in python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
     version=VERSION,
     description="Craft parts tooling",
     long_description=readme,
+    long_description_content_type="text/markdown",
     author="Canonical Ltd.",
     author_email="snapcraft@lists.snapcraft.io",
     url="https://github.com/canonical/craft-parts",


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Some change to the README in https://github.com/canonical/craft-parts/pull/773 started breaking PyPI uploads with twine:
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```

Fixed with the example in https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/

Unblocks CRAFT-3043