### PR TITLE
fix: don't require a specific python interpreter for uv (#1003)

### DIFF
--- a/craft_parts/plugins/uv_plugin.py
+++ b/craft_parts/plugins/uv_plugin.py
@@ -98,8 +98,14 @@ class UvPlugin(BasePythonPlugin):
         return []
 
     def _get_create_venv_commands(self) -> list[str]:
+        # Explicitly request a Python version if provided by the plugin, otherwise use the global
+        # parts interpreter.
+        python_ver = (
+            self._get_system_python_interpreter()
+            or "$(which ${PARTS_PYTHON_INTERPRETER})"
+        )
         return [
-            f'uv venv --relocatable --allow-existing --python "{self._get_system_python_interpreter()}" "{self._get_venv_directory()}"',
+            f'uv venv --relocatable --allow-existing --python {python_ver} "{self._get_venv_directory()}"',
             f'PARTS_PYTHON_VENV_INTERP_PATH="{self._get_venv_directory()}/bin/${{PARTS_PYTHON_INTERPRETER}}"',
         ]
 

--- a/craft_parts/sources/__init__.py
+++ b/craft_parts/sources/__init__.py
@@ -41,7 +41,7 @@ from .zip_source import ZipSource, ZipSourceModel
 
 
 def _detect_source_type(
-    data: SourceModel | dict[str, Any]
+    data: SourceModel | dict[str, Any],
 ) -> SourceModel | dict[str, Any]:
     """Get the source type for a source if it's not already provided."""
     if isinstance(data, BaseSourceModel) or "source-type" in data:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,8 @@ linkcheck_ignore = [
     "https://foo.org/",
     # GNU's site is a bit unreliable
     "https://www.gnu.org/.*",
+    # https://github.com/rust-lang/crates.io/issues/788
+    "https://crates.io/",
     # Ignore releases, since we'll include the next release before it exists.
     "https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
 ]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,16 @@
 Changelog
 *********
 
+2.4.2 (2025-03-04)
+------------------
+
+Bug fixes:
+
+- Allow for a non-specific system Python interpreter when using the
+  :ref:`uv plugin<craft_parts_uv_plugin>`.
+
+For a complete list of commits, check out the `2.4.2`_ release on GitHub.
+
 2.4.1 (2025-01-24)
 ------------------
 
@@ -741,6 +751,7 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.4.2: https://github.com/canonical/craft-parts/releases/tag/2.4.2
 .. _2.4.0: https://github.com/canonical/craft-parts/releases/tag/2.4.0
 .. _2.3.0: https://github.com/canonical/craft-parts/releases/tag/2.3.0
 .. _2.2.2: https://github.com/canonical/craft-parts/releases/tag/2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [  # TODO: Remove this once we've switched CI to uv
     # Testing
     "hypothesis",
     "jsonschema",
-    "pytest-check",
+    "pytest-check<2.5.0",
     "pytest-subprocess",
     "requests-mock",
 

--- a/tests/integration/plugins/test_uv.py
+++ b/tests/integration/plugins/test_uv.py
@@ -148,8 +148,10 @@ def test_uv_plugin_no_system_interpreter(
     )
     actions = lf.plan(Step.PRIME)
 
-    with lf.action_executor() as ctx, pytest.raises(errors.PluginBuildError):
+    with lf.action_executor() as ctx, pytest.raises(errors.PluginBuildError) as exc:
         ctx.execute(actions)
+
+    assert b"No suitable Python interpreter found" in cast(bytes, exc.value.stderr)
 
 
 def test_uv_plugin_remove_symlinks(new_dir, partitions, uv_parts_simple):


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Cherry-picks #1003 onto `hotfix/2.4` to fix a regression in Snapcraft.