### PR TITLE
feat(partitions): custom error for nonexistent partition

### DIFF
--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -82,7 +82,7 @@ class ProjectDirs:
         if self._partitions:
             if not partition:
                 raise PartitionUsageError(
-                    error_list=f"Partitions are enabled, you must specify which partition's {dir_name} you want.",
+                    error_list=[f"Partitions are enabled, you must specify which partition's {dir_name!r} you want."],
                     partitions=self._partitions,
                 )
             if partition not in self._partitions:

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from types import MappingProxyType
 
+from craft_parts.errors import PartitionNotFound
 from craft_parts.utils import partition_utils
 
 
@@ -77,11 +78,11 @@ class ProjectDirs:
     def get_stage_dir(self, partition: str | None = None) -> Path:
         """Get the stage directory for the given partition."""
         if self._partitions and partition not in self._partitions:
-            raise ValueError(f"Unknown partition {partition}")
+            raise PartitionNotFound(partition, self._partitions)
         return self.stage_dirs[partition]
 
     def get_prime_dir(self, partition: str | None = None) -> Path:
         """Get the stage directory for the given partition."""
         if self._partitions and partition not in self._partitions:
-            raise ValueError(f"Unknown partition {partition}")
+            raise PartitionNotFound(partition, self._partitions)
         return self.prime_dirs[partition]

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -82,7 +82,8 @@ class ProjectDirs:
         if self._partitions:
             if not partition:
                 raise PartitionUsageError(
-                    f"Partitions are enabled, you must specify which partition's {dir_name} you want."
+                    error_list=f"Partitions are enabled, you must specify which partition's {dir_name} you want.",
+                    partitions=self._partitions,
                 )
             if partition not in self._partitions:
                 raise PartitionNotFound(partition, self._partitions)

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -82,7 +82,9 @@ class ProjectDirs:
         if self._partitions:
             if not partition:
                 raise PartitionUsageError(
-                    error_list=[f"Partitions are enabled, you must specify which partition's {dir_name!r} you want."],
+                    error_list=[
+                        f"Partitions are enabled, you must specify which partition's {dir_name!r} you want."
+                    ],
                     partitions=self._partitions,
                 )
             if partition not in self._partitions:

--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from types import MappingProxyType
 
-from craft_parts.errors import PartitionNotFound
+from craft_parts.errors import PartitionNotFound, PartitionUsageError
 from craft_parts.utils import partition_utils
 
 
@@ -75,14 +75,24 @@ class ProjectDirs:
             )
         )
 
+    def _validate_requested_partition(
+        self, dir_name: str, partition: str | None = None
+    ) -> None:
+        """Ensure the requested partition is valid."""
+        if self._partitions:
+            if not partition:
+                raise PartitionUsageError(
+                    f"Partitions are enabled, you must specify which partition's {dir_name} you want."
+                )
+            if partition not in self._partitions:
+                raise PartitionNotFound(partition, self._partitions)
+
     def get_stage_dir(self, partition: str | None = None) -> Path:
         """Get the stage directory for the given partition."""
-        if self._partitions and partition not in self._partitions:
-            raise PartitionNotFound(partition, self._partitions)
+        self._validate_requested_partition("stage_dir", partition)
         return self.stage_dirs[partition]
 
     def get_prime_dir(self, partition: str | None = None) -> Path:
-        """Get the stage directory for the given partition."""
-        if self._partitions and partition not in self._partitions:
-            raise PartitionNotFound(partition, self._partitions)
+        """Get the prime directory for the given partition."""
+        self._validate_requested_partition("prime_dir", partition)
         return self.prime_dirs[partition]

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -653,17 +653,21 @@ class PartitionUsageError(PartitionError):
 
     :param error_list: Iterable of strings describing the invalid usages.
     :param partitions: Iterable of the names of valid partitions.
+    :param brief: Override brief message.
     """
 
     def __init__(
-        self, error_list: Iterable[str], partitions: Iterable[str] | None
+        self,
+        error_list: Iterable[str],
+        partitions: Iterable[str] | None,
+        brief: str | None = None,
     ) -> None:
         valid_partitions = (
             f"\nValid partitions: {', '.join(partitions)}" if partitions else ""
         )
 
         super().__init__(
-            brief="Invalid usage of partitions",
+            brief=brief or "Invalid usage of partitions",
             details="\n".join(error_list) + valid_partitions,
             resolution="Correct the invalid partition name(s) and try again.",
         )
@@ -703,4 +707,5 @@ class PartitionNotFound(PartitionUsageError):
         super().__init__(
             brief=f"Requested partition does not exist: {partition_name!r}",
             partitions=partitions,
+            error_list=[],
         )

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -703,6 +703,7 @@ class PartitionNotFound(PartitionUsageError):
     """
 
     def __init__(self, partition_name: str, partitions: Iterable[str]) -> None:
+        # Allow callers catching this exception easy access to the partition name
         self.partition_name = partition_name
         super().__init__(
             brief=f"Requested partition does not exist: {partition_name!r}",

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -652,6 +652,7 @@ class PartitionUsageError(PartitionError):
     """Error for a list of invalid partition usages.
 
     :param error_list: Iterable of strings describing the invalid usages.
+    :param partitions: Iterable of the names of valid partitions.
     """
 
     def __init__(
@@ -688,3 +689,18 @@ class PartitionUsageWarning(PartitionError, Warning):
             ),
         )
         Warning.__init__(self)
+
+
+class PartitionNotFound(PartitionUsageError):
+    """A partition has been specified that does not exist.
+
+    :param partition_name: The name of the partition that does not exist.
+    :param partitions: Iterable of the names of valid partitions.
+    """
+
+    def __init__(self, partition_name: str, partitions: Iterable[str]) -> None:
+        self.partition_name = partition_name
+        super().__init__(
+            brief=f"Requested partition does not exist: {partition_name!r}",
+            partitions=partitions,
+        )

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -175,6 +175,7 @@ PartInfo
 PartSpec
 PartSpecificationError
 PartitionError
+PartitionNotFound
 PartitionPathPair
 PartitionUsageError
 PartitionUsageWarning


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Raise a custom error when a nonexistent partition is asked for, so `corncraft` can catch it more cleanly.

Depending on the stringification is fragile, but if you don't do some sort of deeper check then you could accidentally handle other `ValueError`s.

(CRAFT-3031)