### PR TITLE
test: fix directory test strategy

### DIFF
--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -76,7 +76,9 @@ def test_get_stage_dir_with_partitions(partitions):
 @pytest.mark.usefixtures("enable_partitions_feature")
 @given(
     partitions=strategies.lists(
-        strategies.text(strategies.sampled_from(string.ascii_lowercase), min_size=1),
+        strategies.text(
+            strategies.sampled_from(string.ascii_lowercase), min_size=1
+        ).filter(lambda x: x != "default"),
         min_size=1,
         unique=True,
     )


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Craft Parts would occasionally fail when the strategy generated "default" because there would be 2 partitions named "default".