### PR TITLE
fix: use partitions for stage-packages tracking

### DIFF
--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -202,6 +202,7 @@ PullError
 PullState
 PurePath
 PydanticGeneralMetadata
+PydanticUndefined
 PyPI
 PyYAML
 PyYAML's

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -200,6 +200,7 @@ class TestPartHandling:
             return_value=StepContents({"file"}, {"dir"}),
         )
         mocker.patch("os.getxattr", return_value=b"pkg")
+        mocker.patch("pathlib.Path.exists", return_value=True)
 
         ovmgr = OverlayManager(
             project_info=self._project_info, part_list=[self._part], base_layer_dir=None


### PR DESCRIPTION
This localized fix addresses the issue of stage-package tracking failing in
the presence of partitions by looking for the primed files in each partition.

This solves the most common cases but doesn't fix the issue where a given file
might be present in multiple partitions, as this needs a deeper refactoring of
the state tracking (see discussion in https://github.com/canonical/craft-parts/issues/804).

Fixes https://github.com/canonical/craft-parts/issues/804

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
