### PR TITLE
perf: Do not import filesystem_mounts class/functions in __init__

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,11 +16,6 @@
 
 """Craft a project from several parts."""
 
-from .filesystem_mounts import (
-    FilesystemMount,
-    FilesystemMounts,
-    validate_filesystem_mount,
-)
 from . import plugins
 from .actions import Action, ActionProperties, ActionType
 from .dirs import ProjectDirs
@@ -56,8 +51,6 @@ __all__ = [
     "Action",
     "ActionProperties",
     "ActionType",
-    "FilesystemMount",
-    "FilesystemMounts",
     "ProjectDirs",
     "PartsError",
     "ProjectInfo",
@@ -69,7 +62,6 @@ __all__ = [
     "plugins",
     "expand_environment",
     "validate_part",
-    "validate_filesystem_mount",
     "part_has_overlay",
     "part_has_slices",
     "part_has_chisel_as_build_snap",

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -25,9 +25,13 @@ from typing import TYPE_CHECKING, Any
 
 import pydantic
 
-from craft_parts import FilesystemMounts, errors
+from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
-from craft_parts.filesystem_mounts import FilesystemMount, FilesystemMountItem
+from craft_parts.filesystem_mounts import (
+    FilesystemMount,
+    FilesystemMountItem,
+    FilesystemMounts,
+)
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 

--- a/craft_parts/packages/__init__.py
+++ b/craft_parts/packages/__init__.py
@@ -18,7 +18,7 @@
 
 from typing import TYPE_CHECKING
 
-from . import errors, snaps
+from . import errors
 from .normalize import fix_pkg_config
 from .platform import is_deb_based, is_dnf_based, is_yum_based
 

--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -24,16 +24,19 @@ import subprocess
 import sys
 from collections.abc import Iterator, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
     cast,
 )
 from urllib import parse
 
-import requests
 import requests_unixsocket  # type: ignore[import]
 from requests import exceptions
 
 from . import errors
+
+if TYPE_CHECKING:
+    from requests.models import Response
 
 # pylint: disable=line-too-long
 _STORE_ASSERTION = [
@@ -344,7 +347,7 @@ def _get_local_snap_file_iter(snap_name: str, *, chunk_size: int) -> Iterator[by
     slug = f"snaps/{parse.quote(snap_name, safe='')}/file"
     url = get_snapd_socket_path_template().format(slug)
     try:
-        snap_file: requests.Response = requests_unixsocket.get(url)
+        snap_file: Response = requests_unixsocket.get(url)
     except exceptions.ConnectionError as err:
         raise errors.SnapdConnectionError(snap_name=snap_name, url=url) from err
     snap_file.raise_for_status()

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -19,21 +19,22 @@
 from __future__ import annotations
 
 import abc
-import pathlib
 import textwrap
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from overrides import override
 
-from craft_parts.actions import ActionProperties
-
-from .properties import PluginProperties
 from .validator import PluginEnvironmentValidator
 
 if TYPE_CHECKING:
     # import module to avoid circular imports in sphinx doc generation
+    import pathlib
+
     from craft_parts import infos
+    from craft_parts.actions import ActionProperties
+
+    from .properties import PluginProperties
 
 
 class Plugin(abc.ABC):

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -17,8 +17,7 @@
 """The Go plugin."""
 
 import logging
-import pathlib
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from overrides import override
 
@@ -27,6 +26,9 @@ from craft_parts import errors
 from . import validator
 from .base import Plugin
 from .properties import PluginProperties
+
+if TYPE_CHECKING:
+    import pathlib
 
 logger = logging.getLogger(__name__)
 

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -23,7 +23,6 @@ import re
 from textwrap import dedent
 from typing import Any, Literal, cast
 
-import requests
 from overrides import override
 from pydantic import model_validator
 from typing_extensions import Self
@@ -163,6 +162,8 @@ class NpmPlugin(Plugin):
         :return: The list of Node.js releases.
         """
         logging.info("Fetching Node.js release index...")
+        import requests
+
         resp = requests.get("https://nodejs.org/dist/index.json", timeout=10)
         resp.raise_for_status()
         versions: list[dict[str, Any]] = resp.json()

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import pydantic
-import requests
 from overrides import overrides
 
 from craft_parts.dirs import ProjectDirs
@@ -300,6 +299,7 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
+        import requests
         try:
             request = requests.get(
                 self.source, stream=True, allow_redirects=True, timeout=3600

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -20,17 +20,19 @@ import contextlib
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from craft_parts import parts, sources, steps
 from craft_parts.features import Features
 from craft_parts.infos import ProjectInfo, ProjectVar
 from craft_parts.parts import Part
-from craft_parts.sources import SourceHandler
 from craft_parts.steps import Step
 
 from .reports import Dependency, DirtyReport, OutdatedReport
 from .states import PullState, StepState, get_step_state_path, load_step_state
+
+if TYPE_CHECKING:
+    from craft_parts.sources import SourceHandler
 
 logger = logging.getLogger(__name__)
 

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -20,8 +20,10 @@ import logging
 import os
 import urllib.parse
 import urllib.request
+from typing import TYPE_CHECKING
 
-import requests
+if TYPE_CHECKING:
+    from requests.models import Response
 
 from craft_parts.utils import os_utils
 
@@ -39,7 +41,7 @@ def is_url(url: str) -> bool:
 
 
 def download_request(
-    request: requests.Response,
+    request: "Response",
     destination: str,
     message: str | None = None,
     total_read: int = 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,6 +330,9 @@ lint.select = [  # Base linting rule selections.
     # The team have chosen to only use type-checking blocks when necessary to prevent circular imports.
     # As such, the only enabled type-checking checks are those that warn of an import that needs to be
     # removed from a type-checking block.
+    "TC001", 
+    "TC002", 
+    "TC003", 
     "TC004",  # Remove imports from type-checking guard blocks if used at runtime
     "TC005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Avoid these imports/exports shave ~150-200ms of importing craft-parts. Moreover these are not used outside of craft-parts.

This can be tested by comparing profiles generated with `python3 -X importtime -mcraft_parts --help 2> craft-parts.prof`