### PR TITLE
docs: add examples to the source field in docs

### DIFF
--- a/docs/common/craft-parts/reference/part_properties.rst
+++ b/docs/common/craft-parts/reference/part_properties.rst
@@ -222,7 +222,34 @@ source
 
 **Step:** pull
 
-The location of the source code and data.
+The location of the source code and data. It can refer to a git
+repository, debian package, zip file, local directory, etc. See
+:ref:`source_type`.
+
+The following example points the source field to a git repository:
+
+.. code:: yaml
+
+   source: https://github.com/canonical/rockcraft.git
+
+.. note::
+
+   Note that, in case of git, any of the `git url formats`_ is
+   supported.
+
+On the other hand, a local directory can also be declared as the
+source:
+
+.. code:: yaml
+
+   source: ./my-directory
+
+Any other file formats would be declared the same way, for example
+a zip file:
+
+.. code:: yaml
+
+   source: ./my-directory/my-file.zip
 
 .. _source_branch:
 
@@ -400,3 +427,4 @@ The ``plugin`` and ``parse-info`` keys apply to all steps.
 .. _`NPM`: https://www.npmjs.com/
 .. _`Python package`: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/
 .. _`SCons`: https://scons.org/
+.. _`git url formats`: https://git-scm.com/docs/git-clone#_git_urls

--- a/docs/common/craft-parts/reference/part_properties.rst
+++ b/docs/common/craft-parts/reference/part_properties.rst
@@ -223,7 +223,7 @@ source
 **Step:** pull
 
 The location of the source code and data. It can refer to a git
-repository, debian package, zip file, local directory, etc. See
+repository, deb package, zip file, local directory, etc. See
 :ref:`source_type`.
 
 The following example points the source field to a git repository:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

This PR adds more examples to the `source` field in documentation.

Note that docs now say "every git url format is supported" but SCP formatted string may cause infinite loading - see https://github.com/canonical/craft-parts/issues/1058

----

See [built docs](https://canonical-craft-parts--1057.com.readthedocs.build/en/1057/)