### PR TITLE
fix(jlink): find all jar files in default behavior

### DIFF
--- a/craft_parts/plugins/jlink_plugin.py
+++ b/craft_parts/plugins/jlink_plugin.py
@@ -61,6 +61,15 @@ class JLinkPlugin(Plugin):
     properties_class = JLinkPluginProperties
     validator_class = JLinkPluginEnvironmentValidator
 
+    def _get_find_jars_commands(self) -> str:
+        """Return commands for finding all jarfiles."""
+        options = cast(JLinkPluginProperties, self._options)
+        if len(options.jlink_jars) > 0:
+            jars = " ".join(["${CRAFT_STAGE}/" + x for x in options.jlink_jars])
+            return f"PROCESS_JARS={jars}"
+
+        return 'PROCESS_JARS=$(find ${CRAFT_STAGE} -type f -name "*.jar")'
+
     @override
     def get_build_packages(self) -> set[str]:
         """Return a set of required packages to install in the build environment."""
@@ -79,8 +88,6 @@ class JLinkPlugin(Plugin):
     @override
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
-        options = cast(JLinkPluginProperties, self._options)
-
         commands = []
 
         # Set JAVA_HOME to be used in jlink commands
@@ -106,13 +113,7 @@ class JLinkPlugin(Plugin):
         )
         commands.append("MULTI_RELEASE=${JLINK_VERSION%%.*}")
 
-        # find application jars - either all jars in the staging area
-        # or a list specified in jlink_jars option
-        if len(options.jlink_jars) > 0:
-            jars = " ".join(["${CRAFT_STAGE}/" + x for x in options.jlink_jars])
-            commands.append(f"PROCESS_JARS={jars}")
-        else:
-            commands.append("PROCESS_JARS=$(find ${CRAFT_STAGE} -type f -name *.jar)")
+        commands.append(self._get_find_jars_commands())
 
         # create temp folder
         commands.append("mkdir -p ${CRAFT_PART_BUILD}/tmp")

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -10,6 +10,12 @@ New features:
 - Previously, ``source-commit`` could only accept full length (40 character)
   hashes. Now, ``source-commit`` can accept short hashes.
 
+Bug fixes:
+
+- Fix the default behavior of the :ref:`jlink plugin <craft_parts_jlink_plugin>`
+  only finding JAR files in the top-level directory. It now searches all
+  subdirectories too.
+
 2.4.2 (2025-03-04)
 ------------------
 

--- a/tests/unit/plugins/test_jlink_plugin.py
+++ b/tests/unit/plugins/test_jlink_plugin.py
@@ -52,6 +52,7 @@ def test_jlink_plugin_jar_files(part_info):
 
     assert "PROCESS_JARS=${CRAFT_STAGE}/foo.jar" in plugin.get_build_commands()
 
+
 def test_jlink_plugin_find_jars(part_info, tmp_path):
     """Ensure all jar files are found when not specified in options"""
     (tmp_path / "file1.jar").touch()


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
Note: The actual fix was quoting the "*.jar" in the find command, which was being expanded by bash instead of find. It was moved into a function in the name of testing.

Closes #1027
CRAFT-4266.