### PR TITLE
perf: Do not import filesystem_mounts object in __init__

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -16,11 +16,6 @@
 
 """Craft a project from several parts."""
 
-from .filesystem_mounts import (
-    FilesystemMount,
-    FilesystemMounts,
-    validate_filesystem_mount,
-)
 from . import plugins
 from .actions import Action, ActionProperties, ActionType
 from .dirs import ProjectDirs
@@ -56,8 +51,6 @@ __all__ = [
     "Action",
     "ActionProperties",
     "ActionType",
-    "FilesystemMount",
-    "FilesystemMounts",
     "ProjectDirs",
     "PartsError",
     "ProjectInfo",
@@ -69,7 +62,6 @@ __all__ = [
     "plugins",
     "expand_environment",
     "validate_part",
-    "validate_filesystem_mount",
     "part_has_overlay",
     "part_has_slices",
     "part_has_chisel_as_build_snap",

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -25,9 +25,13 @@ from typing import TYPE_CHECKING, Any
 
 import pydantic
 
-from craft_parts import FilesystemMounts, errors
+from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
-from craft_parts.filesystem_mounts import FilesystemMount, FilesystemMountItem
+from craft_parts.filesystem_mounts import (
+    FilesystemMount,
+    FilesystemMountItem,
+    FilesystemMounts,
+)
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -30,6 +30,9 @@ Bug fixes:
 
 - With the maven-use plugin in Craft Parts, fix versioning errors caused by native Maven 
   plugins when the project indirectly depends on one.
+- Don't expose :class:`~craft_parts.FilesystemMount` or its related classes and functions
+  in the top-level module. It is unused outside of Craft Parts and adds ~150-200ms to
+  the import time of downstream applications.
 
 Documentation:
 


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Avoid these imports/exports shave ~150-200ms of importing craft-parts. Moreover these are not used outside of craft-parts.

This can be tested by comparing profiles generated with `python3 -X importtime -mcraft_parts --help 2> craft-parts.prof`