### PR TITLE
ci: drop focal tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -130,9 +130,6 @@ jobs:
         python-version: ["3.10", "3.12"]
         include:
           - adjective: jammy
-          - os: ubuntu-20.04
-            python-version: "3.10"
-            adjective: focal
           - os: ubuntu-24.04
             python-version: "3.12"
             adjective: noble
@@ -153,7 +150,7 @@ jobs:
           sudo apt install -y libapt-pkg-dev intltool fuse-overlayfs python3-apt
       - name: Install general python dependencies
         run: |
-          pip install python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz
+          pip install python-apt@https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.4.0ubuntu1/python-apt_2.4.0ubuntu1.tar.xz
           pip install -e .[dev]
       - name: Install additional test dependencies
         run: |


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Drops focal from CI now that is no longer available as a github runner (https://github.com/actions/runner-images/issues/11101).