### PR TITLE
fix(util/process): collect complete output from subprocess

### DIFF
--- a/craft_parts/utils/process.py
+++ b/craft_parts/utils/process.py
@@ -151,6 +151,7 @@ def run(
 
         with closing(BytesIO()) as combined_io:
             while True:
+                finished = proc.poll() is not None
                 try:
                     # Time out if we don't have any event to handle
                     for key, mask in selector.select(0.1):
@@ -164,7 +165,7 @@ def run(
                 except BlockingIOError:
                     pass
 
-                if proc.poll() is not None:
+                if finished:
                     combined = combined_io.getvalue()
                     break
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 *********
 
+2.4.3 (unreleased)
+------------------
+
+Bug fixes:
+
+- Address race condition when collecting subprocess output.
+
 2.4.2 (2025-03-04)
 ------------------
 


### PR DESCRIPTION
Run subprocess output one last time before exiting the combined output
processing loop.

Fix #1025

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
