### PR TITLE
fix(docs): include poetry links as a target

### DIFF
--- a/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
@@ -115,6 +115,8 @@ During the build step, the plugin performs the following actions:
    dependencies.
 5. It runs :command:`pip check` to ensure the virtual environment is consistent.
 
+.. _craft_parts_poetry_links:
+
 .. _Poetry: https://python-poetry.org
 .. _dependency groups: https://python-poetry.org/docs/managing-dependencies#dependency-groups
 .. _export command: https://python-poetry.org/docs/cli/#export


### PR DESCRIPTION
This allows applications that have their own custom poetry reference to include all the default links by adding the following to the bottom of their poetry plugin reference:

```
.. include:: /common/craft-parts/reference/plugins/poetry_plugin.rst
    :start-after: .. _craft_parts_poetry_links:
```

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
