### PR TITLE
fix(errors): reformat plugin build error output

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -513,7 +513,7 @@ class UserExecutionError(PartsError, abc.ABC):
     def details(self) -> str | None:
         """Further details on the error.
 
-        Displays last three lines from the error output.
+        Displays the last three lines from the error output.
         """
         if self.stderr is None:
             return None

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -518,21 +518,21 @@ class UserExecutionError(PartsError, abc.ABC):
         if self.stderr is None:
             return None
 
+        stderr = self.stderr.decode("utf-8", errors="replace")
+        stderr_lines = list(filter(lambda x: x, stderr.split("\n")))
+
+        # Find the third trace output line
+        anchor_line = 0
+        traced_lines_to_display = 3
+        count = 0
+        for idx, line in enumerate(reversed(stderr_lines)):
+            if line.startswith("+"):
+                count += 1
+                if count > traced_lines_to_display:
+                    anchor_line = -idx
+                    break
+
         with contextlib.closing(StringIO()) as details_io:
-            stderr = self.stderr.decode("utf-8", errors="replace")
-            stderr_lines = list(filter(lambda x: x, stderr.split("\n")))
-
-            # Find the third trace output line
-            anchor_line = 0
-            traced_lines_to_display = 3
-            count = 0
-            for idx, line in enumerate(reversed(stderr_lines)):
-                if line.startswith("+"):
-                    count += 1
-                    if count > traced_lines_to_display:
-                        anchor_line = -idx
-                        break
-
             for line in stderr_lines[anchor_line:]:
                 details_io.write(f"\n:: {line}")
 

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -529,7 +529,7 @@ class UserExecutionError(PartsError, abc.ABC):
             for idx, line in enumerate(reversed(stderr_lines)):
                 if line.startswith("+"):
                     count += 1
-                    if count >= traced_lines_to_display:
+                    if count > traced_lines_to_display:
                         anchor_line = -idx
                         break
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -156,7 +156,7 @@ class StepHandler:
             raise errors.PluginBuildError(
                 part_name=self._part.name,
                 plugin_name=self._part.plugin_name,
-                stderr=process_error.result.combined,
+                stderr=process_error.result.stderr,
             ) from process_error
 
         return StepContents()
@@ -296,7 +296,7 @@ class StepHandler:
                     part_name=self._part.name,
                     scriptlet_name=scriptlet_name,
                     exit_code=process_error.result.returncode,
-                    stderr=process_error.result.combined,
+                    stderr=process_error.result.stderr,
                 ) from process_error
             finally:
                 ctl_socket.close()

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -156,7 +156,7 @@ class StepHandler:
             raise errors.PluginBuildError(
                 part_name=self._part.name,
                 plugin_name=self._part.plugin_name,
-                stderr=process_error.result.stderr,
+                stderr=process_error.result.combined,
             ) from process_error
 
         return StepContents()
@@ -296,7 +296,7 @@ class StepHandler:
                     part_name=self._part.name,
                     scriptlet_name=scriptlet_name,
                     exit_code=process_error.result.returncode,
-                    stderr=process_error.result.stderr,
+                    stderr=process_error.result.combined,
                 ) from process_error
             finally:
                 ctl_socket.close()

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -164,7 +164,7 @@ class BasePythonPlugin(Plugin):
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null || true)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2020-2024 Canonical Ltd.
+# Copyright 2020-2025 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -164,7 +164,7 @@ class BasePythonPlugin(Plugin):
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -179,12 +179,12 @@ class BasePythonPlugin(Plugin):
                 fi
             else
                 # Otherwise use what _get_system_python_interpreter() told us.
-                echo "Python interpreter not found in payload."
+                echo "Python interpreter not found in payload." >&2
                 symlink_target="{python_interpreter}"
             fi
 
             if [ -z "$symlink_target" ]; then
-                echo "No suitable Python interpreter found, giving up."
+                echo "No suitable Python interpreter found, giving up." >&2
                 exit 1
             fi
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 *********
 
-X.Y.Z (yyyy-mm-dd)
+X.Y.Z ()
 ------------------
 
 Bug fixes:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 *********
 
+X.Y.Z (yyyy-mm-dd)
+------------------
+
+Bug fixes:
+
+- Fix handling and propagation of Python plugin error messages.
+
 2.6.1 (2025-02-12)
 ------------------
 
@@ -10,7 +17,6 @@ Bug fixes:
 - Fix CPATH variable scope in the :ref:`jlink plugin<craft_parts_jlink_plugin>`.
 - Fix Jdeps parameter ordering in the 
   :ref:`jlink plugin<craft_parts_jlink_plugin>`.
-
 
 2.3.1 (2025-02-07)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [  # TODO: Remove this once we've switched CI to uv
     # Testing
     "hypothesis",
     "jsonschema",
-    "pytest-check",
+    "pytest-check<2.5.0",
     "pytest-subprocess",
     "requests-mock",
 

--- a/tests/integration/executor/test_errors.py
+++ b/tests/integration/executor/test_errors.py
@@ -74,6 +74,7 @@ def test_plugin_build_errors(new_dir, partitions):
         """\
             Failed to run the build script for part 'foo'.
 
+            :: + go mod download all
             :: + go install -p 1 ./...
             :: # example.com/hello
             :: ./hello.go:9:9: undefined: fmt.Printfs

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -261,7 +261,7 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
 
     output = err.read_text()
     expected_text = textwrap.dedent(
-        f"""\
+        """\
         + '[' -z '' ']'
         + echo 'No suitable Python interpreter found, giving up.'
         No suitable Python interpreter found, giving up.

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -242,7 +242,12 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     actions = lf.plan(Step.PRIME)
 
     out = pathlib.Path("out.txt")
-    with out.open(mode="w") as outfile, err.open(mode="w") as errfile, pytest.raises(errors.PluginBuildError):
+    err = pathlib.Path("err.txt")
+    with (
+        out.open(mode="w") as outfile,
+        err.open(mode="w") as errfile,
+        pytest.raises(errors.PluginBuildError),
+    ):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
@@ -255,12 +260,7 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     assert expected_text in output
 
     output = err.read_text()
-    expected_text = textwrap.dedent(
-        f"""\
-        No suitable Python interpreter found, giving up.
-        """
-    )
-    assert expected_text in output
+    assert "No suitable Python interpreter found, giving up." in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions, parts_dict, poetry_part):

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -260,8 +260,8 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
-    error = exc_info.value.stderr
-    assert error and expected_error_text in error.decode()
+    assert exc_info.value.stderr is not None
+    assert expected_error_text in exc_info.value.stderr.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -241,15 +241,26 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     )
     actions = lf.plan(Step.PRIME)
 
+    expected_error_text = textwrap.dedent(
+        """\
+        + '[' -z '' ']'
+        + echo 'No suitable Python interpreter found, giving up.'
+        No suitable Python interpreter found, giving up.
+        + exit 1
+        """
+    )
+
     out = pathlib.Path("out.txt")
     err = pathlib.Path("err.txt")
     with (
         out.open(mode="w") as outfile,
         err.open(mode="w") as errfile,
-        pytest.raises(errors.PluginBuildError),
+        pytest.raises(errors.PluginBuildError) as exc_info,
     ):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
+
+    assert expected_error_text in exc_info.value.stderr.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(
@@ -260,15 +271,7 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     assert expected_text in output
 
     output = err.read_text()
-    expected_text = textwrap.dedent(
-        """\
-        + '[' -z '' ']'
-        + echo 'No suitable Python interpreter found, giving up.'
-        No suitable Python interpreter found, giving up.
-        + exit 1
-        """
-    )
-    assert expected_text in output
+    assert expected_error_text in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions, parts_dict, poetry_part):

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -260,7 +260,15 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     assert expected_text in output
 
     output = err.read_text()
-    assert "No suitable Python interpreter found, giving up." in output
+    expected_text = textwrap.dedent(
+        f"""\
+        + '[' -z '' ']'
+        + echo 'No suitable Python interpreter found, giving up.'
+        No suitable Python interpreter found, giving up.
+        + exit 1
+        """
+    )
+    assert expected_text in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions, parts_dict, poetry_part):

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -260,7 +260,8 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
-    assert expected_error_text in exc_info.value.stderr.decode()
+    error = exc_info.value.stderr
+    assert error and expected_error_text in error.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -242,15 +242,21 @@ def test_find_payload_python_bad_version(new_dir, partitions, parts_dict, poetry
     actions = lf.plan(Step.PRIME)
 
     out = pathlib.Path("out.txt")
-    with out.open(mode="w") as outfile, pytest.raises(errors.PluginBuildError):
+    with out.open(mode="w") as outfile, err.open(mode="w") as errfile, pytest.raises(errors.PluginBuildError):
         with lf.action_executor() as ctx:
-            ctx.execute(actions, stdout=outfile)
+            ctx.execute(actions, stdout=outfile, stderr=errfile)
 
     output = out.read_text()
     expected_text = textwrap.dedent(
         f"""\
         Looking for a Python interpreter called "{real_basename}" in the payload...
-        Python interpreter not found in payload.
+        """
+    )
+    assert expected_text in output
+
+    output = err.read_text()
+    expected_text = textwrap.dedent(
+        f"""\
         No suitable Python interpreter found, giving up.
         """
     )

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -321,15 +321,26 @@ def test_find_payload_python_bad_version(new_dir, partitions):
     )
     actions = lf.plan(Step.PRIME)
 
+    expected_error_text = textwrap.dedent(
+        """\
+        + '[' -z '' ']'
+        + echo 'No suitable Python interpreter found, giving up.'
+        No suitable Python interpreter found, giving up.
+        + exit 1
+        """
+    )
+
     out = Path("out.txt")
     err = Path("err.txt")
     with (
         out.open(mode="w") as outfile,
         err.open(mode="w") as errfile,
-        pytest.raises(errors.PluginBuildError),
+        pytest.raises(errors.PluginBuildError) as exc_info,
     ):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
+
+    assert expected_error_text in exc_info.value.stderr.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(
@@ -340,15 +351,7 @@ def test_find_payload_python_bad_version(new_dir, partitions):
     assert expected_text in output
 
     output = err.read_text()
-    expected_text = textwrap.dedent(
-        """\
-        + '[' -z '' ']'
-        + echo 'No suitable Python interpreter found, giving up.'
-        No suitable Python interpreter found, giving up.
-        + exit 1
-        """
-    )
-    assert expected_text in output
+    assert expected_error_text in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions):

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -322,15 +322,22 @@ def test_find_payload_python_bad_version(new_dir, partitions):
     actions = lf.plan(Step.PRIME)
 
     out = Path("out.txt")
-    with out.open(mode="w") as outfile, pytest.raises(errors.PluginBuildError):
+    err = Path("err.txt")
+    with out.open(mode="w") as outfile, err.open(mode="w") as errfile, pytest.raises(errors.PluginBuildError):
         with lf.action_executor() as ctx:
-            ctx.execute(actions, stdout=outfile)
+            ctx.execute(actions, stdout=outfile, stderr=errfile)
 
     output = out.read_text()
     expected_text = textwrap.dedent(
         f"""\
         Looking for a Python interpreter called "{real_basename}" in the payload...
-        Python interpreter not found in payload.
+        """
+    )
+    assert expected_text in output
+
+    output = err.read_text()
+    expected_text = textwrap.dedent(
+        f"""\
         No suitable Python interpreter found, giving up.
         """
     )

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -341,7 +341,7 @@ def test_find_payload_python_bad_version(new_dir, partitions):
 
     output = err.read_text()
     expected_text = textwrap.dedent(
-        f"""\
+        """\
         + '[' -z '' ']'
         + echo 'No suitable Python interpreter found, giving up.'
         No suitable Python interpreter found, giving up.

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -340,7 +340,8 @@ def test_find_payload_python_bad_version(new_dir, partitions):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
-    assert expected_error_text in exc_info.value.stderr.decode()
+    error = exc_info.value.stderr
+    assert error and expected_error_text in error.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -340,7 +340,15 @@ def test_find_payload_python_bad_version(new_dir, partitions):
     assert expected_text in output
 
     output = err.read_text()
-    assert "No suitable Python interpreter found, giving up." in output
+    expected_text = textwrap.dedent(
+        f"""\
+        + '[' -z '' ']'
+        + echo 'No suitable Python interpreter found, giving up.'
+        No suitable Python interpreter found, giving up.
+        + exit 1
+        """
+    )
+    assert expected_text in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions):

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -323,7 +323,11 @@ def test_find_payload_python_bad_version(new_dir, partitions):
 
     out = Path("out.txt")
     err = Path("err.txt")
-    with out.open(mode="w") as outfile, err.open(mode="w") as errfile, pytest.raises(errors.PluginBuildError):
+    with (
+        out.open(mode="w") as outfile,
+        err.open(mode="w") as errfile,
+        pytest.raises(errors.PluginBuildError),
+    ):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
@@ -336,12 +340,7 @@ def test_find_payload_python_bad_version(new_dir, partitions):
     assert expected_text in output
 
     output = err.read_text()
-    expected_text = textwrap.dedent(
-        f"""\
-        No suitable Python interpreter found, giving up.
-        """
-    )
-    assert expected_text in output
+    assert "No suitable Python interpreter found, giving up." in output
 
 
 def test_find_payload_python_good_version(new_dir, partitions):

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -340,8 +340,8 @@ def test_find_payload_python_bad_version(new_dir, partitions):
         with lf.action_executor() as ctx:
             ctx.execute(actions, stdout=outfile, stderr=errfile)
 
-    error = exc_info.value.stderr
-    assert error and expected_error_text in error.decode()
+    assert exc_info.value.stderr is not None
+    assert expected_error_text in exc_info.value.stderr.decode()
 
     output = out.read_text()
     expected_text = textwrap.dedent(

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2021-2023 Canonical Ltd.
+# Copyright 2021-2025 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -146,7 +146,7 @@ def test_python_get_find_python_interpreter_commands(
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.
@@ -238,7 +238,7 @@ def test_python_get_build_commands(new_dir, python_plugin: FooPythonPlugin):
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -161,12 +161,12 @@ def test_python_get_find_python_interpreter_commands(
                 fi
             else
                 # Otherwise use what _get_system_python_interpreter() told us.
-                echo "Python interpreter not found in payload."
+                echo "Python interpreter not found in payload." >&2
                 symlink_target="$(readlink -f "$(which "${{PARTS_PYTHON_INTERPRETER}}")")"
             fi
 
             if [ -z "$symlink_target" ]; then
-                echo "No suitable Python interpreter found, giving up."
+                echo "No suitable Python interpreter found, giving up." >&2
                 exit 1
             fi
 
@@ -253,12 +253,12 @@ def test_python_get_build_commands(new_dir, python_plugin: FooPythonPlugin):
                 fi
             else
                 # Otherwise use what _get_system_python_interpreter() told us.
-                echo "Python interpreter not found in payload."
+                echo "Python interpreter not found in payload." >&2
                 symlink_target="$(readlink -f "$(which "${{PARTS_PYTHON_INTERPRETER}}")")"
             fi
 
             if [ -z "$symlink_target" ]; then
-                echo "No suitable Python interpreter found, giving up."
+                echo "No suitable Python interpreter found, giving up." >&2
                 exit 1
             fi
 

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -146,7 +146,7 @@ def test_python_get_find_python_interpreter_commands(
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null || true)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.
@@ -238,7 +238,7 @@ def test_python_get_build_commands(new_dir, python_plugin: FooPythonPlugin):
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null || true)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/tests/unit/plugins/test_base_python.py
+++ b/tests/unit/plugins/test_base_python.py
@@ -72,7 +72,7 @@ def get_python_build_commands(
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/tests/unit/plugins/test_base_python.py
+++ b/tests/unit/plugins/test_base_python.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/tests/unit/plugins/test_base_python.py
+++ b/tests/unit/plugins/test_base_python.py
@@ -87,12 +87,12 @@ def get_python_build_commands(
                 fi
             else
                 # Otherwise use what _get_system_python_interpreter() told us.
-                echo "Python interpreter not found in payload."
+                echo "Python interpreter not found in payload." >&2
                 symlink_target="$(readlink -f "$(which "${{PARTS_PYTHON_INTERPRETER}}")")"
             fi
 
             if [ -z "$symlink_target" ]; then
-                echo "No suitable Python interpreter found, giving up."
+                echo "No suitable Python interpreter found, giving up." >&2
                 exit 1
             fi
 

--- a/tests/unit/plugins/test_base_python.py
+++ b/tests/unit/plugins/test_base_python.py
@@ -72,7 +72,7 @@ def get_python_build_commands(
             # look for python3.10
             basename=$(basename $(readlink -f ${{PARTS_PYTHON_VENV_INTERP_PATH}}))
             echo Looking for a Python interpreter called \\"${{basename}}\\" in the payload...
-            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null ||:)
+            payload_python=$(find "$install_dir" "$stage_dir" -type f -executable -name "${{basename}}" -print -quit 2>/dev/null || true)
 
             if [ -n "$payload_python" ]; then
                 # We found a provisioned interpreter, use it.

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -33,7 +33,7 @@ _RUN_TEST_CASES = [
 
 @pytest.mark.parametrize(("out", "err"), _RUN_TEST_CASES)
 def test_run(out, err):
-    result = process.run(["/usr/bin/sh", "-c", f"echo {out};sleep 0;echo {err} >&2"])
+    result = process.run(["/usr/bin/sh", "-c", f"echo {out};sleep 0.1;echo {err} >&2"])
     assert result.returncode == 0
     assert result.stdout == (out + "\n").encode()
     assert result.stderr == (err + "\n").encode()
@@ -82,7 +82,7 @@ def test_run_selector(out, err, new_dir):
         [
             "/usr/bin/sh",
             "-c",
-            f"echo {out};sleep 0;echo {err} >&2; echo -n {out}|socat - UNIX-CONNECT:{new_dir}/test.socket",
+            f"echo {out};sleep 0.1;echo {err} >&2; echo -n {out}|socat - UNIX-CONNECT:{new_dir}/test.socket",
         ],
         selector=selector,
     )


### PR DESCRIPTION
In case of Python plugin build errors, print error messages to stderr
instead of stdout so they can be captured and properly displayed to the
user. Don't start printing from the last script execution trace line because
messages printed to stderr appear before the traced `exit` line.

Fixes #1000 

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
