### PR TITLE
fix(maven-use): don't duplicate distributionManagement tags

### DIFF
--- a/craft_parts/utils/maven/_xml.py
+++ b/craft_parts/utils/maven/_xml.py
@@ -89,7 +89,6 @@ MIRROR_REPO = dedent("""\
 
 DISTRIBUTION_REPO_TEMPLATE = dedent("""\
     <distributionManagement>
-        <!-- Added by the maven-use plugin -->
         <repository>
         <id>craft</id>
         <name>Craft-managed intermediate repository</name>

--- a/craft_parts/utils/maven/_xml.py
+++ b/craft_parts/utils/maven/_xml.py
@@ -89,6 +89,7 @@ MIRROR_REPO = dedent("""\
 
 DISTRIBUTION_REPO_TEMPLATE = dedent("""\
     <distributionManagement>
+        <!-- Added by the maven-use plugin -->
         <repository>
         <id>craft</id>
         <name>Craft-managed intermediate repository</name>

--- a/craft_parts/utils/maven/common.py
+++ b/craft_parts/utils/maven/common.py
@@ -179,6 +179,12 @@ def update_pom(
             DISTRIBUTION_REPO_TEMPLATE.format(repo_uri=distribution_dir.as_uri())
         )
 
+        # Remove the existing distributionManagement tag if present.
+        # This is okay because we only need to "distribute" to the backstage directory,
+        # so any other project-specific config is irrelevant to this build.
+        if (existing := project.find("distributionManagement", namespaces)) is not None:
+            project.remove(existing)
+
         project.append(distribution_element)
 
     existing = _get_existing_artifacts(part_info)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -24,6 +24,8 @@ Bug fixes:
 
 - With the maven-use plugin, don't raise errors if dependency versions aren't specified
   in the software's :file:`pom.xml` file.
+- With the maven-use plugin, don't create :file:`pom.xml` files with duplicate
+  ``<distributionManagement>`` tags.
 
 .. _release-2.14.0:
 

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -514,6 +514,14 @@ def test_update_pom_no_pom(part_info: PartInfo) -> None:
         update_pom(part_info=part_info, add_distribution=False, self_contained=False)
 
 
+def create_project(part_info: PartInfo, project_xml: str) -> Path:
+    part_info.part_build_subdir.mkdir(parents=True)
+    pom_xml = part_info.part_build_subdir / "pom.xml"
+    pom_xml.write_text(project_xml)
+
+    return pom_xml
+
+
 def test_update_pom_add_distribution(part_info: PartInfo) -> None:
     project_xml = dedent("""\
         <project>
@@ -532,14 +540,47 @@ def test_update_pom_add_distribution(part_info: PartInfo) -> None:
         </project>
     """)
 
-    part_info.part_build_subdir.mkdir(parents=True)
-    pom_xml = part_info.part_build_subdir / "pom.xml"
-    pom_xml.write_text(project_xml)
+    pom_xml = create_project(part_info, project_xml)
 
     update_pom(part_info=part_info, add_distribution=True, self_contained=False)
 
     # Make sure the distribution tag was added
     assert "<distributionManagement>" in pom_xml.read_text()
+    # Make sure it is still valid XML
+    ET.parse(pom_xml)  # noqa: S314
+
+
+def test_update_pom_multiple_add_distribution(part_info: PartInfo) -> None:
+    """Make sure that pre-existing distributionManagement tags are overwritten."""
+
+    project_xml = dedent("""\
+        <project>
+            <dependencies>
+                <dependency>
+                    <groupId>org.starcraft</groupId>
+                    <artifactId>test1</artifactId>
+                    <version>1.0.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.starcraft</groupId>
+                    <artifactId>test2</artifactId>
+                    <version>1.0.0</version>
+                </dependency>
+            </dependencies>
+
+            <distributionManagement>foo</distributionManagement>
+        </project>
+    """)
+
+    pom_xml = create_project(part_info, project_xml)
+
+    update_pom(part_info=part_info, add_distribution=True, self_contained=False)
+
+    pom_xml_contents = pom_xml.read_text()
+    # Make sure only one distributionManagement tag is present
+    assert pom_xml_contents.count("<distributionManagement>") == 1
+    # Make sure it's the new distributionManagement
+    assert "foo" not in pom_xml_contents
     # Make sure it is still valid XML
     ET.parse(pom_xml)  # noqa: S314
 
@@ -562,9 +603,7 @@ def test_update_pom_self_contained(part_info: PartInfo) -> None:
         </project>
     """)
 
-    part_info.part_build_subdir.mkdir(parents=True)
-    pom_xml = part_info.part_build_subdir / "pom.xml"
-    pom_xml.write_text(project_xml)
+    create_project(part_info, project_xml)
 
     with (
         mock.patch(

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -40,7 +40,6 @@ from craft_parts.utils.maven.common import (
     create_maven_settings,
     update_pom,
 )
-from craft_parts.utils.maven._xml import DISTRIBUTION_REPO_TEMPLATE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

In projects that already have a `<distributionManagement>` tag in their `pom.xml` file, maven-use would append a second one instead of modifying the existing one, which caused a build error from Maven. This PR changes the behavior to always overwrite the existing tag, if present. This is acceptable because the tag's purpose is configuring remote indexes to upload builds of the project, but the only place that the maven-use plugin should deploy is to the local backstage directory.

CRAFT-4603