### PR TITLE
docs: fix linting for release tags and backfill changelog links to 2.0.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,16 +42,22 @@ Documentation:
   plugin</common/craft-parts/reference/plugins/rust_plugin>` doc with recent
   changes to the Rust toolchain.
 
+For a complete list of commits, check out the `2.1.2`_ release on GitHub.
+
 2.1.1 (2024-09-13)
 ------------------
 
 - This release brings the bug fix from ``1.33.1`` into the ``2.1.x`` series.
+
+For a complete list of commits, check out the `2.1.1`_ release on GitHub.
 
 1.33.1 (2024-09-13)
 -------------------
 
 - Fix NPM plugin to be stateless, allowing lifecycle steps to be
   executed in separate runs.
+
+For a complete list of commits, check out the `1.33.1`_ release on GitHub.
 
 2.1.0 (2024-09-09)
 ------------------
@@ -67,6 +73,8 @@ Bug fixes:
 - Fix a regression where numeric part properties could not be parsed.
 - Fix a bug where stage-packages tracking would fail when files were organized
   into a non-default partition.
+
+For a complete list of commits, check out the `2.1.0`_ release on GitHub.
 
 2.0.0 (2024-08-08)
 ------------------
@@ -87,6 +95,8 @@ Bug fixes:
 
 - Xattrs raise FileNotFoundError when appropriate
 - Partition names are more strictly checked.
+
+For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 
 1.34.0 (2024-08-01)
 -------------------
@@ -609,3 +619,8 @@ Bug fixes:
 .. _Poetry: https://python-poetry.org
 
 .. _2.1.3: https://github.com/canonical/craft-parts/releases/tag/2.1.3
+.. _2.1.2: https://github.com/canonical/craft-parts/releases/tag/2.1.2
+.. _2.1.1: https://github.com/canonical/craft-parts/releases/tag/2.1.1
+.. _1.33.1: https://github.com/canonical/craft-parts/releases/tag/1.33.1
+.. _2.1.0: https://github.com/canonical/craft-parts/releases/tag/2.1.0
+.. _2.0.0: https://github.com/canonical/craft-parts/releases/tag/2.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,8 @@ linkcheck_ignore = [
     "https://foo.org/",
     # GNU's site is a bit unreliable
     "https://www.gnu.org/.*",
+    # Ignore releases, since we'll include the next release before it exists.
+    "https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
 ]
 
 rst_epilog = """


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Fixes #908
CRAFT-3715