### PR TITLE
fix: use source-subdir in go-use plugin

### DIFF
--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -100,5 +100,5 @@ class GoUsePlugin(Plugin):
                 )
 
         return [
-            f"go work use {self._part_info.part_src_dir}",
+            f"go work use {self._part_info.part_src_subdir}",
         ]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+
+X.Y.Z (2025-MM-DD)
+------------------
+
+Bug fixes:
+
+- Correctly handle ``source-subdir`` values on the ``go-use`` plugin.
+
+
 2.3.0 (2025-01-20)
 ------------------
 
@@ -12,10 +21,6 @@ New features:
 - Get the error output from step scriptlet execution and surface it when
   raising ScriptletRunError.
 
-
-2.2.2 (2025-01-13)
-------------------
-
 Bug fixes:
 
 - Make sure the :ref:`uv plugin<craft_parts_uv_plugin>` is re-entrant on
@@ -24,6 +29,15 @@ Bug fixes:
 Documentation:
 
 - Correct the Maven plugin docstring to refer to Maven from Go.
+
+
+2.2.2 (2025-01-13)
+------------------
+
+Documentation:
+
+- Add a cross-reference target for Poetry external links.
+
 
 2.2.1 (2024-12-19)
 ------------------

--- a/tests/unit/plugins/test_go_use_plugin.py
+++ b/tests/unit/plugins/test_go_use_plugin.py
@@ -167,7 +167,7 @@ def test_get_build_commands(mocker, part_info, go_workspace):
     )
 
     assert plugin.get_build_commands() == [
-        f"go work use {plugin._part_info.part_src_dir}",
+        f"go work use {plugin._part_info.part_src_subdir}",
     ]
     run_mock.assert_called_once_with(
         ["go", "work", "init"], capture_output=True, check=True, cwd=go_workspace.parent
@@ -182,6 +182,24 @@ def test_get_build_commands_workspace_in_use(mocker, part_info):
     run_mock = mocker.patch("subprocess.run")
 
     assert plugin.get_build_commands() == [
-        f"go work use {plugin._part_info.part_src_dir}",
+        f"go work use {plugin._part_info.part_src_subdir}",
+    ]
+    run_mock.assert_not_called()
+
+
+@pytest.mark.usefixtures("go_workspace")
+def test_get_build_commands_subdir(mocker, new_dir):
+    part_spec = {"source": ".", "source-subdir": "my/subdir"}
+    part_info = PartInfo(
+        project_info=ProjectInfo(application_name="test", cache_dir=new_dir),
+        part=Part("my-part", part_spec),
+    )
+    properties = GoUsePlugin.properties_class.unmarshal(part_spec)
+    plugin = GoUsePlugin(properties=properties, part_info=part_info)
+
+    run_mock = mocker.patch("subprocess.run")
+
+    assert plugin.get_build_commands() == [
+        f"go work use {plugin._part_info.part_src_subdir}",
     ]
     run_mock.assert_not_called()


### PR DESCRIPTION
It's possible, and somewhat common, for a go module to be defined inside a repo's subdir; in this case we can define source-subdir, but the go-use plugin needs to use this - otherwise the repo root gets used.

Fixes #978

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
