### PR TITLE
fix(plugins/rust): fix snap dependency handling

### DIFF
--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -169,8 +169,15 @@ class RustPlugin(Plugin):
     def get_build_snaps(self) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
         options = cast(RustPluginProperties, self._options)
-        if not options.rust_channel and self._check_system_rust():
-            logger.info("Rust is installed on the system, skipping rustup")
+        if options.rust_channel == "none":
+            logger.info(
+                "Not installing rustup because rust-channel 'none' was specified."
+            )
+            return set()
+        if options.after and "rust-deps" in options.after:
+            logger.info(
+                "Not installing rustup because a 'rust-deps' dependent part is specified."
+            )
             return set()
         return {"rustup"}
 


### PR DESCRIPTION
This changes the following:

- If 'rust-channel' is explicitly set to the string 'none', don't install rustup.
- If the rust-using part has a 'rust-deps' plugin, don't install rustup.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
