### PR TITLE
feat: add funcs part_has_slices and part_has_chisel_as_build_snap

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -26,7 +26,13 @@ from .executor import expand_environment
 from .features import Features
 from .infos import PartInfo, ProjectInfo, StepInfo
 from .lifecycle_manager import LifecycleManager
-from .parts import Part, part_has_overlay, validate_part
+from .parts import (
+    Part,
+    part_has_chisel_as_build_snap,
+    part_has_slices,
+    part_has_overlay,
+    validate_part,
+)
 from .steps import Step
 
 __all__ = [
@@ -46,4 +52,6 @@ __all__ = [
     "expand_environment",
     "validate_part",
     "part_has_overlay",
+    "part_has_slices",
+    "part_has_chisel_as_build_snap",
 ]

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -684,6 +684,26 @@ def part_has_overlay(data: dict[str, Any]) -> bool:
     return spec.has_overlay
 
 
+def part_has_slices(data: dict[str, Any]) -> bool:
+    """Whether the part described by ``data`` contains slices.
+
+    :param data: The part data to query.
+    """
+    spec = _get_part_spec(data)
+
+    return spec.has_slices
+
+
+def part_has_chisel_as_build_snap(data: dict[str, Any]) -> bool:
+    """Whether the part described by ``data`` has chisel in build-snaps.
+
+    :param data: The part data to query.
+    """
+    spec = _get_part_spec(data)
+
+    return spec.has_chisel_as_build_snap
+
+
 def _get_part_spec(data: dict[str, Any]) -> PartSpec:
     if not isinstance(data, dict):
         raise TypeError("value must be a dictionary")


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This is add two utility functions `part_has_slices` and `part_has_chisel_as_build_snap` that takes a dictionary (representing a part's data) as an argument and determine whether the part data has slices and whether it has chisel in build-snaps, respectively.

Those functions are needed in Rockcraft, where we deal with part data dictionaries often, and converting those dictionaries to PartSpec objects will require extra code that has been already implemented internally in craft-parts.

Related work: #904 