### PR TITLE
feat: allow customizations on MavenPlugin

### DIFF
--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -16,6 +16,7 @@
 
 """The maven plugin."""
 
+import pathlib
 import re
 from typing import Literal, cast
 
@@ -132,13 +133,14 @@ class MavenPlugin(JavaPlugin):
         if self_contained:
             update_pom(
                 part_info=self._part_info,
-                add_distribution=True,
+                deploy_to=self._get_deploy_dir(),
                 self_contained=True,
             )
 
         return [
             *self._get_mvnw_validation_commands(options=options),
             " ".join(mvn_cmd + options.maven_parameters),
+            *self._get_extra_maven_commands(settings_path),
             *self._get_java_post_build_commands(),
         ]
 
@@ -155,6 +157,24 @@ https://canonical-craft-parts.readthedocs-hosted.com/en/latest/\
 common/craft-parts/reference/plugins/maven_plugin.html'; exit 1;
 }"""
         ]
+
+    def _get_deploy_dir(self) -> pathlib.Path | None:
+        """Get the path that "mvn deploy" should write to.
+
+        The default implementation returns None, which means that no deploying should
+        happen.
+        """
+        return None
+
+    def _get_extra_maven_commands(self, settings_path: pathlib.Path) -> list[str]:  # noqa: ARG002
+        """Get the commands that should be executed after "mvn package".
+
+        The default implementation is empty - this method is provided as a "hook" for
+        subclasses.
+
+        :param settings_path: The settings file that Maven commands should use.
+        """
+        return []
 
     @classmethod
     @override

--- a/craft_parts/plugins/maven_use_plugin.py
+++ b/craft_parts/plugins/maven_use_plugin.py
@@ -114,7 +114,7 @@ class MavenUsePlugin(JavaPlugin):
         try:
             update_pom(
                 part_info=self._part_info,
-                add_distribution=True,
+                deploy_to=self._part_info.part_export_dir,
                 self_contained=self_contained,
             )
         except MavenXMLError as err:

--- a/craft_parts/utils/maven/common.py
+++ b/craft_parts/utils/maven/common.py
@@ -136,12 +136,13 @@ def _get_no_proxy_string() -> str:
 
 
 def update_pom(
-    *, part_info: infos.PartInfo, add_distribution: bool, self_contained: bool
+    *, part_info: infos.PartInfo, deploy_to: Path | None, self_contained: bool
 ) -> None:
     """Update the POM file of a Maven project.
 
     :param part_info: Information about the invoking part.
-    :param add_distribution: Whether or not to configure the `mvn deploy` location.
+    :param deploy_to: The path to configure the `mvn deploy` location. If None, no path
+        is configured.
     :param self_contained: Whether or not to patch version numbers with what is
         actually available.
     """
@@ -160,10 +161,10 @@ def update_pom(
     for prefix, uri in namespaces.items():
         ET.register_namespace(prefix, uri)
 
-    if add_distribution:
+    if deploy_to is not None:
         # Add a distributionManagement element, to tell "maven deploy" to deploy the
         # artifacts (jars, poms, etc) to the export dir.
-        distribution_dir = part_info.part_export_dir / "maven-use"
+        distribution_dir = deploy_to / "maven-use"
         distribution_element = ET.fromstring(  # noqa: S314, unsafe parsing with xml
             DISTRIBUTION_REPO_TEMPLATE.format(repo_uri=distribution_dir.as_uri())
         )

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -24,6 +24,7 @@ New features:
 - Add the ``self-contained`` build attribute, which constrains a part's build to the
   local build environment. This attribute requires explicit plugin support and can
   currently be declared for parts using the Maven and Maven-use plugins.
+- Add methods to let MavenPlugin subclasses extend the default behavior of the plugin.
 
 Bug fixes:
 

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -510,7 +510,7 @@ def test_maven_artifact_update_versions() -> None:
 @pytest.mark.usefixtures("new_dir")
 def test_update_pom_no_pom(part_info: PartInfo) -> None:
     with pytest.raises(MavenXMLError, match="does not exist"):
-        update_pom(part_info=part_info, add_distribution=False, self_contained=False)
+        update_pom(part_info=part_info, deploy_to=None, self_contained=False)
 
 
 def create_project(part_info: PartInfo, project_xml: str) -> Path:
@@ -521,7 +521,7 @@ def create_project(part_info: PartInfo, project_xml: str) -> Path:
     return pom_xml
 
 
-def test_update_pom_add_distribution(part_info: PartInfo) -> None:
+def test_update_pom_deploy_to(part_info: PartInfo) -> None:
     project_xml = dedent("""\
         <project>
             <dependencies>
@@ -541,7 +541,9 @@ def test_update_pom_add_distribution(part_info: PartInfo) -> None:
 
     pom_xml = create_project(part_info, project_xml)
 
-    update_pom(part_info=part_info, add_distribution=True, self_contained=False)
+    update_pom(
+        part_info=part_info, deploy_to=part_info.part_export_dir, self_contained=False
+    )
 
     # Make sure the distribution tag was added
     assert "<distributionManagement>" in pom_xml.read_text()
@@ -549,7 +551,7 @@ def test_update_pom_add_distribution(part_info: PartInfo) -> None:
     ET.parse(pom_xml)  # noqa: S314
 
 
-def test_update_pom_multiple_add_distribution(part_info: PartInfo) -> None:
+def test_update_pom_multiple_deploy_to(part_info: PartInfo) -> None:
     """Make sure that pre-existing distributionManagement tags are overwritten."""
 
     project_xml = dedent("""\
@@ -573,7 +575,9 @@ def test_update_pom_multiple_add_distribution(part_info: PartInfo) -> None:
 
     pom_xml = create_project(part_info, project_xml)
 
-    update_pom(part_info=part_info, add_distribution=True, self_contained=False)
+    update_pom(
+        part_info=part_info, deploy_to=part_info.part_export_dir, self_contained=False
+    )
 
     pom_xml_contents = pom_xml.read_text()
     # Only one distributionManagement tag is present
@@ -624,7 +628,7 @@ def test_update_pom_self_contained(part_info: PartInfo) -> None:
             "craft_parts.utils.maven.common.MavenParent.update_versions"
         ) as mock_parent,
     ):
-        update_pom(part_info=part_info, add_distribution=False, self_contained=True)
+        update_pom(part_info=part_info, deploy_to=None, self_contained=True)
 
     mock_artifact.assert_called_once()
     mock_plugin.assert_called_once()


### PR DESCRIPTION
This commit adds some "customization points" to the MavenPlugin and related
code that allows subclasses to perform extra operations (in addition to the
default "mvn package") and to "deploy" to different paths.

No changes in the default behavior of the plugin.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
