### PR TITLE
Fix(): Permissions block throws `FileNotFoundError` when setting permissions for a symlink

### DIFF
--- a/craft_parts/permissions.py
+++ b/craft_parts/permissions.py
@@ -88,7 +88,7 @@ class Permissions(BaseModel):
             os.chmod(target, self.mode_octal)
 
         if self.owner is not None and self.group is not None:
-            os.chown(target, self.owner, self.group)
+            os.chown(target, self.owner, self.group, follow_symlinks=False)
 
 
 def filter_permissions(

--- a/tests/integration/lifecycle/test_permissions.py
+++ b/tests/integration/lifecycle/test_permissions.py
@@ -61,6 +61,7 @@ def test_part_permissions(new_dir, mock_chown):
     assert chown_call.owner == 1111
     assert chown_call.group == 2222
 
+
 def test_part_permissions_symlink(new_dir):
     files = Path("files")
     files.mkdir()
@@ -95,5 +96,3 @@ def test_part_permissions_symlink(new_dir):
     actions = lf.plan(Step.PRIME)
     with lf.action_executor() as ctx:
         ctx.execute(actions)
-
-

--- a/tests/integration/lifecycle/test_permissions.py
+++ b/tests/integration/lifecycle/test_permissions.py
@@ -60,3 +60,40 @@ def test_part_permissions(new_dir, mock_chown):
     chown_call = mock_chown[str(Path("prime/bar/2.txt").resolve())]
     assert chown_call.owner == 1111
     assert chown_call.group == 2222
+
+def test_part_permissions_symlink(new_dir):
+    files = Path("files")
+    files.mkdir()
+
+    (files / "1.txt").touch()
+    (files / "bar").mkdir()
+    (files / "bar/2.txt").touch()
+    (files / "sym-1.txt").symlink_to(f"{files}/1.txt", target_is_directory=False)
+    (files / "sym-bar").symlink_to(f"{files}/bar", target_is_directory=True)
+
+    parts_yaml = textwrap.dedent(
+        f"""
+        parts:
+          my-part:
+            plugin: dump
+            source: files
+            permissions:
+              - path: sym-1.txt
+                owner: {os.getuid()}
+                group: {os.getgid()}
+              - path: sym-bar
+                owner: {os.getuid()}
+                group: {os.getgid()}
+        """
+    )
+
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts, application_name="test_demo", cache_dir=new_dir
+    )
+    actions = lf.plan(Step.PRIME)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+


### PR DESCRIPTION
Related to the [issue](https://github.com/canonical/rockcraft/issues/660).

When the target of `permission` block has a symlink inside the `permission` block fails with a `FileNotFoundError`. 


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
