### PR TITLE
Work/fix partition prime

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -914,9 +914,8 @@ class PartHandler:
     def _migrate_overlay_files_to_prime(self) -> None:
         """Prime overlay files and create state.
 
-        Files and directories are migrated from stage to prime based on a list
-        of visible overlay entries, including OCI-compatible whiteout files and
-        opaque directories.
+        Files and directories are migrated from stage to prime, including
+        OCI-compatible whiteout files and opaque directories.
         """
         parts_with_overlay = get_parts_with_overlay(part_list=self._part_list)
         if self._part not in parts_with_overlay:
@@ -926,56 +925,53 @@ class PartHandler:
 
         consolidated_states: dict[str | None, MigrationState] = {}
 
-        # Process parts in each partition.
-        for src_partition in self._part_info.partitions or (None,):
+        # Process each partition.
+        for partition in self._part_info.partitions or (None,):
             prime_overlay_state_path = states.get_overlay_migration_state_path(
-                self._part.overlay_dirs[src_partition], Step.PRIME
+                self._part.overlay_dirs[partition], Step.PRIME
             )
 
             # Overlay data is migrated to prime only when the first part declaring overlay
             # parameters is migrated.
             if prime_overlay_state_path.exists():
                 logger.debug(
-                    f"prime overlay migration state exists, not migrating overlay data for partition {src_partition}"
+                    f"prime overlay migration state exists, not migrating overlay data for partition {partition}"
                 )
                 continue
 
-            squasher = _Squasher(
-                # Process layers from top to bottom (reversed)
-                partition=src_partition,
-                filesystem_mount=self._part_info.default_filesystem_mount,
+            stage_overlay_migration_state = states.load_overlay_migration_state(
+                self._part.overlay_dirs[partition], Step.STAGE
             )
-            for part in reversed(parts_with_overlay):
-                logger.debug(
-                    "migrate %s partition part %r layer to prime",
-                    src_partition,
-                    part.name,
-                )
-                squasher.migrate(
-                    refdir=part.part_layer_dirs[src_partition],
-                    srcdir=part.stage_dirs[src_partition],
-                    destdirs=part.prime_dirs,
-                    permissions=part.spec.permissions,
-                )
+            if not stage_overlay_migration_state:
+                continue
 
-            _consolidate_states(
-                consolidated_states=consolidated_states,
-                migrated_files=squasher.migrated_files,
-                migrated_directories=squasher.migrated_directories,
+            srcdir = self._part.dirs.get_stage_dir(partition)
+            destdir = self._part.dirs.get_prime_dir(partition)
+
+            migrated_files, migrated_dirs = migration.migrate_files(
+                files=stage_overlay_migration_state.files,
+                dirs=stage_overlay_migration_state.directories,
+                srcdir=srcdir,
+                destdir=destdir,
+                permissions=self._part.spec.permissions,
             )
 
-            if src_partition == DEFAULT_PARTITION:
+            consolidated_states[partition] = MigrationState(
+                files=migrated_files, directories=migrated_dirs
+            )
+
+            if partition == DEFAULT_PARTITION:
                 for entry in self._part_info.default_filesystem_mount:
                     self._clean_dangling_whiteouts(
                         self._part_info.prime_dirs[entry.device],
-                        set(squasher.migrated_files[entry.device]),
-                        set(squasher.migrated_directories[entry.device]),
+                        migrated_files,
+                        migrated_dirs,
                     )
             else:
                 self._clean_dangling_whiteouts(
-                    self._part_info.prime_dirs[src_partition],
-                    set(squasher.migrated_files[src_partition]),
-                    set(squasher.migrated_directories[src_partition]),
+                    self._part_info.prime_dirs[partition],
+                    migrated_files,
+                    migrated_dirs,
                 )
 
         self._write_overlay_migration_states(consolidated_states, Step.PRIME)
@@ -994,7 +990,9 @@ class PartHandler:
                     step.name,
                 )
                 continue
-            consolidated_states[src_partition].write(step_overlay_state_path)
+            state = consolidated_states.get(src_partition)
+            if state:
+                state.write(step_overlay_state_path)
 
     def _clean_dangling_whiteouts(
         self, prime_dir: Path, migrated_files: set[str], migrated_dirs: set[str]

--- a/tests/unit/features/overlay_partitions/test_executor_part_handler.py
+++ b/tests/unit/features/overlay_partitions/test_executor_part_handler.py
@@ -20,6 +20,7 @@ import pytest
 from craft_parts import errors
 from craft_parts.actions import Action, ActionType
 from craft_parts.executor.part_handler import PartHandler
+from craft_parts.filesystem_mounts import FilesystemMounts
 from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
 from craft_parts.overlays import OverlayManager
 from craft_parts.parts import Part
@@ -532,6 +533,93 @@ class TestOverlayMigration:
         # clean part data
         self._p3_handler.clean_step(step)
         assert Path(f"{step_dir}/file1").exists() is False
+
+
+@pytest.mark.usefixtures("new_dir")
+class TestOverlayMigrationFilesystems:
+    """Overlay migration to stage and prime test cases with a non-default filesystems."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, new_dir, partitions):
+        # pylint: disable=attribute-defined-outside-init
+        filesystem_mounts = FilesystemMounts.unmarshal(
+            {
+                "default": [
+                    {
+                        "mount": "/",
+                        "device": "default",
+                    },
+                    {
+                        "mount": "/foo",
+                        "device": "mypart",
+                    },
+                ]
+            }
+        )
+        p1 = Part(
+            "p1", {"plugin": "nil", "overlay-script": "ls"}, partitions=partitions
+        )
+        p2 = Part(
+            "p2", {"plugin": "nil", "overlay-script": "ls"}, partitions=partitions
+        )
+
+        info = ProjectInfo(
+            application_name="test",
+            cache_dir=new_dir,
+            partitions=partitions,
+            filesystem_mounts=filesystem_mounts,
+        )
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1, p2], base_layer_dir=None
+        )
+
+        self._p1_handler = PartHandler(
+            p1,
+            part_info=PartInfo(info, p1),
+            part_list=[p1, p2],
+            overlay_manager=ovmgr,
+        )
+        self._p2_handler = PartHandler(
+            p2,
+            part_info=PartInfo(info, p2),
+            part_list=[p1, p2],
+            overlay_manager=ovmgr,
+        )
+
+        self._p1_handler._make_dirs()
+        self._p2_handler._make_dirs()
+
+        # populate layers
+        Path(p1.part_layer_dir, "dir1").mkdir()
+        Path(p1.part_layer_dir, "dir1/a").touch()
+        Path(p1.part_layer_dir, "foo").mkdir()
+        Path(p1.part_layer_dir, "foo/bar").touch()
+
+        Path(p2.part_layer_dir, "dir1").mkdir()
+        Path(p2.part_layer_dir, "dir1/baz").touch()
+        Path(p2.part_layer_dir, "foo").mkdir()
+        Path(p2.part_layer_dir, "foo/qux").touch()
+
+    @pytest.mark.parametrize(
+        ("step", "step_dir"), [(Step.STAGE, "stage"), (Step.PRIME, "prime")]
+    )
+    def test_clean_stage_overlay_multiple_parts_with_partitions(self, step, step_dir):
+        _run_step_migration(self._p1_handler, step)
+        _run_step_migration(self._p2_handler, step)
+
+        assert Path(f"{step_dir}/dir1/a").exists()
+        assert Path(f"partitions/mypart/{step_dir}/bar").exists()
+        assert Path(f"{step_dir}/foo").exists()
+        assert Path(f"{step_dir}/dir1/baz").exists()
+        assert Path(f"partitions/mypart/{step_dir}/qux").exists()
+
+        self._p1_handler.clean_step(step)
+        self._p2_handler.clean_step(step)
+        assert Path(f"{step_dir}/dir1/a").exists() is False
+        assert Path(f"partitions/mypart/{step_dir}/bar").exists() is False
+        assert Path(f"{step_dir}/foo").exists() is False
+        assert Path(f"{step_dir}/dir1/baz").exists() is False
+        assert Path(f"partitions/mypart/{step_dir}/qux").exists() is False
 
 
 def _run_step_migration(handler: PartHandler, step: Step) -> None:


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Rework the way to prime content from the overlay. Due to the new feature to distribute content from the overlay to partitions, the content of the default stage directory may not fully reflect the content from the overlay. In this situation, the priming cannot rely on the overlay anymore. 
Adopt a new approach relying on the content of the stage directory and the migration state (to get the list of files/directories coming from the overlay). 
This approach is also closer to the standard way to migrate content.