### PR TITLE
fix: brief only when __str__ for errors

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -52,15 +52,7 @@ class PartsError(Exception):
         self.doc_slug = doc_slug
 
     def __str__(self) -> str:
-        components = [self.brief]
-
-        if self.details:
-            components.append(self.details)
-
-        if self.resolution:
-            components.append(self.resolution)
-
-        return "\n".join(components)
+        return self.brief
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(brief={self.brief!r}, details={self.details!r}, resolution={self.resolution!r}, doc_slug={self.doc_slug!r})"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -36,7 +36,7 @@ def test_parts_error_brief():
 
 def test_parts_error_full():
     err = errors.PartsError(brief="Brief", details="Details", resolution="Resolution")
-    assert str(err) == "Brief\nDetails\nResolution"
+    assert str(err) == "Brief"
     assert (
         repr(err)
         == "PartsError(brief='Brief', details='Details', resolution='Resolution', doc_slug=None)"


### PR DESCRIPTION
This plays better with Craft CLIs current design as seen in
https://github.com/canonical/craft-cli/blob/main/craft_cli/messages.py#L733

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
