### PR TITLE
doc(ant,maven): add labels for description

### DIFF
--- a/docs/common/craft-parts/reference/plugins/ant_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/ant_plugin.rst
@@ -10,6 +10,7 @@ path to the latest JDK found in the build environment.
 After a successful build, this plugin will:
 
 .. _craft_parts_ant_plugin_post_build_begin:
+
 * Create ``bin/`` and ``jar/`` directories in ``$CRAFT_PART_INSTALL``.
 * Find the ``java`` executable provided by the part and link it as
   ``$CRAFT_PART_INSTALL/bin/java``.

--- a/docs/common/craft-parts/reference/plugins/ant_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/ant_plugin.rst
@@ -3,20 +3,20 @@
 Ant plugin
 ==========
 
-.. _craft_parts_ant_plugin_description_begin:
 The Ant plugin builds Java projects using the `Apache Ant`_ build tool.
 This plugin will set the ``JAVA_HOME`` environment variable to the
 path to the latest JDK found in the build environment.
 
 After a successful build, this plugin will:
 
+.. _craft_parts_ant_plugin_post_build_begin:
 * Create ``bin/`` and ``jar/`` directories in ``$CRAFT_PART_INSTALL``.
 * Find the ``java`` executable provided by the part and link it as
   ``$CRAFT_PART_INSTALL/bin/java``.
 * Hard link the ``.jar`` files generated in ``$CRAFT_PART_BUILD`` to
   ``$CRAFT_PART_INSTALL/jar``.
 
-.. _craft_parts_ant_plugin_description_end:
+.. _craft_parts_ant_plugin_post_build_end:
 
 Keywords
 --------

--- a/docs/common/craft-parts/reference/plugins/ant_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/ant_plugin.rst
@@ -3,6 +3,7 @@
 Ant plugin
 ==========
 
+.. _craft_parts_ant_plugin_description_begin:
 The Ant plugin builds Java projects using the `Apache Ant`_ build tool.
 This plugin will set the ``JAVA_HOME`` environment variable to the
 path to the latest JDK found in the build environment.
@@ -15,6 +16,7 @@ After a successful build, this plugin will:
 * Hard link the ``.jar`` files generated in ``$CRAFT_PART_BUILD`` to
   ``$CRAFT_PART_INSTALL/jar``.
 
+.. _craft_parts_ant_plugin_description_end:
 
 Keywords
 --------

--- a/docs/common/craft-parts/reference/plugins/maven_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_plugin.rst
@@ -10,6 +10,7 @@ path to the latest JDK found in the build environment.
 After a successful build, this plugin will:
 
 .. _craft_parts_maven_plugin_post_build_begin:
+
 * Create ``bin/`` and ``jar/`` directories in ``$CRAFT_PART_INSTALL``.
 * Find the ``java`` executable provided by the part and link it as
   ``$CRAFT_PART_INSTALL/bin/java``.

--- a/docs/common/craft-parts/reference/plugins/maven_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_plugin.rst
@@ -3,20 +3,20 @@
 Maven plugin
 ============
 
-.. _craft_parts_maven_plugin_description_begin:
 The Maven plugin builds Java projects using the Maven build tool.
 This plugin will set the ``JAVA_HOME`` environment variable to the
 path to the latest JDK found in the build environment.
 
 After a successful build, this plugin will:
 
+.. _craft_parts_maven_plugin_post_build_begin:
 * Create ``bin/`` and ``jar/`` directories in ``$CRAFT_PART_INSTALL``.
 * Find the ``java`` executable provided by the part and link it as
   ``$CRAFT_PART_INSTALL/bin/java``.
 * Hard link the ``.jar`` files generated in ``$CRAFT_PART_BUILD`` to
   ``$CRAFT_PART_INSTALL/jar``.
 
-.. _craft_parts_maven_plugin_description_end:
+.. _craft_parts_maven_plugin_post_build_end:
 
 Keywords
 --------

--- a/docs/common/craft-parts/reference/plugins/maven_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_plugin.rst
@@ -3,6 +3,7 @@
 Maven plugin
 ============
 
+.. _craft_parts_maven_plugin_description_begin:
 The Maven plugin builds Java projects using the Maven build tool.
 This plugin will set the ``JAVA_HOME`` environment variable to the
 path to the latest JDK found in the build environment.
@@ -15,6 +16,7 @@ After a successful build, this plugin will:
 * Hard link the ``.jar`` files generated in ``$CRAFT_PART_BUILD`` to
   ``$CRAFT_PART_INSTALL/jar``.
 
+.. _craft_parts_maven_plugin_description_end:
 
 Keywords
 --------


### PR DESCRIPTION
Ant and maven plugin descriptions are overriden by rockcraft. Add labels to simplify documentation override.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
