### PR TITLE
build(deps): drop unnecessary pydantic-yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ install_requires = [
     "overrides!=7.6.0",
     "PyYAML",
     "pydantic>=2.0.0",
-    "pydantic-yaml[pyyaml]>=1.0.0",
     "pyxdg",
     "requests<2.32.0",
     "requests-unixsocket",


### PR DESCRIPTION
Not needed anymore since Pydantic 2, where we model_dump() the model and then use PyYAML directly.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
