### PR TITLE
fix: Honor the ${pcfiledir} entries in pkgconfig

### DIFF
--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -173,6 +173,10 @@ def fix_pkg_config(
     - From snaps built locally: `<local-path-to-project>/stage`
     - Built during the build stage: the install directory
 
+    But if the prefix begins with `${pcfiledir}`, it must be kept as-is, because
+    that variable refers to the current location of the .pc file. It allows
+    to do "relocatable" pkgconfig files, so no changes are required.
+
     :param pkg_config_file: pkg-config (.pc) file to modify
     :param prefix_prepend: directory to prepend to the prefix
     :param prefix_trim: directory to remove from prefix
@@ -190,6 +194,9 @@ def fix_pkg_config(
     # process .pc file
     with fileinput.input(pkg_config_file, inplace=True) as input_file:
         for line in input_file:
+            # If the prefix begins with ${pcfiledir} statement, this is
+            # a position-independent (thus, "relocatable") .pc file, so
+            # no changes are required.
             if pattern_pcfiledir.search(line) is not None:
                 print(line, end="")
                 continue

--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -185,10 +185,14 @@ def fix_pkg_config(
         f"^prefix=(?P<trim>{'|'.join(prefixes_to_trim)})(?P<prefix>.*)"
     )
     pattern = re.compile("^prefix=(?P<prefix>.*)")
+    pattern_pcfiledir = re.compile("^prefix *= *[$]{pcfiledir}.*")
 
     # process .pc file
     with fileinput.input(pkg_config_file, inplace=True) as input_file:
         for line in input_file:
+            if pattern_pcfiledir.search(line) is not None:
+                print(line, end="")
+                continue
             match = pattern.search(line)
             match_trim = pattern_trim.search(line)
 

--- a/craft_parts/packages/normalize.py
+++ b/craft_parts/packages/normalize.py
@@ -173,9 +173,9 @@ def fix_pkg_config(
     - From snaps built locally: `<local-path-to-project>/stage`
     - Built during the build stage: the install directory
 
-    But if the prefix begins with `${pcfiledir}`, it must be kept as-is, because
-    that variable refers to the current location of the .pc file. It allows
-    to do "relocatable" pkgconfig files, so no changes are required.
+    But if the prefix begins with `pcfiledir` variable, it must be kept as-is,
+    because that variable refers to the current location of the .pc file. It
+    allows to create "relocatable" pkgconfig files, so no changes are required.
 
     :param pkg_config_file: pkg-config (.pc) file to modify
     :param prefix_prepend: directory to prepend to the prefix

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -408,6 +408,7 @@ packahe
 param
 params
 pc
+pcfiledir
 pkgconfig
 pre
 prepend

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -34,7 +34,7 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
-- Honor the ``pcfiledir`` tag in ``pkgconfig`` files.
+- Preserve the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -34,7 +34,7 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
-- Honor the \${pcfiledir} entries in pkgconfig files.
+- Honor the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -34,7 +34,7 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
-- Honor the `\${pcfiledir}` entries in `pkgconfig` files.
+- Honor the \${pcfiledir} entries in pkgconfig files.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -34,7 +34,7 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
-- Honor the ${pcfiledir} entries in pkgconfig
+- Honor the `\${pcfiledir}` entries in `pkgconfig` files.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 *********
 
+X.Y.Z (2025-MM-DD)
+------------------
+
+Bug fixes:
+
+- Preserve the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 2.4.0 (2025-01-23)
 ------------------
@@ -13,7 +19,6 @@ New features:
 Bug fixes:
 
 - Correctly handle ``source-subdir`` values on the ``go-use`` plugin.
-- Preserve the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -34,6 +34,7 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
+- Honor the ${pcfiledir} entries in pkgconfig
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -13,6 +13,7 @@ New features:
 Bug fixes:
 
 - Correctly handle ``source-subdir`` values on the ``go-use`` plugin.
+- Preserve the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 Documentation:
 
@@ -34,7 +35,6 @@ Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
   source changes.
-- Preserve the ``pcfiledir`` tag in ``pkgconfig`` files.
 
 Documentation:
 

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -365,6 +365,18 @@ class TestFixPkgConfig:
             f"{tmpdir}/usr"
         )
 
+    def test_normalize_fix_pkg_config_with_pcfiledir(
+        self, tmpdir, pkg_config_file, expected_pkg_config_content
+    ):
+        """Verify normalization fixes pkg-config files."""
+        pc_file = tmpdir / "my-file.pc"
+        pkg_config_file(pc_file, "${pcfiledir}/../../..")
+        normalize(tmpdir, repository=DummyRepository)
+
+        assert pc_file.read_text(encoding="utf-8") == expected_pkg_config_content(
+            "${pcfiledir}/../../.."
+        )
+
     def test_fix_pkg_config_is_dir(self, tmpdir):
         """Verify directories ending in .pc do not raise an error."""
         pc_file = tmpdir / "granite.pc"


### PR DESCRIPTION
The ${pcfiledir} tag allows to make .pc files relocatables, by being replaced with the path where the .pc file is stored. In these cases, the "prefix=" entry must be left as-is, to ensure that it continues to work as expected.

It is complemented by https://github.com/canonical/snapcraft/pull/5157

Fix https://github.com/canonical/snapcraft/issues/5158

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
