### PR TITLE
fix(plugins): ensure stateless npm plugin

### DIFF
--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -280,6 +280,12 @@ class NpmPlugin(Plugin):
     @override
     def get_pull_commands(self) -> List[str]:
         """Return a list of commands to run during the pull step."""
+        return []
+
+    @override
+    def get_build_commands(self) -> List[str]:
+        """Return a list of commands to run during the build step."""
+        cmd = []
         options = cast(NpmPluginProperties, self._options)
         if options.npm_include_node:
             arch = self._get_architecture()
@@ -291,7 +297,7 @@ class NpmPlugin(Plugin):
             self._node_binary_path = os.path.join(
                 self._part_info.part_cache_dir, file_name
             )
-            return [
+            cmd += [
                 dedent(
                     f"""\
                 if [ ! -f "{self._node_binary_path}" ]; then
@@ -299,17 +305,22 @@ class NpmPlugin(Plugin):
                     curl --retry 5 -s "{checksum_uri}" -o "{self._part_info.part_cache_dir}"/SHASUMS256.txt
                     curl --retry 5 -s "{node_uri}" -o "{self._node_binary_path}"
                 fi
-                cd "{self._part_info.part_cache_dir}"
+                pushd "{self._part_info.part_cache_dir}"
                 sha256sum --ignore-missing --strict -c SHASUMS256.txt
+                popd
                 """
                 )
             ]
-        return []
-
-    @override
-    def get_build_commands(self) -> List[str]:
-        """Return a list of commands to run during the build step."""
-        cmd = [
+        if self._node_binary_path is not None:
+            cmd += [
+                dedent(
+                    f"""\
+                tar -xzf "{self._node_binary_path}" -C "${{CRAFT_PART_INSTALL}}/" \
+                    --no-same-owner --strip-components=1
+                """
+                ),
+            ]
+        cmd += [
             dedent(
                 """\
             NPM_VERSION="$(npm --version)"
@@ -322,14 +333,4 @@ class NpmPlugin(Plugin):
             """
             )
         ]
-        if self._node_binary_path is not None:
-            cmd.insert(
-                0,
-                dedent(
-                    f"""\
-                tar -xzf "{self._node_binary_path}" -C "${{CRAFT_PART_INSTALL}}/" \
-                    --no-same-owner --strip-components=1
-                """
-                ),
-            )
         return cmd

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -290,17 +290,16 @@ class TestPluginNpmPlugin:
         ]
         plugin = NpmPlugin(properties=properties, part_info=part_info)
 
-        assert plugin.get_pull_commands() == [
+        assert plugin.get_pull_commands() == []
+
+        assert plugin.get_build_commands() == [
             f'if [ ! -f "{part_info.part_cache_dir}/node-v20.13.1-linux-x64.tar.gz" ]; then\n'
             f'    mkdir -p "{part_info.part_cache_dir}"\n'
             f'    curl --retry 5 -s "https://nodejs.org/dist/v20.13.1/SHASUMS256.txt" -o "{part_info.part_cache_dir}"/SHASUMS256.txt\n'
             f'    curl --retry 5 -s "https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-x64.tar.gz" -o "{part_info.part_cache_dir}/node-v20.13.1-linux-x64.tar.gz"\n'
             "fi\n"
-            f'cd "{part_info.part_cache_dir}"\n'
-            "sha256sum --ignore-missing --strict -c SHASUMS256.txt\n"
-        ]
-
-        assert plugin.get_build_commands() == [
+            f'pushd "{part_info.part_cache_dir}"\n'
+            "sha256sum --ignore-missing --strict -c SHASUMS256.txt\npopd\n",
             f'tar -xzf "{part_info.part_cache_dir}/node-v20.13.1-linux-x64.tar.gz"'
             ' -C "${CRAFT_PART_INSTALL}/"                     --no-same-owner '
             "--strip-components=1\n",


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This pull request works around an issue that regressed NPM-based projects on the Launchpad auto-build system.

The issue was that the Launchpad auto-build system executed pull and build steps separately, thereby losing the shared state between them.

This is a temporary fix for the 1.33 branch.