### PR TITLE
feat: add chisel as a build snap when stage-packages contain slices

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -158,6 +158,14 @@ class LifecycleManager:
             part_list.append(part)
 
         self._has_overlay = any(p.has_overlay for p in part_list)
+        self._needs_chisel = any(p.has_slices for p in part_list)
+        self._has_chisel = any(p.has_chisel_as_build_snap for p in part_list)
+
+        # add a chisel as a build snap if needed
+        if self._needs_chisel and not self._has_chisel:
+            if extra_build_snaps is None:
+                extra_build_snaps = []
+            extra_build_snaps.append("chisel/latest/stable")
 
         # a base layer is mandatory if overlays are in use
         if self._has_overlay:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -178,11 +178,15 @@ class PartSpec(BaseModel):
     @property
     def has_slices(self) -> bool:
         """Return whether the part contains chisel slices."""
-        return any(p for p in self.stage_packages if "_" in p)
+        if not self.stage_packages:
+            return False
+        return any("_" in p for p in self.stage_packages)
 
     @property
     def has_chisel_as_build_snap(self) -> bool:
         """Return whether the part has chisel as build snap."""
+        if not self.build_snaps:
+            return False
         return any(
             p for p in self.build_snaps if p == "chisel" or p.startswith("chisel/")
         )

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -175,6 +175,18 @@ class PartSpec(BaseModel):
             or self.overlay_files != ["*"]
         )
 
+    @property
+    def has_slices(self) -> bool:
+        """Return whether the part contains chisel slices."""
+        return any(p for p in self.stage_packages if "_" in p)
+
+    @property
+    def has_chisel_as_build_snap(self) -> bool:
+        """Return whether the part has chisel as build snap."""
+        return any(
+            p for p in self.build_snaps if p == "chisel" or p.startswith("chisel/")
+        )
+
 
 # pylint: disable=too-many-public-methods
 class Part:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -393,6 +393,16 @@ class Part:
         """Return whether this part declares overlay content."""
         return self.spec.has_overlay
 
+    @property
+    def has_slices(self) -> bool:
+        """Return whether this part has slices in its stage-packages."""
+        return self.spec.has_slices
+
+    @property
+    def has_chisel_as_build_snap(self) -> bool:
+        """Return whether this part has chisel in its build-snaps."""
+        return self.spec.has_chisel_as_build_snap
+
     def _check_partition_feature(self) -> None:
         """Check if the partitions feature is properly used.
 

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -335,6 +335,31 @@ class TestPartData:
         p = Part("foo", {}, partitions=partitions)
         assert p.has_overlay is False
 
+    @pytest.mark.parametrize(
+        ("tc_spec", "tc_result"),
+        [
+            ({}, False),
+            ({"stage-packages": ["base-files_base", "hello_bins"]}, True),
+            ({"stage-packages": ["bash", "python3"]}, False),
+        ],
+    )
+    def test_part_has_slices(self, partitions, tc_spec, tc_result):
+        p = Part("foo", tc_spec, partitions=partitions)
+        assert p.spec.has_slices == tc_result
+
+    @pytest.mark.parametrize(
+        ("tc_spec", "tc_result"),
+        [
+            ({}, False),
+            ({"build-snaps": ["hello", "chisel/latest/candidate"]}, True),
+            ({"build-snaps": ["chisel"]}, True),
+            ({"build-snaps": ["hello"]}, False),
+        ],
+    )
+    def test_part_has_chisel_as_build_snap(self, partitions, tc_spec, tc_result):
+        p = Part("foo", tc_spec, partitions=partitions)
+        assert p.spec.has_chisel_as_build_snap == tc_result
+
 
 class TestPartOrdering:
     """Test part ordering.

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -353,6 +353,7 @@ class TestPartData:
             ({}, False),
             ({"build-snaps": ["hello", "chisel/latest/candidate"]}, True),
             ({"build-snaps": ["chisel"]}, True),
+            ({"build-snaps": ["chiselhelper"]}, False),
             ({"build-snaps": ["hello"]}, False),
         ],
     )


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR aims to stop chisel from being unnecessarily installed in the Rockcraft snap.

It does that by having chisel as a build snap only when the following conditions are met:
- there is at least one `part` that has slices in its `stage-packages`
- there is no `part` that has chisel in its `build-snaps`
