### PR TITLE
cmake: use the cmake snap by default

### DIFF
--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -31,6 +31,7 @@ class CMakePluginProperties(PluginProperties, frozen=True):
 
     cmake_parameters: list[str] = []
     cmake_generator: str = "Unix Makefiles"
+    cmake_source: str = "snap"
 
     # part properties required by the plugin
     source: str  # pyright: ignore[reportGeneralTypeIssues]
@@ -65,6 +66,11 @@ class CMakePlugin(Plugin):
           (string; default: "Unix Makefiles")
           Determine what native build system is to be used.
           Can be either `Ninja` or `Unix Makefiles` (default).
+
+        - cmake-source
+          (string; default: "deb")
+          Determine the source type.
+          Can be either `deb` (default) or `snap`.
     """
 
     properties_class = CMakePluginProperties
@@ -72,14 +78,19 @@ class CMakePlugin(Plugin):
     @override
     def get_build_snaps(self) -> set[str]:
         """Return a set of required snaps to install in the build environment."""
+        options = cast(CMakePluginProperties, self._options)
+        if options.cmake_source == "snap":
+            return {"cmake"}
         return set()
 
     @override
     def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
-        build_packages = {"gcc", "cmake"}
-
         options = cast(CMakePluginProperties, self._options)
+
+        if options.cmake_source == "deb":
+            build_packages = {"gcc", "cmake"}
+        build_packages = {"gcc"}
 
         if options.cmake_generator == "Ninja":
             build_packages.add("ninja-build")

--- a/tests/unit/plugins/test_cmake_plugin.py
+++ b/tests/unit/plugins/test_cmake_plugin.py
@@ -47,28 +47,32 @@ class TestPluginCMakePlugin:
 
     def test_get_build_snaps(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(new_dir)
-        assert plugin.get_build_snaps() == set()
+        assert plugin.get_build_snaps() == {"cmake"}
 
     def test_get_build_packages_default(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(new_dir)
-        assert plugin.get_build_packages() == {
-            "gcc",
-            "cmake",
-        }
+        assert plugin.get_build_packages() == {"gcc"}
+        assert plugin.get_build_snaps() == {"cmake"}
 
     def test_get_build_packages_ninja(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(new_dir, properties={"cmake-generator": "Ninja"})
 
         assert plugin.get_build_packages() == {
             "gcc",
-            "cmake",
             "ninja-build",
         }
+        assert plugin.get_build_snaps() == {"cmake"}
 
     def test_get_build_packages_unix_makefiles(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture(
             new_dir, properties={"cmake-generator": "Unix Makefiles"}
         )
+
+        assert plugin.get_build_packages() == {"gcc"}
+        assert plugin.get_build_snaps() == {"cmake"}
+
+    def test_get_build_packages_deb(self, setup_method_fixture, new_dir):
+        plugin = setup_method_fixture(new_dir, properties={"cmake-source": "deb"})
 
         assert plugin.get_build_packages() == {
             "gcc",


### PR DESCRIPTION
- allow using the cmake snap or deb
- add an option to specify the source for cmake

The snap is set by default because
1. It's more up-to-date and can run on any base reliably
2. Debs have a path precedence over the snaps, so, if the cmake snap is shipped with the cmake, the cmake deb is used by default until the `PATH` is overriden, which is problematic. see [here](https://invent.kde.org/network/neochat/-/merge_requests/2055)


---
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
