### PR TITLE
fix: add keyrings to standard chroot mount

### DIFF
--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -332,6 +332,7 @@ _ubuntu_apt_mounts = [
         "/usr/share/ca-certificates/",
         skip_missing=False,
     ),
+    _BindMount("/usr/share/keyrings/", "/usr/share/keyrings/", skip_missing=True),
     _BindMount("/etc/ssl/certs/", "/etc/ssl/certs/", skip_missing=False),
     _BindMount(
         "/etc/ca-certificates.conf", "/etc/ca-certificates.conf", skip_missing=False


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

This PR adds a directory to the set of paths mounted when executing `craftctl chroot ...`. This change is necessary for noble build-bases to verify archive signatures during the hidden apt-upgrade step.
