### PR TITLE
chore(merge): 1.19.8 into main

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -321,6 +321,12 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 - Tox and packaging updates
 - Documentation updates
 
+1.19.8 (2024-09-24)
+-------------------
+
+- Replace requests-unixsocket with requests-unixsocket2
+- Bump minimum Python version to 3.8 (required for requests-unixsocket2)
+
 1.19.7 (2023-08-09)
 -------------------
 

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -28,7 +28,7 @@ from craft_parts.utils import os_utils
 IS_CI: bool = os.getenv("CI") == "true"
 
 # These are the Ubuntu versions that Chisel currently supports.
-SUPPORTED_UBUNTU_VERSIONS = {"20.04", "22.04", "22.10"}
+SUPPORTED_UBUNTU_VERSIONS = {"20.04", "22.04", "22.10", "24.04"}
 
 
 def _current_release_supported() -> bool:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Cleaning up the pile of stale hotfix branches and folding all the tags into main.

1.19.8 has virtually no changes because 1.19 is so old.