### PR TITLE
style: enforce strict checking for shadowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,9 @@ lint.ignore = [
 [tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true
 
+[tool.ruff.lint.flake8-builtins]
+strict-checking = true
+
 [tool.ruff.lint.pylint]
 max-args = 8
 max-branches = 16


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Ruff 0.10 made the [rule for module shadowing](https://docs.astral.sh/ruff/settings/#lint_flake8-builtins_strict-checking) less strict by default.  My preference is to keep the same level of strictness.

See the "failure" [here](https://github.com/canonical/craft-parts/actions/runs/13917827360/job/38944036599?pr=1044), where a `noqa` becomes superfluous.