### PR TITLE
Fix and changelog for 2.4.4

### DIFF
--- a/craft_parts/packages/platform.py
+++ b/craft_parts/packages/platform.py
@@ -1,4 +1,3 @@
-# noqa: A005 (this module shadows the stdlib platform module)
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright 2017-2023 Canonical Ltd.

--- a/craft_parts/plugins/uv_plugin.py
+++ b/craft_parts/plugins/uv_plugin.py
@@ -71,7 +71,6 @@ class UvPluginEnvironmentValidator(validator.PluginEnvironmentValidator):
             dependency="uv",
             plugin_name=self._options.plugin,
             part_dependencies=part_dependencies,
-            argument="version",
         )
         if not version.startswith("uv") and (
             part_dependencies is None or "uv-deps" not in part_dependencies

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+2.4.4 (2025-05-01)
+------------------
+
+Bug fixes:
+
+- Fix the uv plugin breaking with uv 0.7
+
+For a complete list of commits, check out the `2.4.4`_ release on GitHub.
+
 2.4.3 (2025-03-11)
 ------------------
 
@@ -9,6 +18,8 @@ Bug fixes:
 
 - Address race condition when collecting subprocess output.
 - Update jinja2 dependency to address CVE-2025-27516
+
+For a complete list of commits, check out the `2.4.3`_ release on GitHub.
 
 2.4.2 (2025-03-04)
 ------------------
@@ -759,6 +770,8 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.4.4: https://github.com/canonical/craft-parts/releases/tag/2.4.4
+.. _2.4.3: https://github.com/canonical/craft-parts/releases/tag/2.4.3
 .. _2.4.2: https://github.com/canonical/craft-parts/releases/tag/2.4.2
 .. _2.4.0: https://github.com/canonical/craft-parts/releases/tag/2.4.0
 .. _2.3.0: https://github.com/canonical/craft-parts/releases/tag/2.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -70,7 +70,7 @@ gitpython==3.1.44
     # via
     #   -r requirements.txt
     #   canonical-sphinx-extensions
-h11==0.14.0
+h11==0.16.0
     # via
     #   -r requirements.txt
     #   uvicorn


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

This backports #1086 to the 2.4 branch for Charmcraft 3.4