### PR TITLE
refactor: generalize settings file generation for the maven plugin

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,15 +16,15 @@
 
 """Craft a project from several parts."""
 
-from . import plugins
-from .actions import Action, ActionProperties, ActionType
-from .dirs import ProjectDirs
-from .errors import PartsError
 from .filesystem_mounts import (
     FilesystemMount,
     FilesystemMounts,
     validate_filesystem_mount,
 )
+from . import plugins
+from .actions import Action, ActionProperties, ActionType
+from .dirs import ProjectDirs
+from .errors import PartsError
 from .executor import expand_environment
 from .features import Features
 from .infos import PartInfo, ProjectInfo, StepInfo

--- a/craft_parts/plugins/_maven_util.py
+++ b/craft_parts/plugins/_maven_util.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for Maven projects and settings."""
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from craft_parts import infos
+
+from ._maven_xml import (
+    PROXIES_TEMPLATE,
+    PROXY_CREDENTIALS_TEMPLATE,
+    PROXY_TEMPLATE,
+    SETTINGS_TEMPLATE,
+)
+
+
+def create_maven_settings(*, part_info: infos.PartInfo) -> Path:
+    """Create a Maven configuration file.
+
+    The settings file contains additional configuration for Maven, such
+    as proxy parameters.
+
+    :param part_info: The part info for the part invoking Maven.
+    """
+    settings_path = part_info.part_build_subdir / ".parts/.m2/settings.xml"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+    proxies_element = _get_proxy_config()
+
+    settings_xml = SETTINGS_TEMPLATE.format(proxies_element=proxies_element)
+
+    settings_path.write_text(settings_xml)
+
+    return settings_path
+
+
+def _get_proxy_config() -> str:
+    """Generate an XML string for proxy configurations.
+
+    Reads the environment for information on desired proxy settings and
+    transforms those variables into Maven XML settings entries.
+    """
+    # Transform all environment variables to their lowercase form to support HTTPS_PROXY
+    # vs. https_proxy and such
+    case_insensitive_env = {item[0].lower(): item[1] for item in os.environ.items()}
+
+    proxies: list[str] = []
+    for protocol in ["http", "https"]:
+        env_name = f"{protocol}_proxy"
+        if env_name not in case_insensitive_env:
+            continue
+
+        proxy_url = urlparse(case_insensitive_env[env_name])
+        if proxy_url.username is not None and proxy_url.password is not None:
+            credentials = PROXY_CREDENTIALS_TEMPLATE.format(
+                username=proxy_url.username, password=proxy_url.password
+            )
+        else:
+            credentials = ""
+
+        proxy_element = PROXY_TEMPLATE.format(
+            id=env_name,
+            protocol=protocol,
+            host=proxy_url.hostname,
+            port=proxy_url.port,
+            credentials=credentials,
+            non_proxy_hosts=_get_no_proxy_string(),
+        )
+
+        proxies.append(proxy_element)
+
+    return PROXIES_TEMPLATE.format(proxies="\n".join(proxies))
+
+
+def _get_no_proxy_string() -> str:
+    no_proxy = [k.strip() for k in os.environ.get("no_proxy", "localhost").split(",")]
+    return "|".join(no_proxy)

--- a/craft_parts/plugins/_maven_xml.py
+++ b/craft_parts/plugins/_maven_xml.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""XML templates for Maven project settings."""
+
+from textwrap import dedent
+
+SETTINGS_TEMPLATE = dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <interactiveMode>false</interactiveMode>
+        {proxies_element}
+    </settings>
+""")
+
+PROXIES_TEMPLATE = dedent("""\
+    <proxies>
+        {proxies}
+    </proxies>
+""")
+
+PROXY_TEMPLATE = dedent("""\
+    <proxy>
+        <id>{id}</id>
+        <protocol>{protocol}</protocol>
+        <host>{host}</host>
+        <port>{port}</port>
+        <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>
+        {credentials}
+        <active>true</active>
+    </proxy>
+""")
+
+PROXY_CREDENTIALS_TEMPLATE = dedent("""\
+    <username>{username}</username>
+    <password>{password}</password>
+""")

--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -16,16 +16,13 @@
 
 """The maven plugin."""
 
-import os
 import re
-import xml.etree.ElementTree as ET
-from pathlib import Path
 from typing import Literal, cast
-from urllib.parse import urlparse
 
 from overrides import override
 
 from craft_parts import errors
+from craft_parts.plugins._maven_util import create_maven_settings
 
 from . import validator
 from .java_plugin import JavaPlugin
@@ -122,12 +119,9 @@ class MavenPlugin(JavaPlugin):
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         options = cast(MavenPluginProperties, self._options)
+        settings_path = create_maven_settings(part_info=self._part_info)
 
-        mvn_cmd = [self._maven_executable, "package"]
-        if self._use_proxy():
-            settings_path = self._part_info.part_build_dir / ".parts/.m2/settings.xml"
-            _create_settings(settings_path)
-            mvn_cmd += ["-s", str(settings_path)]
+        mvn_cmd = [self._maven_executable, "package", "-s", str(settings_path)]
 
         return [
             *self._get_mvnw_validation_commands(options=options),
@@ -148,76 +142,3 @@ https://canonical-craft-parts.readthedocs-hosted.com/en/latest/\
 common/craft-parts/reference/plugins/maven_plugin.html'; exit 1;
 }"""
         ]
-
-    def _use_proxy(self) -> bool:
-        env_vars_lower = list(map(str.lower, os.environ.keys()))
-        return any(k in env_vars_lower for k in ("http_proxy", "https_proxy"))
-
-
-def _create_settings(settings_path: Path) -> None:
-    """Create a Maven configuration file.
-
-    The settings file contains additional configuration for Maven, such
-    as proxy parameters.
-
-    :param settings_path: the location the settings file will be created.
-    """
-    settings = ET.Element(
-        "settings",
-        attrib={
-            "xmlns": "http://maven.apache.org/SETTINGS/1.0.0",
-            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-            "xsi:schemaLocation": (
-                "http://maven.apache.org/SETTINGS/1.0.0 "
-                "http://maven.apache.org/xsd/settings-1.0.0.xsd"
-            ),
-        },
-    )
-    element = ET.Element("interactiveMode")
-    element.text = "false"
-    settings.append(element)
-    proxies = ET.Element("proxies")
-
-    for protocol in ("http", "https"):
-        env_name = f"{protocol}_proxy"
-        case_insensitive_env = {item[0].lower(): item[1] for item in os.environ.items()}
-        if env_name not in case_insensitive_env:
-            continue
-
-        proxy_url = urlparse(case_insensitive_env[env_name])
-        proxy = ET.Element("proxy")
-        proxy_tags = [
-            ("id", env_name),
-            ("active", "true"),
-            ("protocol", protocol),
-            ("host", proxy_url.hostname),
-            ("port", str(proxy_url.port)),
-        ]
-        if proxy_url.username is not None and proxy_url.password is not None:
-            proxy_tags.extend(
-                [
-                    ("username", proxy_url.username),
-                    ("password", proxy_url.password),
-                ]
-            )
-        proxy_tags.append(("nonProxyHosts", _get_no_proxy_string()))
-
-        for tag, text in proxy_tags:
-            element = ET.Element(tag)
-            element.text = text
-            proxy.append(element)
-
-        proxies.append(proxy)
-
-    settings.append(proxies)
-    tree = ET.ElementTree(settings)
-    os.makedirs(os.path.dirname(settings_path), exist_ok=True)
-
-    with settings_path.open("w") as file:
-        tree.write(file, encoding="unicode")
-        file.write("\n")
-
-
-def _get_no_proxy_string() -> str:
-    no_proxy = [k.strip() for k in os.environ.get("no_proxy", "localhost").split(",")]
-    return "|".join(no_proxy)


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Upstreams the generation of the Maven settings file to a Maven utilities file in preparation for the maven-use plugin. I followed the lead of how the settings file was generated in [this branch](https://github.com/canonical/craft-parts/blob/4cc452ee31c99f79d96635d2bcc2ed765e7de12b/craft_parts/plugins/_maven_util.py).

The change in `craft_parts/__init__.py` was to fix a circular import error when directly importing `craft_parts.infos`.

CRAFT-4569