### PR TITLE
chore: split _get_java_post_build_commands

### DIFF
--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -99,6 +99,27 @@ class JavaPlugin(Plugin):
     symlink creation.
     """
 
+    def _get_java_link_commands(self) -> list[str]:
+        """Get the bash commands to provide /bin/java symlink."""
+        # pylint: disable=line-too-long
+        return [
+            '# Find the "java" executable and make a link to it in CRAFT_PART_INSTALL/bin/java',
+            "mkdir -p ${CRAFT_PART_INSTALL}/bin",
+            "java_bin=$(find ${CRAFT_PART_INSTALL} -name java -type f -executable)",
+            "ln -s --relative $java_bin ${CRAFT_PART_INSTALL}/bin/java",
+        ]
+        # pylint: enable=line-too-long
+
+    def _get_jar_link_commands(self) -> list[str]:
+        """Get the bash commands to provide ${CRAFT_STAGE}/jars."""
+        # pylint: disable=line-too-long
+        return [
+            "# Find all the generated jars and hardlink them inside CRAFT_PART_INSTALL/jar/",
+            "mkdir -p ${CRAFT_PART_INSTALL}/jar",
+            r'find ${CRAFT_PART_BUILD}/ -iname "*.jar" -exec ln {} ${CRAFT_PART_INSTALL}/jar \;',
+        ]
+        # pylint: enable=line-too-long
+
     def _get_java_post_build_commands(self) -> list[str]:
         """Get the bash commands to structure a Java build in the part's install dir.
 
@@ -110,22 +131,7 @@ class JavaPlugin(Plugin):
           - Hardlink the .jar files generated in ${CRAFT_PART_BUILD} to
             ${CRAFT_PART_INSTALL}/jar.
         """
-        # pylint: disable=line-too-long
-        link_java = [
-            '# Find the "java" executable and make a link to it in CRAFT_PART_INSTALL/bin/java',
-            "mkdir -p ${CRAFT_PART_INSTALL}/bin",
-            "java_bin=$(find ${CRAFT_PART_INSTALL} -name java -type f -executable)",
-            "ln -s --relative $java_bin ${CRAFT_PART_INSTALL}/bin/java",
-        ]
-
-        link_jars = [
-            "# Find all the generated jars and hardlink them inside CRAFT_PART_INSTALL/jar/",
-            "mkdir -p ${CRAFT_PART_INSTALL}/jar",
-            r'find ${CRAFT_PART_BUILD}/ -iname "*.jar" -exec ln {} ${CRAFT_PART_INSTALL}/jar \;',
-        ]
-        # pylint: enable=line-too-long
-
-        return link_java + link_jars
+        return self._get_java_link_commands() + self._get_jar_link_commands()
 
 
 class BasePythonPlugin(Plugin):


### PR DESCRIPTION
JavaPlugin provides _get_java_post_build_commands() that is called from derived classes.

/bin/java link is broken for rockcraft projects.
Split _get_java_link_commands() into _get_java_link_commands() and _get_jar_link_commands() to allow rockcraft plugins override _get_java_link_commands().

This MR addresses https://github.com/canonical/craft-parts/issues/813

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
