### PR TITLE
feat(go-use): make the go-use plugin use backstage

### DIFF
--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -128,7 +128,7 @@ class GoPlugin(Plugin):
                 "go work init .",
                 "go work use .",
                 *(
-                    f"go work use {dependencies_dir}/{dep_part}"
+                    f"go work use '{dependencies_dir}/{dep_part}'"
                     for dep_part in self._part_info.part_dependencies
                     if (dependencies_dir / dep_part).exists()
                 ),

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -17,6 +17,7 @@
 """The Go plugin."""
 
 import logging
+import pathlib
 from typing import Literal, cast
 
 from overrides import override
@@ -121,20 +122,22 @@ class GoPlugin(Plugin):
         options = cast(GoPluginProperties, self._options)
 
         # Matches go-use plugin expectation.
-        workspace_dir = self._part_info.project_info.dirs.parts_dir
-        workspace = workspace_dir / "go.work"
-
-        if workspace.exists():
-            init_cmd = f"go work use {self._part_info.part_build_dir}"
+        dependencies_dir: pathlib.Path = self._part_info.backstage_dir / "go-use"
+        if dependencies_dir.is_dir():
+            setup_cmds = [
+                "go work init .",
+                "go work use .",
+                *(f"go work use {dep_part}" for dep_part in dependencies_dir.iterdir()),
+            ]
         else:
-            init_cmd = "go mod download all"
+            setup_cmds = ["go mod download all"]
 
         tags = f"-tags={','.join(options.go_buildtags)}" if options.go_buildtags else ""
 
         generate_cmds: list[str] = [f"go generate {cmd}" for cmd in options.go_generate]
 
         return [
-            init_cmd,
+            *setup_cmds,
             *generate_cmds,
             f'go install -p "{self._part_info.parallel_build_count}" {tags} ./...',
         ]

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -127,7 +127,11 @@ class GoPlugin(Plugin):
             setup_cmds = [
                 "go work init .",
                 "go work use .",
-                *(f"go work use {dep_part}" for dep_part in dependencies_dir.iterdir()),
+                *(
+                    f"go work use {dependencies_dir}/{dep_part}"
+                    for dep_part in self._part_info.part_dependencies
+                    if (dependencies_dir / dep_part).exists()
+                ),
             ]
         else:
             setup_cmds = ["go mod download all"]

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -76,6 +76,6 @@ class GoUsePlugin(Plugin):
             self._part_info.part_export_dir / "go-use" / self._part_info.part_name
         )
         return [
-            f"mkdir -p {dest_dir.parent}",
-            f"ln -s {self._part_info.part_src_subdir} {dest_dir}",
+            f'mkdir -p "{dest_dir.parent}"',
+            f"ln -sf {self._part_info.part_src_subdir} {dest_dir}",
         ]

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -75,30 +75,10 @@ class GoUsePlugin(Plugin):
     @override
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
-        # Set the go workspace directory to live at the root of all parts.
-        workspace_dir = self._part_info.project_info.dirs.parts_dir
-        workspace = workspace_dir / "go.work"
-
-        # We do not want this implementation detail exposed in the run script
-        if not workspace.exists():
-            logger.debug(f"Init go workspace at {workspace}")
-            try:
-                subprocess.run(
-                    ["go", "work", "init"],
-                    capture_output=True,
-                    check=True,
-                    cwd=workspace_dir,
-                )
-            except subprocess.CalledProcessError as call_error:
-                logger.debug(
-                    f"Workspace init failed {call_error!r} "
-                    f"stdout: {call_error.stdout!r} "
-                    f"stderr: {call_error.stderr}"
-                )
-                raise errors.PluginBuildError(
-                    part_name=self._part_info.part_name, plugin_name="go-use"
-                )
-
+        dest_dir = (
+            self._part_info.part_export_dir / "go-use" / self._part_info.part_name
+        )
         return [
-            f"go work use {self._part_info.part_src_subdir}",
+            f"mkdir -p {dest_dir}",
+            f"ln -s {self._part_info.part_build_subdir} {dest_dir}",
         ]

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -76,6 +76,6 @@ class GoUsePlugin(Plugin):
             self._part_info.part_export_dir / "go-use" / self._part_info.part_name
         )
         return [
-            f'mkdir -p "{dest_dir.parent}"',
-            f"ln -sf {self._part_info.part_src_subdir} {dest_dir}",
+            f"mkdir -p '{dest_dir.parent}'",
+            f"ln -sf '{self._part_info.part_src_subdir}' '{dest_dir}'",
         ]

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -76,6 +76,6 @@ class GoUsePlugin(Plugin):
             self._part_info.part_export_dir / "go-use" / self._part_info.part_name
         )
         return [
-            f"mkdir -p {dest_dir}",
-            f"ln -s {self._part_info.part_build_subdir} {dest_dir}",
+            f"mkdir -p {dest_dir.parent}",
+            f"ln -s {self._part_info.part_src_subdir} {dest_dir}",
         ]

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -17,12 +17,9 @@
 """The Go Use plugin."""
 
 import logging
-import subprocess
 from typing import Literal
 
 from overrides import override
-
-from craft_parts import errors
 
 from .base import Plugin
 from .go_plugin import GoPluginEnvironmentValidator

--- a/tests/integration/plugins/test_go_use.py
+++ b/tests/integration/plugins/test_go_use.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pathlib
 import re
 import subprocess
 import textwrap

--- a/tests/integration/plugins/test_go_use.py
+++ b/tests/integration/plugins/test_go_use.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pathlib
 import re
 import subprocess
 import textwrap
@@ -56,14 +57,7 @@ def test_go_workspace_use(new_dir, partitions, go_version):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    go_work = (new_dir / "parts" / "go.work").read_text(encoding="utf-8")
-    assert go_work == textwrap.dedent(
-        f"""\
-        go {go_version}
-
-        use {new_dir}/parts/go-flags/src
-        """
-    )
+    assert (new_dir / "backstage" / "go-use" / "go-flags").exists()
 
 
 def test_go_workspace_use_multiple(new_dir, partitions, go_version):
@@ -92,14 +86,5 @@ def test_go_workspace_use_multiple(new_dir, partitions, go_version):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    go_work = (new_dir / "parts" / "go.work").read_text(encoding="utf-8")
-    assert go_work == textwrap.dedent(
-        f"""\
-        go {go_version}
-
-        use (
-        \t{new_dir}/parts/go-flags/src
-        \t{new_dir}/parts/go-starlark/src
-        )
-        """
-    )
+    assert (new_dir / "backstage" / "go-use" / "go-flags").exists()
+    assert (new_dir / "backstage" / "go-use" / "go-starlark").exists()

--- a/tests/unit/plugins/test_go_plugin.py
+++ b/tests/unit/plugins/test_go_plugin.py
@@ -248,6 +248,6 @@ def test_get_build_commands_go_use_with_go_dependency(project_info, part_data):
     assert plugin.get_build_commands() == [
         "go work init .",
         "go work use .",
-        f"go work use {dependency_backstage}",
+        f"go work use '{dependency_backstage}'",
         'go install -p "1"  ./...',
     ]

--- a/tests/unit/plugins/test_go_use_plugin.py
+++ b/tests/unit/plugins/test_go_use_plugin.py
@@ -157,6 +157,6 @@ def test_get_build_commands(mocker, part_info, part_data):
     dest_dir = part_info.part_export_dir / "go-use" / part_info.part_name
 
     assert plugin.get_build_commands() == [
-        f"mkdir -p {part_info.part_export_dir}/go-use",
-        f"ln -s {part_info.part_src_subdir} {dest_dir}",
+        f"mkdir -p '{part_info.part_export_dir}/go-use'",
+        f"ln -sf '{part_info.part_src_subdir}' '{dest_dir}'",
     ]

--- a/tests/unit/plugins/test_go_use_plugin.py
+++ b/tests/unit/plugins/test_go_use_plugin.py
@@ -157,6 +157,6 @@ def test_get_build_commands(mocker, part_info, part_data):
     dest_dir = part_info.part_export_dir / "go-use" / part_info.part_name
 
     assert plugin.get_build_commands() == [
-        f"mkdir -p {dest_dir}",
-        f"ln -s {part_info.part_build_subdir} {dest_dir}",
+        f"mkdir -p {part_info.part_export_dir}/go-use",
+        f"ln -s {part_info.part_src_subdir} {dest_dir}",
     ]


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

This rearranges the way the `go` plugin and the `go-use` plugin work together. The `go` plugin now checks its dependencies and sets up a workspace if relevant, allowing for a mix of online and offline builds in a single `parts.yaml`. The `go-use` plugin simply creates what's roughly equivalent to a Debian vendor repository.

CRAFT-4530