### PR TITLE
feat: add an API for registering source types

### DIFF
--- a/craft_parts/sources/__init__.py
+++ b/craft_parts/sources/__init__.py
@@ -29,7 +29,13 @@ from .local_source import LocalSource, LocalSourceModel
 from .rpm_source import RpmSource, RpmSourceModel
 from .sevenzip_source import SevenzipSource, SevenzipSourceModel
 from .snap_source import SnapSource, SnapSourceModel
-from .sources import SourceHandler, get_source_handler, get_source_type_from_uri
+from .sources import (
+    SourceHandler,
+    get_source_handler,
+    get_source_type_from_uri,
+    register,
+    unregister,
+)
 from .tar_source import TarSource, TarSourceModel
 from .zip_source import ZipSource, ZipSourceModel
 
@@ -79,4 +85,6 @@ __all__ = [
     "TarSourceModel",
     "ZipSource",
     "ZipSourceModel",
+    "register",
+    "unregister",
 ]

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -72,7 +72,18 @@ class BaseSourceModel(pydantic.BaseModel, frozen=True):  # type: ignore[misc]
 
     model_config = get_model_config()
     source_type: str
+    """The name of this source type.
+
+    Sources must define this with a type hint of a Literal type of its name
+    and a value of its name.
+    """
     source: str
+    pattern: ClassVar[str | None] = None
+    """A regular expression for inferring this source type.
+
+    If pattern is None (the default), the source type cannot be inferred and must
+    always be explicitly written in the source-type field of a part.
+    """
 
 
 class BaseFileSourceModel(BaseSourceModel, frozen=True):

--- a/craft_parts/sources/deb_source.py
+++ b/craft_parts/sources/deb_source.py
@@ -36,7 +36,8 @@ logger = logging.getLogger(__name__)
 class DebSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for deb file sources."""
 
-    model_config = get_model_config(get_json_extra_schema(r"\.deb$"))
+    pattern = r"\.deb$"
+    model_config = get_model_config(get_json_extra_schema(pattern))
     source_type: Literal["deb"] = "deb"
 
 

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -32,11 +32,16 @@ class InvalidSourceType(SourceError):
     :param source: The source defined for the part.
     """
 
-    def __init__(self, source: str) -> None:
+    def __init__(self, source: str, *, source_type: str | None = None) -> None:
         self.source = source
-        brief = f"Failed to pull source: unable to determine source type of {source!r}."
+        self.source_type = source_type
 
-        super().__init__(brief=brief)
+        if source_type:
+            message = f"unknown source-type {source_type!r}."
+        else:
+            message = f"unable to determine source type of {source!r}."
+
+        super().__init__(brief=f"Failed to pull source: {message}")
 
 
 class InvalidSourceOption(SourceError):

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 class GitSourceModel(BaseSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a git-based source."""
 
+    pattern = r"(^git(\+.+:|[@:])|\.git$)"
     model_config = get_model_config(get_json_extra_schema(r"(^git[+@:]|\.git$)"))
     source_type: Literal["git"] = "git"
     source: str

--- a/craft_parts/sources/rpm_source.py
+++ b/craft_parts/sources/rpm_source.py
@@ -39,7 +39,8 @@ logger = logging.getLogger(__name__)
 class RpmSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for an rpm file source."""
 
-    model_config = get_model_config(get_json_extra_schema(r"\.rpm$"))
+    pattern = r"\.rpm$"
+    model_config = get_model_config(get_json_extra_schema(pattern))
     source_type: Literal["rpm"] = "rpm"
 
 

--- a/craft_parts/sources/sevenzip_source.py
+++ b/craft_parts/sources/sevenzip_source.py
@@ -32,7 +32,8 @@ from .base import (
 class SevenzipSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic for a 7zip file source."""
 
-    model_config = get_model_config(get_json_extra_schema(r"\.7z$"))
+    pattern = r"\.7z$"
+    model_config = get_model_config(get_json_extra_schema(pattern))
     source_type: Literal["7z"] = "7z"
 
 

--- a/craft_parts/sources/snap_source.py
+++ b/craft_parts/sources/snap_source.py
@@ -39,7 +39,8 @@ from .base import (
 class SnapSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a snap file source."""
 
-    model_config = get_model_config(get_json_extra_schema(r"\.snap$"))
+    pattern = r"\.snap$"
+    model_config = get_model_config(get_json_extra_schema(pattern))
     source_type: Literal["snap"] = "snap"
 
 

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2015-2021 Canonical Ltd.
+# Copyright 2015-2021,2024 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -27,7 +27,7 @@ code for that part, and how to unpack it if necessary.
     directory tree or a tarball or a revision control repository
     ('git:...').
 
-  - source-type: git, bzr, hg, svn, tar, deb, rpm, or zip
+  - source-type: git, tar, deb, rpm, or zip
 
     In some cases the source string is not enough to identify the version
     control system or compression algorithm. The source-type key can tell
@@ -83,10 +83,12 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pydantic_core
+
 from craft_parts.dirs import ProjectDirs
 
 from . import errors
-from .base import SourceHandler
+from .base import BaseSourceModel, SourceHandler
 from .deb_source import DebSource
 from .file_source import FileSource
 from .git_source import GitSource
@@ -102,8 +104,7 @@ if TYPE_CHECKING:
 
 SourceHandlerType = type[SourceHandler]
 
-
-_source_handler: dict[str, SourceHandlerType] = {
+_MANDATORY_SOURCES: dict[str, SourceHandlerType] = {
     "local": LocalSource,
     "tar": TarSource,
     "git": GitSource,
@@ -114,6 +115,39 @@ _source_handler: dict[str, SourceHandlerType] = {
     "rpm": RpmSource,
     "7z": SevenzipSource,
 }
+
+_SOURCES: dict[str, SourceHandlerType] = {}
+
+
+def _get_type_name_from_model(model: type[BaseSourceModel]) -> str:
+    source_type = model.model_fields["source_type"]
+    if (default := source_type.get_default()) is not pydantic_core.PydanticUndefined:
+        return str(default)
+    if source_type.annotation is None:
+        raise TypeError("Source type needs an annotation.")
+    return str(source_type.annotation.__args__[0])
+
+
+def register(source: SourceHandlerType, /) -> None:
+    """Register source handlers.
+
+    :param source: a SourceHandler class to register.
+    :raises: ValueError if the source handler overrides a built-in source type.
+    """
+    source_name = _get_type_name_from_model(source.source_model)
+    if source_name in _MANDATORY_SOURCES:
+        raise ValueError(f"Built-in source types cannot be overridden: {source_name!r}")
+    _SOURCES[source_name] = source
+
+
+def unregister(source: str, /) -> None:
+    """Unregister a source handler by name."""
+    if source in _MANDATORY_SOURCES:
+        raise ValueError(f"Built-in source types cannot be unregistered: {source!r}")
+    try:
+        del _SOURCES[source]
+    except KeyError:
+        raise ValueError(f"Source type not registered: {source!r}") from None
 
 
 def get_source_handler(
@@ -163,13 +197,12 @@ def _get_source_handler_class(
     if not source_type:
         source_type = get_source_type_from_uri(source)
 
-    if source_type not in _source_handler:
-        raise errors.InvalidSourceType(source)
+    if source_type in _MANDATORY_SOURCES:
+        return _MANDATORY_SOURCES[source_type]
+    if source_type in _SOURCES:
+        return _SOURCES[source_type]
 
-    return _source_handler.get(source_type, LocalSource)
-
-
-_tar_type_regex = re.compile(r".*\.((tar(\.(xz|gz|bz2))?)|tgz)$")
+    raise errors.InvalidSourceType(source, source_type=source_type)
 
 
 def get_source_type_from_uri(
@@ -180,24 +213,17 @@ def get_source_type_from_uri(
     :param source: The source specification.
     :param ignore_errors: Don't raise InvalidSourceType if the source
         type could not be determined.
+    :returns: a string matching the registered source type.
 
     :raise InvalidSourceType: If the source type is unknown.
     """
-    for extension in ["zip", "deb", "rpm", "7z", "snap"]:
-        if source.endswith(f".{extension}"):
-            return extension
-    source_type = ""
-    if source.startswith(("bzr:", "lp:")):
-        source_type = "bzr"
-    elif source.startswith(("git:", "git@", "git+ssh:")) or source.endswith(".git"):
-        source_type = "git"
-    elif source.startswith("svn:"):
-        source_type = "subversion"
-    elif _tar_type_regex.match(source):
-        source_type = "tar"
-    elif os.path.isdir(source):
-        source_type = "local"
-    elif not ignore_errors:
-        raise errors.InvalidSourceType(source)
-
-    return source_type
+    for source_cls in (*_MANDATORY_SOURCES.values(), *_SOURCES.values()):
+        source_model = source_cls.source_model
+        if source_model.pattern and re.search(source_model.pattern, source):
+            return _get_type_name_from_model(source_model)
+    # Special case for the "local" source for backwards compatibility.
+    if os.path.isdir(source):
+        return "local"
+    if ignore_errors:
+        return ""
+    raise errors.InvalidSourceType(source)

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -36,6 +36,7 @@ from .base import (
 class TarSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a tar file source."""
 
+    pattern = r"\.(tar(\.[a-z0-9]+)?|tgz)$"
     model_config = get_model_config(
         get_json_extra_schema(r"\.(tar(\.[a-z0-9]+)?|tgz)$")
     )

--- a/craft_parts/sources/zip_source.py
+++ b/craft_parts/sources/zip_source.py
@@ -32,7 +32,8 @@ from .base import (
 class ZipSourceModel(BaseFileSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a zip file source."""
 
-    model_config = get_model_config(get_json_extra_schema(r"\.zip$"))
+    pattern = r"\.zip$"
+    model_config = get_model_config(get_json_extra_schema(pattern))
     source_type: Literal["zip"] = "zip"
 
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,5 +72,5 @@ woke:
 	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 rundocs: ## start a documentation runserver
-	sphinx-autobuild $(SPHINXOPTS) --ignore ".git/*" --ignore "*.scss"  --host 0.0.0.0 --port $(PORT) "$(SOURCEDIR)" "$(BUILDDIR)"
+	sphinx-autobuild $(SPHINXOPTS) --ignore ".git/*" --ignore "*.scss" --ignore "*.kate-swp"  --host 0.0.0.0 --port $(PORT) "$(SOURCEDIR)" "$(BUILDDIR)"
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ X.Y.Z (2024-MM-DD)
 
 - Set JAVA_HOME environment variable in Java-based plugins. The plugin will
   try to detect the latest available JDK.
+- Add an API for :ref:`registering custom source types <how_to_add_a_source_handler>`.
 
 2.1.4 (2024-12-04)
 ------------------

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -418,6 +418,7 @@ recognized
 reorganize
 reorganized
 returncode
+rsync
 runtime
 rustc
 rustup

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -11,3 +11,4 @@ How-to guides
    Override a part's default build behavior </common/craft-parts/how-to/override_build>
    Document a plugin <document-plugin>
    Including local files and remote resources </common/craft-parts/how-to/include_files>
+   Add a custom source type to an application <source-handler>

--- a/docs/how-to/source-handler.rst
+++ b/docs/how-to/source-handler.rst
@@ -1,0 +1,86 @@
+.. _how_to_add_a_source_handler:
+
+How to add a custom source type to an application
+=================================================
+
+An application may need additional source types not included in craft-parts
+by default. In this case, you can create and register a new non-default source
+handler.
+
+.. warning::
+    New source handlers may be added in minor releases of craft-parts. If a
+    custom source handler shares a ``source_type`` value with a new source
+    handler, registering a custom source handler will override the existing
+    source handler.
+
+    Some source types are considered mandatory and cannot be overridden or
+    unregistered. In a major release, the set of mandatory source types
+    may change. At that point, an application-defined source type may not
+    override the mandatory source type.
+
+
+Write a new source handler
+--------------------------
+
+The first step in adding a new source handler is to write one. The components
+of a source handler are its source model (a `Pydantic <https://pydantic.dev/>`_
+model that defines the ``source-*`` keys that may be used in a part) and the
+handler, a class that defines how the source type behaves during the ``PULL``
+step.
+
+The Pydantic model is a child class of
+:py:class:`~craft_parts.sources.base.BaseSourceModel`. The only mandatory field
+is :py:attr:`~craft_parts.sources.base.BaseSourceModel.source_type`.
+
+.. literalinclude:: source-handler/rsync_source.py
+    :language: python
+    :pyobject: RsyncDirectorySourceModel
+
+The :py:attr:`~craft_parts.sources.base.BaseSourceModel.pattern` attribute
+allows Craft Parts to infer the source based on a regular expression. The first
+source handler with a matching regular expression will be used, with built-in
+source types matching before externally registered source types.
+
+Once this is defined, a :py:class:`~craft_parts.sources.base.SourceHandler` is
+needed to define the ``PULL`` behaviour of the source type.
+
+.. literalinclude:: source-handler/rsync_source.py
+    :language: python
+    :pyobject: RsyncSource
+
+.. note::
+    Craft Parts does not install any required tools for custom source handlers.
+    The given handler will fail on a machine that does not have
+    `rsync <https://rsync.samba.org/>`_ installed before the part is pulled.
+
+
+Register the source handler
+---------------------------
+
+Once created, a source must be registered to be used. This must occur before
+entering the :py:class:`~craft_parts.executor.executor.ExecutionContext` with
+the :py:class:`~craft_parts.lifecycle_manager.LifecycleManager`'s
+:py:meth:`~craft_parts.lifecycle_manager.LifecycleManager.action_executor`
+method.
+
+.. literalinclude:: source-handler/rsync_source.py
+    :language: python
+    :start-after: # docs[register-source:start]
+    :end-before: # docs[register-source:end]
+
+
+Run the lifecycle
+-----------------
+
+With those steps completed, the new source handler is ready to use. A ``parts.yaml``
+file such as the following will use the example rsync source type:
+
+.. literalinclude:: source-handler/rsync_parts.yaml
+    :language: yaml
+
+After loading the parts into a YAML structure, all that's left is to run it:
+
+.. literalinclude:: source-handler/rsync_source.py
+    :language: python
+    :start-after: # docs[run-lifecycle:start]
+    :end-before: # docs[run-lifecycle:end]

--- a/docs/how-to/source-handler.rst
+++ b/docs/how-to/source-handler.rst
@@ -50,7 +50,7 @@ needed to define the ``PULL`` behaviour of the source type.
 
 .. note::
     Craft Parts does not install any required tools for custom source handlers.
-    The given handler will fail on a machine that does not have
+    The handler in this example will fail on a machine that does not have
     `rsync <https://rsync.samba.org/>`_ installed before the part is pulled.
 
 

--- a/docs/how-to/source-handler/rsync_parts.yaml
+++ b/docs/how-to/source-handler/rsync_parts.yaml
@@ -1,0 +1,4 @@
+parts:
+  my-part:
+    plugin: make
+    source: rsync://code-host.internal/my-app

--- a/docs/how-to/source-handler/rsync_source.py
+++ b/docs/how-to/source-handler/rsync_source.py
@@ -1,0 +1,43 @@
+import pathlib
+from typing import Literal
+from typing_extensions import override
+from craft_parts import Action, LifecycleManager, Step, sources
+import yaml
+
+
+class RsyncDirectorySourceModel(sources.BaseSourceModel, frozen=True):
+    pattern = "^rsync://"
+    source_type: Literal["rsync"] = "rsync"
+
+
+class RsyncSource(sources.SourceHandler):
+    source_model = RsyncDirectorySourceModel
+
+    @override
+    def pull(self) -> None:
+        self._run(
+            [
+                "rsync",
+                "--archive",
+                "--delete",
+                self.source,
+                self.part_src_dir.as_posix(),
+            ]
+        )
+
+# docs[register-source:start]
+sources.register(RsyncSource)
+# docs[register-source:end]
+
+parts_path = pathlib.Path(__file__).parent / "rsync_parts.yaml"
+parts = yaml.safe_load(parts_path.read_text())
+
+# docs[run-lifecycle:start]
+lcm = LifecycleManager(
+    parts,
+    application_name="rsync_parts",
+    cache_dir=pathlib.Path.home() / ".cache",
+)
+with lcm.action_executor() as ctx:
+    ctx.execute(Action("my-part", Step.PULL))
+# docs[run-lifecycle:end]

--- a/tests/integration/sources/test_registered_source.py
+++ b/tests/integration/sources/test_registered_source.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pathlib
+from typing import Literal
+
+import craft_parts
+import pytest
+from craft_parts import sources
+from typing_extensions import override
+
+
+class FakeSourceModel(sources.BaseSourceModel, frozen=True):
+    pattern = "^fake:"
+    source_type: Literal["fake"] = "fake"
+
+
+class FakeSource(sources.SourceHandler):
+    source_model = FakeSourceModel
+
+    @override
+    def pull(self) -> None:
+        """Build a fake source."""
+        (self.part_src_dir / "It's a fake!").write_text(self.source)
+
+
+@pytest.mark.parametrize(
+    "source_info",
+    [
+        {"source": "fake://youtube.com/watch?v=H6yQOs93Cgg"},
+        {"source-type": "fake", "source": "https://youtube.com/watch?v=H6yQOs93Cgg"},
+    ],
+)
+def test_register_and_pull_fake_source(source_info, new_dir):
+    parts = {
+        "parts": {
+            "foo": {
+                "plugin": "nil",
+                **source_info,
+            }
+        }
+    }
+    fake_file = pathlib.Path("parts", "foo", "src", "It's a fake!")
+
+    lcm = craft_parts.LifecycleManager(
+        parts, application_name="test_fake_source", cache_dir=new_dir
+    )
+
+    sources.register(FakeSource)
+    with lcm.action_executor() as ctx:
+        ctx.execute(craft_parts.Action("foo", craft_parts.Step.PULL))
+
+    assert fake_file.read_text() == source_info["source"]

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -27,6 +27,15 @@ def test_invalid_source_type():
     assert err.resolution is None
 
 
+def test_invalid_source_type_with_type():
+    err = errors.InvalidSourceType("t-death.adf", source_type="yolo")
+    assert err.source == "t-death.adf"
+    assert err.source_type == "yolo"
+    assert err.brief == ("Failed to pull source: unknown source-type 'yolo'.")
+    assert err.details is None
+    assert err.resolution is None
+
+
 def test_invalid_source_option():
     err = errors.InvalidSourceOption(source_type="lzx", option="source-depth")
     assert err.source_type == "lzx"

--- a/tests/unit/sources/test_git_source.py
+++ b/tests/unit/sources/test_git_source.py
@@ -817,7 +817,7 @@ class TestGitSource(GitBaseTestCase):
         assert raised.value.option == "source-checksum"
 
     def test_has_source_handler_entry(self):
-        assert sources._source_handler["git"] is GitSource
+        assert sources._get_source_handler_class("", source_type="git") is GitSource
 
     def test_pull_failure(self, mocker, new_dir):
         mock_process_run = mocker.patch("craft_parts.utils.os_utils.process_run")

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -280,7 +280,7 @@ class TestLocal:
         assert os.readlink(file_symlink) == "file"
 
     def test_has_source_handler_entry(self):
-        assert sources._source_handler["local"] is LocalSource
+        assert sources._get_source_handler_class("", source_type="local") is LocalSource
 
     def test_ignore_patterns_workdir(self, new_dir, partitions):
         ignore_patterns = ["hello"]

--- a/tests/unit/sources/test_sevenzip_source.py
+++ b/tests/unit/sources/test_sevenzip_source.py
@@ -120,4 +120,7 @@ class TestZipSource:
         assert raised.value.exit_code == 1
 
     def test_has_source_handler_entry(self):
-        assert sources._source_handler["7z"] is sources.SevenzipSource
+        assert (
+            sources._get_source_handler_class("", source_type="7z")
+            is sources.SevenzipSource
+        )

--- a/tests/unit/sources/test_snap_source.py
+++ b/tests/unit/sources/test_snap_source.py
@@ -17,7 +17,6 @@
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -73,11 +72,11 @@ class TestSnapSource:
         assert Path(self._dest_dir / "meta.basic").is_dir()
         assert Path(self._dest_dir / "meta.basic/snap.yaml").is_file()
 
-    def test_has_source_handler_entry_on_linux(self):
-        if sys.platform == "linux":
-            assert sources._source_handler["snap"] is sources.SnapSource
-        else:
-            assert "snap" not in sources._source_handler
+    def test_has_source_handler_entry(self):
+        assert (
+            sources._get_source_handler_class("", source_type="snap")
+            is sources.SnapSource
+        )
 
     def test_pull_failure_bad_unsquash(self, new_dir, mocker):
         mocker.patch(

--- a/tests/unit/sources/test_zip_source.py
+++ b/tests/unit/sources/test_zip_source.py
@@ -75,4 +75,7 @@ class TestZipSource:
             assert zip_file.read() == "Test fake file"
 
     def test_has_source_handler_entry(self):
-        assert sources._source_handler["zip"] is sources.ZipSource
+        assert (
+            sources._get_source_handler_class("", source_type="zip")
+            is sources.ZipSource
+        )


### PR DESCRIPTION
This provides a pair of functions (sources.register, sources.unregister) for registering and unregistering source types. This differs slightly from plugin registration:

- All current sources are considered mandatory, meaning they cannot be replaced or unregistered by the application.
- Mandatory sources can be changed at a major release.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Fixes #915, CRAFT-3734