### PR TITLE
docs(build): switch to extensionless URLs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ submodules:
     - docs/sphinx-resources
 
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,8 +2,17 @@
 Changelog
 *********
 
+2.7.1 (2025-XX-XX)
+------------------
+
+Documentation:
+
+- Fix an issue where the documentation was hosting pages at URLs that contained the
+  ``.html`` extension. This regression was causing links to the site to break.
+
+
 2.7.0 (2025-03-18)
--------------------
+------------------
 
 New features:
 


### PR DESCRIPTION
This fixes a regression. Do we want a changelog entry for it?

---
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
