### PR TITLE
fix: partitions break when using special characters

### DIFF
--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -21,13 +21,13 @@ from typing import Dict, Iterable, Optional, Sequence, Set
 
 from craft_parts import errors, features
 
-_VALID_PARTITION_REGEX = re.compile(r"(?!-)[a-z0-9-]+(?<!-)", re.ASCII)
-_VALID_NAMESPACE_REGEX = re.compile(r"[a-z0-9]+", re.ASCII)
-_VALID_NAMESPACED_PARTITION_REGEX = re.compile(
-    _VALID_NAMESPACE_REGEX.pattern + r"/" + _VALID_PARTITION_REGEX.pattern, re.ASCII
+VALID_PARTITION_REGEX = re.compile(r"(?!-)[a-z0-9-]+(?<!-)", re.ASCII)
+VALID_NAMESPACE_REGEX = re.compile(r"[a-z0-9]+", re.ASCII)
+VALID_NAMESPACED_PARTITION_REGEX = re.compile(
+    VALID_NAMESPACE_REGEX.pattern + r"/" + VALID_PARTITION_REGEX.pattern, re.ASCII
 )
 
-_PARTITION_DETAIL = (
+PARTITION_INVALID_MSG = (
     "Partitions must only contain lowercase letters, numbers,"
     "and hyphens, and may not begin or end with a hyphen."
 )
@@ -82,7 +82,7 @@ def _is_valid_partition_name(partition: str) -> bool:
 
     :returns: true if the namespaced partition is valid
     """
-    return bool(re.fullmatch(_VALID_PARTITION_REGEX, partition))
+    return bool(re.fullmatch(VALID_PARTITION_REGEX, partition))
 
 
 def _is_valid_namespaced_partition_name(partition: str) -> bool:
@@ -92,7 +92,7 @@ def _is_valid_namespaced_partition_name(partition: str) -> bool:
 
     :returns: true if the namespaced partition is valid
     """
-    return bool(re.fullmatch(_VALID_NAMESPACED_PARTITION_REGEX, partition))
+    return bool(re.fullmatch(VALID_NAMESPACED_PARTITION_REGEX, partition))
 
 
 def _validate_partition_naming_convention(partitions: Sequence[str]) -> None:
@@ -114,13 +114,13 @@ def _validate_partition_naming_convention(partitions: Sequence[str]) -> None:
                 details=(
                     "Namespaced partitions are formatted as `<namespace>/"
                     "<partition>`. Namespaces must only contain lowercase letters "
-                    "and numbers. " + _PARTITION_DETAIL
+                    "and numbers. " + PARTITION_INVALID_MSG
                 ),
             )
 
         raise errors.FeatureError(
             message=f"Partition {partition!r} is invalid.",
-            details=_PARTITION_DETAIL,
+            details=PARTITION_INVALID_MSG,
         )
 
 

--- a/craft_parts/utils/path_utils.py
+++ b/craft_parts/utils/path_utils.py
@@ -21,14 +21,20 @@ from typing import NamedTuple, Optional, Tuple, TypeVar, Union
 
 from craft_parts.errors import FeatureError
 from craft_parts.features import Features
+from craft_parts.utils import partition_utils
 
 FlexiblePath = TypeVar("FlexiblePath", PurePath, str)
 
-# regex for a path beginning with a partition
-HAS_PARTITION_REGEX = re.compile(r"^\([a-z]+\)(/.*)?$")
+# regex for a path beginning with a (partition), like "(boot)/bin/sh"
+HAS_PARTITION_REGEX = re.compile(
+    r"^\(" + partition_utils.VALID_PARTITION_REGEX.pattern + r"\)(/.*)?$"
+)
 
-# regex for a path beginning with a namespaced partition
-HAS_NAMESPACED_PARTITION_REGEX = re.compile(r"^(\([a-z]+/(?!-)[a-z\-]+(?<!-)\))(/.*)?$")
+# regex for a path beginning with a namespaced partition, like "(a/boot)/bin/sh"
+# Note that unlike HAS_PARTITION_REGEX, this one captures both namespaced partition and path.
+HAS_NAMESPACED_PARTITION_REGEX = re.compile(
+    r"^(\(" + partition_utils.VALID_NAMESPACED_PARTITION_REGEX.pattern + r"\))(/.*)?$"
+)
 
 
 class PartitionPathPair(NamedTuple):

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -118,14 +118,13 @@ class TestPartPartitionUsage:
     @pytest.fixture()
     def partition_list(self):
         """Return a list of partitions, 'default' and 'kernel'."""
-        return ["default", "kernel", "a/b", "a/c-d"]
+        return ["default", "kernel", "a/b", "a/c-d", "f00d", "ha-ha"]
 
     @pytest.fixture()
     def valid_fileset(self):
-        """Return a fileset of that properly uses partition names.
+        """Return a fileset of valid partition names.
 
-        Assumes "default", "a/b", "a/c-d", and "kernel" are passed to
-        the LifecycleManager.
+        Assumes partition_list has been passed to the LifecycleManager.
 
         This list contains variations of two scenarios:
         1. A filepath beginning with a valid partition name (i.e. `(default)/test`)
@@ -178,6 +177,8 @@ class TestPartPartitionUsage:
             "test/(a/c-d)",
             "test(a/c-d)/test",
             "test/(a/c-d)/test",
+            "(f00d)/test",
+            "(ha-ha)/test",
         ]
 
     @pytest.fixture()
@@ -187,14 +188,18 @@ class TestPartPartitionUsage:
         Partition names are misused when an entry begins with a partition name
         but is not wrapped in parentheses.
 
-        Assumes "default", "a/b", "a/c-d", and "kernel" are passed to
-        the LifecycleManager.
+        Assumes partition_list has been passed to the LifecycleManager.
+
         """
         return [
             "default",
             "default/foo",
             "kernel",
             "kernel/foo",
+            "f00d",
+            "f00d/foo",
+            "ha-ha",
+            "ha-ha/foo",
         ]
 
     @pytest.fixture()
@@ -204,8 +209,7 @@ class TestPartPartitionUsage:
         Partition names are misused when an entry begins with a partition name
         but is not wrapped in parentheses.
 
-        Assumes "default", "a/b", "a/c-d", and "kernel" are passed to
-        the LifecycleManager.
+        Assumes partition_list has been passed to the LifecycleManager.
         """
         return [
             "a/b",
@@ -220,8 +224,8 @@ class TestPartPartitionUsage:
 
         These filepaths are not necessarily violating the naming convention for
         partitions, but the partitions here are unknown and thus invalid to a
-        LifecycleManager that was created with the partitions "default", "a/b",
-        "a/c-d", and "kernel".
+
+        Assumes partition_list has been passed to the LifecycleManager.
         """
         return [
             # unknown partition names
@@ -363,7 +367,7 @@ class TestPartPartitionUsage:
 
         assert raised.value.brief == "Invalid usage of partitions"
         assert raised.value.details == dedent(
-            """\
+            f"""\
               parts.part-a.organize
                 unknown partition 'foo' in '(foo)'
               parts.part-a.stage
@@ -371,7 +375,7 @@ class TestPartPartitionUsage:
               parts.part-a.prime
                 unknown partition 'baz' in '(baz)'
                 no path specified after partition in '(baz)'
-            Valid partitions: default, kernel, a/b, a/c-d"""
+            Valid partitions: {", ".join(partition_list)}"""
         )
 
     def test_part_invalid_partition_usage_complex(
@@ -429,7 +433,9 @@ class TestPartPartitionUsage:
             no path specified after partition in '(foo)/'
             unknown partition 'foo' in '(foo)/test'
             unknown partition 'foo-bar' in '(foo-bar)'
+            no path specified after partition in '(foo-bar)'
             unknown partition 'foo-bar' in '(foo-bar)/'
+            no path specified after partition in '(foo-bar)/'
             unknown partition 'foo-bar' in '(foo-bar)/test'
             unknown partition 'foo/bar' in '(foo/bar)'
             no path specified after partition in '(foo/bar)'
@@ -472,5 +478,6 @@ class TestPartPartitionUsage:
             + indent(unknown_partitions_stage_and_prime, "    ")
             + "  parts.part-a.prime\n"
             + indent(unknown_partitions_stage_and_prime, "    ")
-            + "Valid partitions: default, kernel, a/b, a/c-d"
+            + "Valid partitions: "
+            + ", ".join(partition_list)
         )

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -223,7 +223,7 @@ class TestPartPartitionUsage:
         """Return a fileset of invalid uses of partition names.
 
         These filepaths are not necessarily violating the naming convention for
-        partitions, but the partitions here are unknown and thus invalid to a
+        partitions, but the partitions here are unknown and thus invalid.
 
         Assumes partition_list has been passed to the LifecycleManager.
         """

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -39,6 +39,9 @@ PARTITION_PATHS = [
     "(default)/path",
     "(default)//path",
     "(partition)/path",
+    "(parti-tion)/path",
+    "(parti-tion)//path",
+    "(parti-tion2)/path",
     "(test/partition)",
     "(test/partition)/",
     "(test/partition)//",
@@ -46,6 +49,7 @@ PARTITION_PATHS = [
     "(test/partition)//path",
     "(test/parti-tion)/path",
     "(test/parti-tion)//path",
+    "(test/parti-tion2)/path",
 ]
 
 PARTITION_EXPECTED_PARTITIONS = [
@@ -55,6 +59,9 @@ PARTITION_EXPECTED_PARTITIONS = [
     "default",
     "default",
     "partition",
+    "parti-tion",
+    "parti-tion",
+    "parti-tion2",
     "test/partition",
     "test/partition",
     "test/partition",
@@ -62,6 +69,7 @@ PARTITION_EXPECTED_PARTITIONS = [
     "test/partition",
     "test/parti-tion",
     "test/parti-tion",
+    "test/parti-tion2",
 ]
 
 PARTITION_EXPECTED_INNER_PATHS = [
@@ -71,9 +79,13 @@ PARTITION_EXPECTED_INNER_PATHS = [
     "path",
     "path",
     "path",
+    "path",
+    "path",
+    "path",
     "",
     "",
     "",
+    "path",
     "path",
     "path",
     "path",
@@ -93,15 +105,20 @@ assert len(PARTITION_PATHS) == len(
     ("full_path", "expected"),
     [
         ("some/path", False),
+        ("not(a)partition", False),
         # regular partitions
         ("(default)", True),
         ("(default)/", True),
         ("(part)/some/path", True),
+        ("(is1)/apartition", True),
+        ("(woo-hoo)/im-a-partition", True),
         ("(nota)partition", False),
         ("(NOTA)/partition", False),
-        ("(not1)/partition", False),
+        ("(not!a)/partition", False),
         # namespaced partitions
         ("(is/a)/partition", True),
+        ("(look/ma-n0-hands)", True),
+        ("(foo/bar)/baz/qux", True),
         ("(not/a)partition", False),
         ("(NOT/a)partition", False),
         ("(not/A)partition", False),


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Partitions with numbers and hyphens can currently be added, but once you get into lifecycle steps the process will fail strangely - craft-parts thinks paths like `(partition-name1)` are normal paths.

(CRAFT-3031)