### PR TITLE
refactor: split _check_for_stage_collisions_per_partition

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -449,6 +449,38 @@ class PartFilesConflict(PartsError):
         super().__init__(brief=brief, details=details)
 
 
+class OverlayStageConflict(PartsError):
+    """A conflict between contents to be overlaid and to be staged from the build step."""
+
+    def __init__(
+        self,
+        *,
+        part_name: str,
+        overlay_part_name: str,
+        conflicting_files: list[str],
+        partition: str | None = None,
+    ) -> None:
+        self.part_name = part_name
+        self.overlay_part_name = overlay_part_name
+        self.conflicting_files = conflicting_files
+        self.partition = partition
+
+        indented_conflicting_files = (f"    {i}" for i in conflicting_files)
+        file_paths = "\n".join(sorted(indented_conflicting_files))
+        partition_info = f" for the {partition!r} partition" if partition else ""
+        brief = (
+            "Failed to stage: parts list the same file "
+            "with different contents or permissions."
+        )
+        details = (
+            f"Part {part_name!r} and the overlay of part {overlay_part_name!r} list the following "
+            f"files{partition_info}, but with different contents or permissions:\n"
+            f"{file_paths}"
+        )
+
+        super().__init__(brief=brief, details=details)
+
+
 class StageFilesConflict(PartsError):
     """Files from a part conflict with files already being staged.
 

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -202,6 +202,7 @@ OverlayMountError
 OverlayPackageNotFound
 OverlayPermissionError
 OverlayPlatformError
+OverlayStageConflict
 OverlayState
 OverlayUnmountError
 Overlayfs

--- a/tests/integration/executor/test_collisions.py
+++ b/tests/integration/executor/test_collisions.py
@@ -13,13 +13,251 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import re
+import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 from craft_parts import LifecycleManager, Step
-from craft_parts.errors import PartFilesConflict
+from craft_parts.errors import OverlayStageConflict, PartFilesConflict
+
+# Different cases of part declarations that must result in a conflict between files/dirs
+# being staged from the regular build, and from the overlay.
+OVERLAY_MUST_COLLIDE_SCENARIOS = {
+    "simple": {
+        # Part A has a file in its install dir, part B overlays the same file
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "B",
+    },
+    "simple after": {
+        # Part A has a file in its install dir, part B overlays the same file; part A
+        # comes explicitly *after* B.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                after: [B]
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "B",
+    },
+    "two overlay parts": {
+        # Part A has a file in its install dir, part B overlays the same file, but
+        # part C comes *after* B and also overlays the file (hiding the one in B)
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  echo "from part C" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "C",
+    },
+    "three overlay parts": {
+        # Similar to "two overlay parts", but the part D that overwrites the conflicting
+        # file is "further away" from part B on the overlay stack
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  echo "from part C" >> $CRAFT_OVERLAY/not-a-conflict.txt
+              D:
+                after: [C]
+                plugin: nil
+                overlay-script: |
+                  echo "from part D" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "D",
+    },
+    "same part": {
+        # Part A has a file in its install dir, and overlays the same file
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from BUILD" >> $CRAFT_PART_INSTALL/conflict.txt
+                overlay-script: |
+                  echo "from OVERLAY" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "A",
+    },
+    "file and directory": {
+        # Part A has a file in its install dir, and overlays the same name as a directory
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from BUILD" >> $CRAFT_PART_INSTALL/conflict
+                overlay-script: |
+                  mkdir $CRAFT_OVERLAY/conflict
+              """),
+        "regular_part": "A",
+        "overlay_part": "A",
+    },
+}
+
+
+# Cases where the overlay and install dirs create items with the same name, but that
+# must *not* result in a collision
+OVERLAY_MUST_NOT_COLLIDE_SCENARIOS = {
+    "simple": {
+        # Part A has a file in its install dir, part B overlays the same file with the
+        # same contents
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is conflict.txt" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "this is conflict.txt" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "layer-hides-file": {
+        # Part A has a file in its install dir, part B overlays the same file with
+        # different contents but part C removes the file from the overlay.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "this is from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  rm $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "layer-hides-dir": {
+        # Part A has a file in its install dir, part B overlays the same name as a dir,
+        # but part C removes the dir from the overlay.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is from part A" >> $CRAFT_PART_INSTALL/conflict
+              B:
+                plugin: nil
+                overlay-script: |
+                  mkdir $CRAFT_OVERLAY/conflict
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  rm -r $CRAFT_OVERLAY/conflict
+              """),
+    },
+    "filtered in stage": {
+        # Part A has a file in its install dir, part B overlays the same file; part A
+        # filters the file through a "stage" declaration
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+                stage:
+                  - "-conflict.txt"
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "filtered in overlay": {
+        # Part A has a file in its install dir, part B overlays the same file; part B
+        # filters the file through an "overlay" declaration
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+                overlay:
+                  - "-conflict.txt"
+              """),
+    },
+}
+
+
+@pytest.fixture
+def run_lifecycle(new_dir, partitions):
+    """Create and run a lifecycle with overlay and optionally partitions."""
+
+    def _run(parts_yaml):
+        base_dir = Path("base")
+        base_dir.mkdir()
+
+        parts = yaml.safe_load(parts_yaml)
+        lf = LifecycleManager(
+            parts,
+            application_name="test_lifecycle",
+            cache_dir=new_dir,
+            base_layer_dir=base_dir,
+            base_layer_hash=b"hash",
+            partitions=partitions,
+        )
+
+        actions = lf.plan(Step.PRIME)
+        with lf.action_executor() as ctx:
+            ctx.execute(actions)
+
+    return _run
 
 
 class TestCollisions:
@@ -91,3 +329,38 @@ class TestCollisions:
                 "Parts 'part2' and 'part1' list the following files, but with different contents or permissions:\n"
                 "    file"
             )
+
+    @pytest.mark.usefixtures(
+        "mock_overlay_support_prerequisites", "add_overlay_feature"
+    )
+    @pytest.mark.parametrize("scenario", list(OVERLAY_MUST_COLLIDE_SCENARIOS.keys()))
+    def test_overlay_must_collide(self, run_lifecycle, partitions, scenario):
+        data = OVERLAY_MUST_COLLIDE_SCENARIOS[scenario]
+        parts_yaml = data["yaml"]
+        regular_part = data["regular_part"]
+        overlay_part = data["overlay_part"]
+
+        partition_message = ""
+        if partitions:
+            partition_message = " for the 'default' partition"
+
+        expected_message = re.escape(
+            f"Part {regular_part!r} and the overlay of part {overlay_part!r} "
+            f"list the following files{partition_message}, "
+            "but with different contents or permissions:"
+        )
+
+        with pytest.raises(OverlayStageConflict, match=expected_message):
+            run_lifecycle(parts_yaml)
+
+    @pytest.mark.usefixtures(
+        "mock_overlay_support_prerequisites", "add_overlay_feature"
+    )
+    @pytest.mark.parametrize(
+        "scenario", list(OVERLAY_MUST_NOT_COLLIDE_SCENARIOS.keys())
+    )
+    def test_overlay_must_not_collide(self, run_lifecycle, partitions, scenario):
+        data = OVERLAY_MUST_NOT_COLLIDE_SCENARIOS[scenario]
+        parts_yaml = data["yaml"]
+
+        run_lifecycle(parts_yaml)


### PR DESCRIPTION
The function did both a) gather the files and permissions per part and b) check the sets of files for each part for conflicts. Split the first bit into a separate function, with no behavior changes, so that we can next include the overlay in conflict resolution.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
