### PR TITLE
build(docs): parallelize spellcheck task

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,7 +55,7 @@ clean-html: clean-doc
 	+$(MAKE) html
 
 spelling: clean-html
-	. $(VENV) ; python3 -m pyspelling -c sphinx-resources/.sphinx/spellingcheck.yaml
+	. $(VENV) ; python3 -m pyspelling -c sphinx-resources/.sphinx/spellingcheck.yaml -j $(shell nproc)
 
 linkcheck:
 	. $(VENV) ; $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"


### PR DESCRIPTION
Sync the task with the [upstream code](https://github.com/canonical/sphinx-docs-starter-pack/blob/74fd0053cddc2bd55e38ca07f2ee16336e357469/docs/Makefile#L118) from the Starter Pack.

This makes the doc spelling check effectual on local systems.

Sample performance differences:

```bash
$ time python3 -m pyspelling -c sphinx-resources/.sphinx/spellingcheck.yaml
Spelling check passed :)

real    7m2.737s
user    4m14.033s
sys     2m50.220s
```

```bash
$ time python3 -m pyspelling -c sphinx-resources/.sphinx/spellingcheck.yaml -j 8
Spelling check passed :)

real    0m52.026s
user    4m24.655s
sys     2m29.639s
```

---

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-----
