### PR TITLE
fix(maven-use): always set version

### DIFF
--- a/craft_parts/utils/maven/common.py
+++ b/craft_parts/utils/maven/common.py
@@ -196,18 +196,24 @@ class MavenArtifact:
 
     group_id: str
     artifact_id: str
-    version: str
+    version: str | None
 
     field_name: str = "Dependency"
 
     @classmethod
     def from_element(cls, element: ET.Element, namespaces: dict[str, str]) -> Self:
         """Create a MavenArtifact from an XML artifact element."""
+
+        # We can always just set the version if it's missing, so don't raise
+        try:
+            version = _get_element_text(_find_element(element, "version", namespaces))
+        except MavenXMLError:
+            version = None
+
         group_id = _get_element_text(_find_element(element, "groupId", namespaces))
         artifact_id = _get_element_text(
             _find_element(element, "artifactId", namespaces)
         )
-        version = _get_element_text(_find_element(element, "version", namespaces))
 
         return cls(group_id, artifact_id, version)
 
@@ -266,16 +272,23 @@ class MavenPlugin(MavenArtifact):
         For more information on the default plugin group, see:
         https://maven.apache.org/guides/mini/guide-configuring-plugins.html
         """
-        group_id_element = element.find("groupId", namespaces)
-        if group_id_element is not None:
-            group_id = _get_element_text(group_id_element)
-        else:
+
+        # We can always just set the version if it's missing, so don't raise
+        try:
+            group_id_element = _find_element(element, "groupId", namespaces)
+        except MavenXMLError:
             group_id = "org.apache.maven.plugins"
+        else:
+            group_id = _get_element_text(group_id_element)
+
+        try:
+            version = _get_element_text(_find_element(element, "version", namespaces))
+        except MavenXMLError:
+            version = None
 
         artifact_id = _get_element_text(
             _find_element(element, "artifactId", namespaces)
         )
-        version = _get_element_text(_find_element(element, "version", namespaces))
 
         return cls(group_id, artifact_id, version)
 
@@ -309,7 +322,11 @@ def _get_existing_artifacts(part_info: infos.PartInfo) -> GroupDict:
             art = MavenArtifact.from_pom(pom)
             group_artifacts = result.setdefault(art.group_id, {})
             versions = group_artifacts.setdefault(art.artifact_id, set())
-            versions.add(art.version)
+
+            # Note on cast: technically we can't guarantee that this is a string.
+            # However, in this case, if it is "None" then this is an error that should
+            # be caught and reported by Maven rather than craft parts.
+            versions.add(cast("str", art.version))
 
     return result
 

--- a/craft_parts/utils/maven/common.py
+++ b/craft_parts/utils/maven/common.py
@@ -203,7 +203,6 @@ class MavenArtifact:
     @classmethod
     def from_element(cls, element: ET.Element, namespaces: dict[str, str]) -> Self:
         """Create a MavenArtifact from an XML artifact element."""
-
         # We can always just set the version if it's missing, so don't raise
         try:
             version = _get_element_text(_find_element(element, "version", namespaces))
@@ -272,7 +271,6 @@ class MavenPlugin(MavenArtifact):
         For more information on the default plugin group, see:
         https://maven.apache.org/guides/mini/guide-configuring-plugins.html
         """
-
         # We can always just set the version if it's missing, so don't raise
         try:
             group_id_element = _find_element(element, "groupId", namespaces)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -16,6 +16,15 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+
+X.Y.Z (2025-MM-DD)
+------------------
+
+Bug fixes:
+
+- With the maven-use plugin, do not raise errors if versions are not specified
+  in a project's :file:`pom.xml`.
+
 .. _release-2.14.0:
 
 2.14.0 (2025-06-20)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -22,8 +22,8 @@ X.Y.Z (2025-MM-DD)
 
 Bug fixes:
 
-- With the maven-use plugin, do not raise errors if versions are not specified
-  in a project's :file:`pom.xml`.
+- With the maven-use plugin, don't raise errors if dependency versions aren't specified
+  in the software's :file:`pom.xml` file.
 
 .. _release-2.14.0:
 

--- a/tests/integration/plugins/test_maven_use.py
+++ b/tests/integration/plugins/test_maven_use.py
@@ -77,4 +77,7 @@ def test_maven_use_plugin(new_dir, partitions, monkeypatch, caplog):
         assert f"Updating version of '{artifact}' from '{old}' to '{new}'" in log
 
     # Check that missing versions are filled in by what's available
-    assert f"Setting version of 'org.apache.maven.plugins.maven-shade-plugin' to '{shaded_version}'" in log
+    assert (
+        f"Setting version of 'org.apache.maven.plugins.maven-shade-plugin' to '{shaded_version}'"
+        in log
+    )

--- a/tests/integration/plugins/test_maven_use.py
+++ b/tests/integration/plugins/test_maven_use.py
@@ -70,8 +70,11 @@ def test_maven_use_plugin(new_dir, partitions, monkeypatch, caplog):
     expected_bumps = [
         ("org.starcraft.add", "2.0.0", "2.2.0"),
         ("org.starcraft.print-addition", "1.0.0", "1.1.0"),
-        ("org.apache.maven.plugins.maven-shade-plugin", "X.Y.Z", shaded_version),
     ]
 
+    # Check that versions are adjusted as necessary
     for artifact, old, new in expected_bumps:
         assert f"Updating version of '{artifact}' from '{old}' to '{new}'" in log
+
+    # Check that missing versions are filled in by what's available
+    assert f"Setting version of 'org.apache.maven.plugins.maven-shade-plugin' to '{shaded_version}'" in log

--- a/tests/integration/plugins/test_maven_use/java-main-part/pom.xml
+++ b/tests/integration/plugins/test_maven_use/java-main-part/pom.xml
@@ -27,8 +27,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <!-- invalid version on purpose - must be replaced with the archive one -->
-        <version>X.Y.Z</version>
+        <!-- omitted version on purpose - must be replaced with the archive one -->
         <executions>
           <execution>
             <phase>package</phase>

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -426,7 +426,7 @@ def test_maven_artifact_from_element_no_version() -> None:
 
     assert art.group_id == "org.starcraft"
     assert art.artifact_id == "test"
-    assert art.version == None
+    assert art.version is None
 
 
 def test_maven_plugin_from_element_no_group() -> None:

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -414,6 +414,21 @@ def test_maven_artifact_from_element() -> None:
     assert art.version == "X.Y.Z"
 
 
+def test_maven_artifact_from_element_no_version() -> None:
+    element = ET.fromstring("""\
+        <dependency>
+            <groupId>org.starcraft</groupId>
+            <artifactId>test</artifactId>
+        </dependency>
+        """)  # noqa: S314
+
+    art = MavenArtifact.from_element(element, {})
+
+    assert art.group_id == "org.starcraft"
+    assert art.artifact_id == "test"
+    assert art.version == None
+
+
 def test_maven_plugin_from_element_no_group() -> None:
     element = ET.fromstring("""\
         <dependency>


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

The maven-use plugin will always overwrite the version number of a dependency with whatever is available (unless, of course, what's available is already being used). In the case that a version number isn't specified at all, instead of raising an error, the plugin should just simply write in a version that is available.

CRAFT-4601