### PR TITLE
build(deps): use correct canonical-sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,4 +20,4 @@ sphinxcontrib-htmlhelp==2.0.5
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxext-opengraph==0.9.1
-canonical-sphinx~=0.1
+canonical-sphinx==0.1.0


### PR DESCRIPTION
0.2.0 causes some breakages that will need attention.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
