### PR TITLE
docs: add anchors to support charmcraft documentation

### DIFF
--- a/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
@@ -5,6 +5,8 @@ Poetry plugin
 
 The Poetry plugin can be used for Python projects that use the `Poetry`_ build system.
 
+.. _craft_parts_poetry_plugin-keywords:
+
 Keywords
 --------
 
@@ -19,6 +21,8 @@ poetry-with:
 **Type:** list of strings
 
 Extra `dependency groups`_ to use other than the defaults.
+
+.. _craft_parts_poetry_plugin-environment_variables:
 
 Environment variables
 ---------------------

--- a/docs/common/craft-parts/reference/plugins/python_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/python_plugin.rst
@@ -11,6 +11,7 @@ any of the following things:
   :file:`pyproject.toml` file.
 - Install packages using :command:`pip`.
 
+.. _craft_parts_python_plugin-keywords:
 
 Keywords
 --------
@@ -40,6 +41,7 @@ python-packages
 A list of dependencies to install from PyPI. If needed, :command:`pip`,
 :command:`setuptools` and :command:`wheel` can be upgraded here.
 
+.. _craft_parts_python_plugin-environment_variables:
 
 Environment variables
 ---------------------


### PR DESCRIPTION
This adds anchors to the Python and Poetry documentation to support how Charmcraft is going to use these.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
