### PR TITLE
fix(poetry): don't install poetry with poetry-deps

### DIFF
--- a/craft_parts/plugins/poetry_plugin.py
+++ b/craft_parts/plugins/poetry_plugin.py
@@ -88,7 +88,10 @@ class PoetryPlugin(BasePythonPlugin):
     def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
         build_packages = super().get_build_packages()
-        if not self._system_has_poetry():
+        if (
+            not self._system_has_poetry()
+            and "poetry-deps" not in self._part_info.dependencies
+        ):
             build_packages |= {"python3-poetry"}
         return build_packages
 

--- a/tests/unit/plugins/test_poetry_plugin.py
+++ b/tests/unit/plugins/test_poetry_plugin.py
@@ -34,16 +34,19 @@ def plugin(new_dir):
 
 
 @pytest.mark.parametrize(
-    ("has_poetry", "expected_packages"),
+    ("has_poetry", "part_deps", "expected_packages"),
     [
-        (False, {"python3-poetry"}),
-        (True, set()),
+        (False, set(), {"python3-poetry"}),
+        (False, {"poetry-deps"}, set()),
+        (True, {"poetry-deps"}, set()),
+        (True, set(), set()),
     ],
 )
 def test_get_build_packages(
-    monkeypatch, plugin: PoetryPlugin, has_poetry, expected_packages: set
+    monkeypatch, plugin: PoetryPlugin, has_poetry, part_deps, expected_packages: set
 ):
     monkeypatch.setattr(plugin, "_system_has_poetry", lambda: has_poetry)
+    plugin._part_info.dependencies = part_deps  # type: ignore[attr-defined]
 
     assert plugin.get_build_packages().issuperset(expected_packages)
 


### PR DESCRIPTION
If a `poetry-deps` dependent part exists, don't add poetry to the packages to install.

Fixes https://github.com/canonical/charmcraft/issues/1996
CRAFT-3687

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
