### PR TITLE
fix(errors): remove html suffix from plugin docs slug

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -505,7 +505,7 @@ class UserExecutionError(PartsError, abc.ABC):
     ) -> None:
         self.stderr = stderr
         super().__init__(
-            brief=brief, resolution=resolution, doc_slug="/reference/plugins.html"
+            brief=brief, resolution=resolution, doc_slug="/reference/plugins"
         )
 
     @property

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+2.7.1 (2025-04-09)
+-------------------
+
+Bug fixes:
+
+- Fix the link to the plugins documentation in error outputs.
+
+
 2.7.0 (2025-03-18)
 -------------------
 

--- a/tests/integration/executor/test_errors.py
+++ b/tests/integration/executor/test_errors.py
@@ -80,4 +80,4 @@ def test_plugin_build_errors(new_dir, partitions):
             :: ./hello.go:9:9: undefined: fmt.Printfs
             Check the build output and verify the project can work with the 'go' plugin."""
     )
-    assert raised.value.doc_slug == "/reference/plugins.html"
+    assert raised.value.doc_slug == "/reference/plugins"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -325,7 +325,7 @@ def test_plugin_build_error():
         err.resolution
         == "Check the build output and verify the project can work with the 'go' plugin."
     )
-    assert err.doc_slug == "/reference/plugins.html"
+    assert err.doc_slug == "/reference/plugins"
 
 
 def test_invalid_control_api_call():


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

## Issue

When `sourcecraft pack` fails to build, it returns the following error:
```
Recommended resolution: Check the build output and verify the project can work with the '<plugin>' plugin.
For more information, check out: https://canonical-sourcecraft.readthedocs-hosted.com/en/latest/reference/plugins.html
```
The documentation link https://canonical-sourcecraft.readthedocs-hosted.com/en/latest/reference/plugins.html returns a 404 error. 

<details><summary>Full output from a build failure with <code>cmake</code></summary>

```yaml
# sourcecraft.yaml
...
parts:
  tinyobjloader-c:
    plugin: cmake
    source: .
...
```
```shell
andreia@tux ~$ sourcecraft pack

Failed to run the build script for part 'tinyobjloader-c'.
Detailed information: 
:: + cmake /root/parts/tinyobjloader-c/src -G 'Unix Makefiles'
:: CMake Warning:
::   Ignoring extra path from command line:
::    "/root/parts/tinyobjloader-c/src"
:: CMake Error: The source directory "/root/parts/tinyobjloader-c/src" does not appear to contain CMakeLists.txt.
:: Specify --help for usage, or press the help button on the CMake GUI.
Recommended resolution: Check the build output and verify the project can work with the 'cmake' plugin.
For more information, check out: https://canonical-sourcecraft.readthedocs-hosted.com/en/latest/reference/plugins.html
Failed to execute sourcecraft in instance.
Full execution log: '/home/andreia/.local/state/sourcecraft/log/sourcecraft-20250409-105840.992405.log'
```

</details>

## Solution

Remove `.html` from the `doc_slug` variable. 