### PR TITLE
fix: remove .html extension from doc slug

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -505,7 +505,7 @@ class UserExecutionError(PartsError, abc.ABC):
     ) -> None:
         self.stderr = stderr
         super().__init__(
-            brief=brief, resolution=resolution, doc_slug="/reference/plugins.html"
+            brief=brief, resolution=resolution, doc_slug="/reference/plugins/"
         )
 
     @property

--- a/tests/integration/executor/test_errors.py
+++ b/tests/integration/executor/test_errors.py
@@ -80,4 +80,4 @@ def test_plugin_build_errors(new_dir, partitions):
             :: ./hello.go:9:9: undefined: fmt.Printfs
             Check the build output and verify the project can work with the 'go' plugin."""
     )
-    assert raised.value.doc_slug == "/reference/plugins.html"
+    assert raised.value.doc_slug == "/reference/plugins/"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -325,7 +325,7 @@ def test_plugin_build_error():
         err.resolution
         == "Check the build output and verify the project can work with the 'go' plugin."
     )
-    assert err.doc_slug == "/reference/plugins.html"
+    assert err.doc_slug == "/reference/plugins/"
 
 
 def test_invalid_control_api_call():


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

I couldn't find any applications consuming craft-parts that still use the `.html` extension on RTD, so I believe this can be updated safely. If I'm overlooking anything, please let me know.