### PR TITLE
ci: reference the OS to build the tox tests result filename

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Tox environments
         run: tox run -m unit-tests --notest
       - name: Unit tests
-        run: .tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m unit-tests
+        run: .tox/.tox/bin/tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.os }}.json -m unit-tests
         env:
           PYTEST_ADDOPTS: "--no-header -vv -rN"
   tests:


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

`matrix.platform` is not defined (anymore?), so use `matrix.os`.