### PR TITLE
docs: make plugin links external refs

### DIFF
--- a/docs/common/craft-parts/reference/plugins/ant_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/ant_plugin.rst
@@ -22,8 +22,9 @@ After a successful build, this plugin will:
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 ant-build-targets

--- a/docs/common/craft-parts/reference/plugins/autotools_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/autotools_plugin.rst
@@ -19,8 +19,9 @@ After a successful build, this plugin will install the generated binaries in
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 autotools-bootstrap-parameters

--- a/docs/common/craft-parts/reference/plugins/cmake_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/cmake_plugin.rst
@@ -12,8 +12,9 @@ binaries in ``$CRAFT_PART_INSTALL``.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 cmake-parameters

--- a/docs/common/craft-parts/reference/plugins/dotnet_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/dotnet_plugin.rst
@@ -8,8 +8,9 @@ The ``dotnet`` plugin builds .NET projects using the ``dotnet`` tool.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 dotnet-build-configuration
@@ -41,12 +42,13 @@ Some common means of providing ``dotnet`` are:
 * The ``dotnet8`` Ubuntu package, declared as a ``build-package``.
 * The ``dotnet-sdk`` snap, declared as a ``build-snap`` from the desired channel.
 
-Another alternative is to define another part with the name ``dotnet-deps``, and
-declare that the part using the ``dotnet`` plugin comes :ref:`after <after>` the
-``dotnet-deps`` part. In this case, the plugin will assume that this new part will
-stage the ``dotnet`` executable to be used in the build step. This can be useful,
-for example, in cases where a specific, unreleased version of ``dotnet`` is desired
-but unavailable as a snap or an Ubuntu package.
+Another alternative is to define another part with the name ``dotnet-deps``,
+and declare that the part using the ``dotnet`` plugin comes
+:external+craft-parts:ref:`after <after>` the ``dotnet-deps`` part. In this
+case, the plugin will assume that this new part will stage the ``dotnet``
+executable to be used in the build step. This can be useful, for example, in
+cases where a specific, unreleased version of ``dotnet`` is desired but
+unavailable as a snap or an Ubuntu package.
 
 Finally, whether the resulting built artefact will need the presence of the .NET
 runtime to execute depends on the value of the

--- a/docs/common/craft-parts/reference/plugins/dump_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/dump_plugin.rst
@@ -15,12 +15,14 @@ directory, a remote repository, or a URL. Common use cases include:
 Keywords
 --------
 
-This plugin uses the common :ref:`plugin <part-properties-plugin>` keywords as
-well as those for :ref:`sources <part-properties-sources>`.
+This plugin uses the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` keywords as well as those for
+:external+craft-parts:ref:`sources <part-properties-sources>`.
 
-You must specify at least the :ref:`source <source>` keyword.
-The :ref:`source-type <source_type>` keyword is optional, but recommended, as it
-is used to specify how the source should be handled.
+You must specify at least the :external+craft-parts:ref:`source <source>`
+keyword. The :external+craft-parts:ref:`source-type <source_type>` keyword is
+optional, but recommended, as it is used to specify how the source should be
+handled.
 
 
 Dependencies

--- a/docs/common/craft-parts/reference/plugins/go_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/go_plugin.rst
@@ -12,8 +12,9 @@ build, this plugin will install the generated binaries in
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 go-buildtags
@@ -52,11 +53,12 @@ Common means of providing ``go`` are:
 * The ``go`` snap, declared as a ``build-snap`` from the desired channel.
 
 Another alternative is to define another part with the name ``go-deps``, and
-declare that the part using the ``go`` plugin comes :ref:`after <after>` the
-``go-deps`` part. In this case, the plugin will assume that this new part will
-stage the ``go`` executable to be used in the build step. This can be useful,
-for example, in cases where a specific, unreleased version of ``go`` is desired
-but unavailable as a snap or an Ubuntu package.
+declare that the part using the ``go`` plugin comes
+:external+craft-parts:ref:`after <after>` the ``go-deps`` part. In this case,
+the plugin will assume that this new part will stage the ``go`` executable to
+be used in the build step. This can be useful, for example, in cases where a
+specific, unreleased version of ``go`` is desired but unavailable as a snap or
+an Ubuntu package.
 
 .. _go-details-end:
 
@@ -65,9 +67,9 @@ How it works
 
 During the build step the plugin performs the following actions:
 
-* If a `go workspace`_ has been setup by use of the :ref:`go-use <craft_parts_go_use_plugin>`
-  plugin,
-  call ``go work use <build-dir>`` to add the source for the part to the workspace;
+* If a `go workspace`_ has been setup by use of the
+  :external+craft-parts:ref:`go-use <craft_parts_go_use_plugin>` plugin, call
+  ``go work use <build-dir>`` to add the source for the part to the workspace;
 * If not operating in the context of  a `go workspace`_, call ``go mod download all``
   to find and download all necessary modules;
 * Call ``go generate <item>`` for each item in ``go-generate``;

--- a/docs/common/craft-parts/reference/plugins/go_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/go_use_plugin.rst
@@ -3,15 +3,17 @@
 Go Use plugin
 =============
 
-The Go Use plugin allows for setting up a `go workspace`_ for `Go`_ modules. It is
-a companion plugin meant to be used with the :ref:`Go plugin <craft_parts_go_plugin>`.
-Use of this plugin sets up ``go.work`` and affects all parts.
+The Go Use plugin allows for setting up a `go workspace`_ for `Go`_ modules. It
+is a companion plugin meant to be used with the :external+craft-parts:ref:`Go
+plugin <craft_parts_go_plugin>`. Use of this plugin sets up ``go.work`` and
+affects all parts.
 
 Keywords
 --------
 
-There are no additional keywords to the the common :ref:`plugin <part-properties-plugin>`
-and :ref:`sources <part-properties-sources>` keywords.
+There are no additional keywords to the the common
+:external+craft-parts:ref:`plugin <part-properties-plugin>` and
+:external+craft-parts:ref:`sources <part-properties-sources>` keywords.
 
 .. _go-use-details-begin:
 
@@ -27,11 +29,12 @@ Common means of providing ``go`` are:
 * The ``go`` snap, declared as a ``build-snap`` from the desired channel.
 
 Another alternative is to define another part with the name ``go-deps``, and
-declare that the part using the ``go`` plugin comes :ref:`after <after>` the
-``go-deps`` part. In this case, the plugin will assume that this new part will
-stage the ``go`` executable to be used in the build step. This can be useful,
-for example, in cases where a specific, unreleased version of ``go`` is desired
-but unavailable as a snap or an Ubuntu package.
+declare that the part using the ``go`` plugin comes
+:external+craft-parts:ref:`after <after>` the ``go-deps`` part. In this case,
+the plugin will assume that this new part will stage the ``go`` executable to
+be used in the build step. This can be useful, for example, in cases where a
+specific, unreleased version of ``go`` is desired but unavailable as a snap or
+an Ubuntu package.
 
 .. _go-use-details-end:
 

--- a/docs/common/craft-parts/reference/plugins/make_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/make_plugin.rst
@@ -11,8 +11,9 @@ the ``install`` ``Makefile`` target with ``DESTDIR`` set to
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and ::external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 make-parameters

--- a/docs/common/craft-parts/reference/plugins/maven_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_plugin.rst
@@ -22,8 +22,9 @@ After a successful build, this plugin will:
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 maven-parameters

--- a/docs/common/craft-parts/reference/plugins/meson_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/meson_plugin.rst
@@ -11,8 +11,9 @@ binaries in ``$CRAFT_PART_INSTALL``.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 meson_parameters
@@ -31,11 +32,12 @@ The plugin needs the ``meson`` executable to configure the project, and the
 typically be provisioned via ``build-packages`` or ``build-snaps``.
 
 Another alternative is to define another part with the name ``meson-deps``, and
-declare that the part using the ``meson`` plugin comes :ref:`after <after>` the
-``meson-deps`` part. In this case, the plugin will assume that this new part will
-stage the ``meson`` and ``ninja`` executables to be used in the build step.
-This can be useful, for example, in cases where specific, unreleased versions of
-the tools are desired but unavailable as a snap or an Ubuntu package.
+declare that the part using the ``meson`` plugin comes
+:external+craft-parts:ref:`after <after>` the ``meson-deps`` part. In this
+case, the plugin will assume that this new part will stage the ``meson`` and
+``ninja`` executables to be used in the build step. This can be useful, for
+example, in cases where specific, unreleased versions of the tools are desired
+but unavailable as a snap or an Ubuntu package.
 
 How it works
 ------------

--- a/docs/common/craft-parts/reference/plugins/nil_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/nil_plugin.rst
@@ -8,16 +8,18 @@ parts primitives are required.
 
 Common cases include:
 
-- Adding only :ref:`stage-packages <part-properties-plugin>` in a discrete part
+- Adding only :external+craft-parts:ref:`stage-packages
+  <part-properties-plugin>` in a discrete part
 - Building source for when there is no suitable plugin with
-  :ref:`override-build <part-properties-plugin>`.
+  :external+craft-parts:ref:`override-build <part-properties-plugin>`.
 
 
 Keywords
 --------
 
-This plugin uses the common :ref:`plugin <part-properties-plugin>` keywords as
-well as those for :ref:`sources <part-properties-sources>`.
+This plugin uses the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` keywords as well as those for
+:external+craft-parts:ref:`sources <part-properties-sources>`.
 
 This plugin in itself has no requirement.
 
@@ -30,14 +32,15 @@ This plugin has no dependencies.
 How it works
 ------------
 
-This plugin does nothing. It serves as a *noop* when there is a need to only use
-native :ref:`part properties <part_properties>`.
+This plugin does nothing. It serves as a *noop* when there is a need to only
+use native :external+craft-parts:ref:`part properties <part_properties>`.
 
 Examples
 --------
 
-The following snippet declares a part using the ``nil`` plugin to fetch
-and unpack ``hello`` defined in :ref:`stage-packages <part-properties-plugin>`:
+The following snippet declares a part using the ``nil`` plugin to fetch and
+unpack ``hello`` defined in :external+craft-parts:ref:`stage-packages
+<part-properties-plugin>`:
 
 .. code-block:: yaml
 

--- a/docs/common/craft-parts/reference/plugins/npm_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/npm_plugin.rst
@@ -8,9 +8,10 @@ The NPM plugin can be used for Node.js projects that use NPM (or Yarn) as the pa
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords (see :ref:`common part 
-properties <part_properties>`), this plugin provides the following 
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords (see :external+craft-parts:ref:`common part
+properties <part_properties>`), this plugin provides the following
 plugin-specific keywords:
 
 npm-include-node

--- a/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/poetry_plugin.rst
@@ -10,8 +10,8 @@ The Poetry plugin can be used for Python projects that use the `Poetry`_ build s
 Keywords
 --------
 
-This plugin uses the common :ref:`plugin <part-properties-plugin>` keywords as
-well as those for :ref:`sources <part-properties-sources>`.
+This plugin uses the common :external+craft-parts:ref:`plugin <part-properties-plugin>` keywords as
+well as those for :external+craft-parts:ref:`sources <part-properties-sources>`.
 
 Additionally, this plugin provides the plugin-specific keywords defined in the
 following sections.
@@ -20,7 +20,8 @@ poetry-export-extra-args:
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 **Type:** list of strings
 
-Extra arguments to pass at the end of the poetry `export command`_.
+Extra arguments to pass at the end of the poetry `export command
+<https://python-poetry.org/docs/cli/#export>`_.
 
 poetry-pip-extra-args:
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -117,5 +118,4 @@ During the build step, the plugin performs the following actions:
 
 .. _Poetry: https://python-poetry.org
 .. _Dependency groups: https://python-poetry.org/docs/managing-dependencies#dependency-groups
-.. _export command: https://python-poetry.org/docs/cli/#export
 .. _environment variables to configure Poetry: https://python-poetry.org/docs/configuration/#using-environment-variables

--- a/docs/common/craft-parts/reference/plugins/python_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/python_plugin.rst
@@ -16,8 +16,9 @@ any of the following things:
 Keywords
 --------
 
-This plugin uses the common :ref:`plugin <part-properties-plugin>` keywords as
-well as those for :ref:`sources <part-properties-sources>`.
+This plugin uses the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` keywords as well as those for
+:external+craft-parts:ref:`sources <part-properties-sources>`.
 
 Additionally, this plugin provides the plugin-specific keywords defined in the
 following sections.
@@ -95,4 +96,3 @@ During the build step, the plugin performs the following actions:
   ``python-packages`` keywords.
 * If the source contains a ``setup.py`` or ``pyproject.toml`` file, those
   files are used to install the dependencies specified by the package itself.
-

--- a/docs/common/craft-parts/reference/plugins/qmake_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/qmake_plugin.rst
@@ -12,8 +12,9 @@ binaries in ``$CRAFT_PART_INSTALL``.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 qmake-parameters

--- a/docs/common/craft-parts/reference/plugins/rust_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/rust_plugin.rst
@@ -8,8 +8,9 @@ The Rust plugin can be used for Rust projects that use the Cargo build system.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 rust-channel
@@ -52,7 +53,8 @@ rust-no-default-features
 If this option is set to ``true``, the default features specified by the project
 will be ignored.
 
-You can then use the :ref:`rust-features` keyword to specify any features you wish to override.
+You can then use the :external+craft-parts:ref:`rust-features` keyword to
+specify any features you wish to override.
 
 rust-path
 ~~~~~~~~~
@@ -78,7 +80,8 @@ in the Cargo.toml file.
 
 This is equivalent to the ``lto = "fat"`` option in the Cargo.toml file.
 
-If you want better runtime performance, see the :ref:`Performance tuning<perf-tuning>` section below.
+If you want better runtime performance, see the :ref:`Performance
+tuning<perf-tuning>` section below.
 
 rust-ignore-toolchain-file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -162,8 +165,9 @@ Many Rust programs boast their performance over similar programs implemented in 
 programming languages.
 To get even better performance, you might want to follow the tips below.
 
-* Use the :ref:`rust-use-global-lto` option to enable LTO support. This is suitable for most
-  projects. However, analysing the whole program during the build time requires more memory and CPU time.
+* Use the :external+craft-parts:ref:`rust-use-global-lto` option to enable LTO
+  support. This is suitable for most projects. However, analysing the whole
+  program during the build time requires more memory and CPU time.
 
 * Specify ``codegen-units=1`` in ``Cargo.toml`` to reduce LLVM parallelism. This may sound counter-intuitive,
   but reducing code generator threads could improve the quality of generated machine code.

--- a/docs/common/craft-parts/reference/plugins/scons_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/scons_plugin.rst
@@ -11,8 +11,9 @@ binaries in ``$CRAFT_PART_INSTALL``.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the following
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
 plugin-specific keywords:
 
 scons-parameters
@@ -37,12 +38,13 @@ The common means of providing ``scons`` is through a
 :ref:`build-packages <build_packages>` entry which for Ubuntu, would be ``scons``.
 
 Another alternative is to define another part with the name ``scons-deps``, and
-declare that the part using the ``scons`` plugin comes :ref:`after <after>` the
-``scons-deps`` part. In this case, the plugin will assume that this new part will
-provide the ``scons`` executable to be used in the build step. This can be useful,
-for example, in cases where a specific, unreleased version of ``scons`` is desired
-but only possible by either building the tool itself from source or through some
-other custom mechanism.
+declare that the part using the ``scons`` plugin comes
+:external+craft-parts:ref:`after <after>` the ``scons-deps`` part. In this
+case, the plugin will assume that this new part will provide the ``scons``
+executable to be used in the build step. This can be useful, for example, in
+cases where a specific, unreleased version of ``scons`` is desired but only
+possible by either building the tool itself from source or through some other
+custom mechanism.
 
 
 How it works
@@ -75,4 +77,3 @@ sets the ``scons-parameters`` for a ``prefix`` to be set to
 
 
 .. _SCons: https://scons.org/
-

--- a/docs/common/craft-parts/reference/plugins/uv_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/uv_plugin.rst
@@ -10,9 +10,10 @@ The uv plugin can be used for Python projects that use the uv build tool.
 Keywords
 --------
 
-In addition to the common :ref:`plugin <part-properties-plugin>` and
-:ref:`sources <part-properties-sources>` keywords, this plugin provides the
-following plugin-specific keywords:
+In addition to the common :external+craft-parts:ref:`plugin
+<part-properties-plugin>` and :external+craft-parts:ref:`sources
+<part-properties-sources>` keywords, this plugin provides the following
+plugin-specific keywords:
 
 uv-extras
 ~~~~~~~~~
@@ -33,9 +34,9 @@ exactly as ``--group GROUP``.
 Environment variables
 ---------------------
 
-Along with the variables defined by the :ref:`Python plugin
-<craft_parts_python_plugin-environment_variables>`, this plugin responds to its
-own special variables.
+Along with the variables defined by the :external+craft-parts:ref:`Python
+plugin <craft_parts_python_plugin-environment_variables>`, this plugin responds
+to its own special variables.
 
 .. note::
 
@@ -71,7 +72,7 @@ UV_PYTHON
 ~~~~~~~~~
 **Default value:** ``${PARTS_PYTHON_INTERPRETER}``
 
-The version of Python that uv should use. See :ref:`Python plugin environment
+The version of Python that uv should use. See :external+craft-parts:ref:`Python plugin environment
 variables <craft_parts_python_plugin-environment_variables>` for more
 information.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions.extend(
         "sphinx.ext.autodoc",
         "sphinx.ext.autosummary",
         "sphinx.ext.ifconfig",
+        "sphinx.ext.intersphinx",
         "sphinx.ext.napoleon",
         "sphinx.ext.viewcode",
         "sphinx_autodoc_typehints",  # must be loaded after napoleon
@@ -81,6 +82,10 @@ linkcheck_ignore = [
 rst_epilog = """
 .. include:: /common/craft-parts/reuse/links.txt
 """
+
+intersphinx_mapping = {
+    "craft-parts": ("https://canonical-craft-parts.readthedocs-hosted.com/en/latest/", None),
+}
 
 autodoc_mock_imports = ["apt"]
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -9,6 +9,8 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
+- Fix a downstream issue where apps that transclude some but not all of the
+  Craft Parts plugin references have Sphinx build errors.
 
 2.2.1 (2024-12-19)
 ------------------


### PR DESCRIPTION
Fixes the library side of CRAFT-3890.

- Makes the hosted Craft Parts docs an external source for this doc set.
- All interlinks in the plugin pages, which are often used by apps as modular docs, now use intersphinx and treats them as external links.
- Any potentially standalone pages should prefix references to other pages with `:external+craft-parts:ref:`. References to labels within the page can use simple `:ref:` like normal.

@lengau There's a flaw with this approach, though. Only already published pages can be linked to externally. If for example we add a new plugin page and want to link pages to it as part of the same code change, those links will break because the new page hasn't been published yet.

My thinking now is that the only straightforward approach is for the common dir generator script to transform the links after copying the files.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
