### PR TITLE
[PROTOTYPE] feat: build first the overlay-populating part

### DIFF
--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -20,6 +20,7 @@ import os
 from glob import iglob
 
 from craft_parts import errors, features
+from craft_parts.features import Features
 from craft_parts.utils import path_utils
 from craft_parts.utils.partition_utils import DEFAULT_PARTITION
 
@@ -343,7 +344,7 @@ def _normalize_entry(entry: str, default_partition: str) -> str:
         split_file[1], default_partition
     )
 
-    if partition:
+    if Features().enable_partitions:
         return f"{split_file[0]}({partition})/{inner_path}"
 
     return entry

--- a/craft_parts/executor/filesets.py
+++ b/craft_parts/executor/filesets.py
@@ -228,7 +228,7 @@ def _get_file_list(
     # only include files for the partition
     processed_includes: list[str] = []
     for file in includes:
-        file_partition, file_inner_path = path_utils.get_partition_and_path(
+        file_partition, file_inner_path = path_utils.get_area_and_path(
             file, default_partition
         )
         if file_partition == partition:
@@ -237,7 +237,7 @@ def _get_file_list(
     # only exclude files for the partition
     processed_excludes: list[str] = []
     for file in excludes:
-        file_partition, file_inner_path = path_utils.get_partition_and_path(
+        file_partition, file_inner_path = path_utils.get_area_and_path(
             file, default_partition
         )
         if file_partition == partition:
@@ -339,7 +339,7 @@ def _normalize_entry(entry: str, default_partition: str) -> str:
     # split file into an optional prefix (a hyphen character) and the file
     split_file = (entry[0], entry[1:]) if entry[0] == "-" else ("", entry)
 
-    partition, inner_path = path_utils.get_partition_and_path(
+    partition, inner_path = path_utils.get_area_and_path(
         split_file[1], default_partition
     )
 

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -66,7 +66,7 @@ def organize_files(
         the default partition.
     """
     for key in sorted(file_map, key=lambda x: ["*" in x, x]):
-        src_partition, src_inner_path = path_utils.get_partition_and_path(
+        src_partition, src_inner_path = path_utils.get_area_and_path(
             key, default_partition
         )
 
@@ -90,7 +90,7 @@ def organize_files(
 
         # Remove the leading slash so the path actually joins
         # Also trailing slash is significant, be careful if using pathlib!
-        dst_partition, dst_inner_path = path_utils.get_partition_and_path(
+        dst_partition, dst_inner_path = path_utils.get_area_and_path(
             file_map[key].lstrip("/"),
             default_partition,
         )

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -40,7 +40,11 @@ from craft_parts.packages import platform
 from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
-from craft_parts.utils.partition_utils import DEFAULT_PARTITION, get_partition_dir_map
+from craft_parts.utils.partition_utils import (
+    DEFAULT_PARTITION,
+    OVERLAY_IDENTIFIER,
+    get_partition_dir_map,
+)
 from craft_parts.utils.path_utils import get_partition_and_path
 
 
@@ -915,7 +919,8 @@ class Part:
         """Check if partitions are properly used in a fileset.
 
         If a filepath begins with a parentheses, then the text inside the parentheses
-        must be a valid partition. This is an error.
+        must be a valid partition. This is an error except if the text reference the
+        overlay.
 
         Some filesets must specify a path to avoid ambiguity. For example, the
         following is not allowed:
@@ -950,7 +955,10 @@ class Part:
             match = re.match(partition_pattern, filepath)
             if match:
                 partition = match.group("partition")
-                if str(partition) not in self._partitions:
+                if (
+                    str(partition) not in self._partitions
+                    and str(partition) != OVERLAY_IDENTIFIER
+                ):
                     error_list.append(
                         f"    unknown partition {partition!r} in {filepath!r}"
                     )
@@ -958,7 +966,10 @@ class Part:
                 match = re.match(possible_partition_pattern, filepath)
                 if match:
                     partition = match.group("possible_partition")
-                    if partition in self._partitions:
+                    if (
+                        partition in self._partitions
+                        and str(partition) != OVERLAY_IDENTIFIER
+                    ):
                         warning_list.append(
                             f"    misused partition {partition!r} in {filepath!r}"
                         )

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1084,7 +1084,7 @@ def part_dependencies(
 def part_dependencies_overlay_bootstrap(
     part: Part, *, part_list: list[Part]
 ) -> set[Part]:
-    """Return a set of all the parts upon which the named part depends and bootstraping the overlay.
+    """Return a set of all the parts upon which the named part depends and bootstrapping the overlay.
 
     :param part: The dependent part.
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -45,7 +45,7 @@ from craft_parts.utils.partition_utils import (
     OVERLAY_IDENTIFIER,
     get_partition_dir_map,
 )
-from craft_parts.utils.path_utils import get_partition_and_path
+from craft_parts.utils.path_utils import get_area_and_path
 
 
 class PartSpec(BaseModel):
@@ -975,7 +975,7 @@ class Part:
                         )
 
             if require_inner_path:
-                _, inner_path = get_partition_and_path(filepath, self.default_partition)
+                _, inner_path = get_area_and_path(filepath, self.default_partition)
                 if not inner_path:
                     error_list.append(
                         f"    no path specified after partition in {filepath!r}"

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -858,7 +858,7 @@ class Part:
         return DEFAULT_PARTITION
 
     @property
-    def bootstrap_overlay(self) -> bool:
+    def is_bootstrap_overlay(self) -> bool:
         """Placeholder property indicating if the part bootstraps the overlay.
 
         Must be replaced with a proper heuristic checking the `organize` entries.
@@ -1097,10 +1097,10 @@ def part_dependencies(
     return dependencies
 
 
-def part_dependencies_overlay_bootstrap(
+def dependencies_that_bootstrap_overlay(
     part: Part, *, part_list: list[Part]
 ) -> set[Part]:
-    """Return a set of all the parts upon which the named part depends and bootstrapping the overlay.
+    """Return a set of all the parts upon which the named part depends and that are bootstrapping the overlay.
 
     :param part: The dependent part.
 
@@ -1108,7 +1108,9 @@ def part_dependencies_overlay_bootstrap(
     """
     dependency_names = set(part.dependencies)
 
-    return {p for p in part_list if p.name in dependency_names and p.bootstrap_overlay}
+    return {
+        p for p in part_list if p.name in dependency_names and p.is_bootstrap_overlay
+    }
 
 
 def has_overlay_visibility(
@@ -1125,7 +1127,7 @@ def has_overlay_visibility(
 
     :return: Whether the part has overlay visibility.
     """
-    if (viewers and part in viewers) or part.has_overlay or part.bootstrap_overlay:
+    if (viewers and part in viewers) or part.has_overlay or part.is_bootstrap_overlay:
         return True
 
     if not part.spec.after:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -848,6 +848,14 @@ class Part:
             return self._partitions[0]
         return DEFAULT_PARTITION
 
+    @property
+    def is_overlay_populating(self) -> bool:
+        """Placeholder property indicating if the part populate the overlay.
+
+        Must be replaced with a proper heuristic checking the `organize` entries.
+        """
+        return "populate-overlay" in self.name
+
     def _check_partition_feature(self) -> None:
         """Check if the partitions feature is properly used.
 
@@ -1071,6 +1079,22 @@ def part_dependencies(
             )
 
     return dependencies
+
+
+def part_dependencies_overlay_populating(
+    part: Part, *, part_list: list[Part]
+) -> set[Part]:
+    """Return a set of all the parts upon which the named part depends and populating the overlay.
+
+    :param part: The dependent part.
+
+    :returns: The set of parts the given part depends on.
+    """
+    dependency_names = set(part.dependencies)
+
+    return {
+        p for p in part_list if p.name in dependency_names and p.is_overlay_populating
+    }
 
 
 def has_overlay_visibility(

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -779,6 +779,11 @@ class Part:
         return self.dirs.overlay_dir
 
     @property
+    def overlay_mount_dir(self) -> Path:
+        """Return the overlay mount directory."""
+        return self.dirs.overlay_mount_dir
+
+    @property
     def overlay_dirs(self) -> Mapping[str | None, Path]:
         """A mapping of partition name to partition overlay directory.
 
@@ -1120,7 +1125,7 @@ def has_overlay_visibility(
 
     :return: Whether the part has overlay visibility.
     """
-    if (viewers and part in viewers) or part.has_overlay:
+    if (viewers and part in viewers) or part.has_overlay or part.bootstrap_overlay:
         return True
 
     if not part.spec.after:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -849,12 +849,12 @@ class Part:
         return DEFAULT_PARTITION
 
     @property
-    def is_overlay_populating(self) -> bool:
-        """Placeholder property indicating if the part populate the overlay.
+    def bootstrap_overlay(self) -> bool:
+        """Placeholder property indicating if the part bootstraps the overlay.
 
         Must be replaced with a proper heuristic checking the `organize` entries.
         """
-        return "populate-overlay" in self.name
+        return "bootstrap-overlay" in self.name
 
     def _check_partition_feature(self) -> None:
         """Check if the partitions feature is properly used.
@@ -1081,10 +1081,10 @@ def part_dependencies(
     return dependencies
 
 
-def part_dependencies_overlay_populating(
+def part_dependencies_overlay_bootstrap(
     part: Part, *, part_list: list[Part]
 ) -> set[Part]:
-    """Return a set of all the parts upon which the named part depends and populating the overlay.
+    """Return a set of all the parts upon which the named part depends and bootstraping the overlay.
 
     :param part: The dependent part.
 
@@ -1092,9 +1092,7 @@ def part_dependencies_overlay_populating(
     """
     dependency_names = set(part.dependencies)
 
-    return {
-        p for p in part_list if p.name in dependency_names and p.is_overlay_populating
-    }
+    return {p for p in part_list if p.name in dependency_names and p.bootstrap_overlay}
 
 
 def has_overlay_visibility(

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -69,7 +69,7 @@ class Sequencer:
                 parts.has_overlay_visibility(
                     part, viewers=self._overlay_viewers, part_list=part_list
                 )
-                and not part.bootstrap_overlay
+                and not part.is_bootstrap_overlay
                 # Exclude the part bootstrapping the overlay to avoid infinite
                 # recursion.
             ):
@@ -226,7 +226,7 @@ class Sequencer:
             steps.ovl_bootstrap_dependency_prerequisite_step(step)
         )
         if prerequisite_step_bootstrap_ovl:
-            all_overlay_init_deps = parts.part_dependencies_overlay_bootstrap(
+            all_overlay_init_deps = parts.dependencies_that_bootstrap_overlay(
                 part, part_list=self._part_list
             )
             self._add_deps_actions(

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -65,8 +65,13 @@ class Sequencer:
 
         self._overlay_viewers: set[Part] = set()
         for part in part_list:
-            if parts.has_overlay_visibility(
-                part, viewers=self._overlay_viewers, part_list=part_list
+            if (
+                parts.has_overlay_visibility(
+                    part, viewers=self._overlay_viewers, part_list=part_list
+                )
+                and not part.bootstrap_overlay
+                # Exclude the part bootstraping the overlay to avoid infinite
+                # recursion.
             ):
                 self._overlay_viewers.add(part)
 

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -70,7 +70,7 @@ class Sequencer:
                     part, viewers=self._overlay_viewers, part_list=part_list
                 )
                 and not part.bootstrap_overlay
-                # Exclude the part bootstraping the overlay to avoid infinite
+                # Exclude the part bootstrapping the overlay to avoid infinite
                 # recursion.
             ):
                 self._overlay_viewers.add(part)

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -216,11 +216,35 @@ class Sequencer:
         return None
 
     def _process_dependencies(self, part: Part, step: Step) -> None:
+        pop_prerequisite_step = steps.pop_dependency_prerequisite_step(step)
+        logger.debug(f"############# pop_prerequisite_step: {pop_prerequisite_step}")
+        if pop_prerequisite_step:
+            all_overlay_populating_deps = parts.part_dependencies_overlay_populating(
+                part, part_list=self._part_list
+            )
+            logger.debug(
+                f"############# all_overlay_populating_deps: {all_overlay_populating_deps}"
+            )
+
+            pop_deps = {
+                p
+                for p in all_overlay_populating_deps
+                if self._sm.should_step_run(p, pop_prerequisite_step)
+            }
+            for dep in pop_deps:
+                self._add_all_actions(
+                    target_step=pop_prerequisite_step,
+                    part_names=[dep.name],
+                    reason=f"required to {_step_verb[step]} {part.name!r}",
+                )
+
         prerequisite_step = steps.dependency_prerequisite_step(step)
         if not prerequisite_step:
             return
+        logger.debug(f"prerequisite_step: {prerequisite_step}")
 
         all_deps = parts.part_dependencies(part, part_list=self._part_list)
+        logger.debug(f"############# all_deps: {all_deps}")
         deps = {p for p in all_deps if self._sm.should_step_run(p, prerequisite_step)}
         for dep in deps:
             self._add_all_actions(
@@ -237,7 +261,9 @@ class Sequencer:
         reason: str | None = None,
         rerun: bool = False,
     ) -> None:
+        logger.debug(f"############# _process_dependencies for: {part}")
         self._process_dependencies(part, step)
+        logger.debug(f"############# procesed dependencies for: {part}")
 
         if step == Step.OVERLAY:
             # Make sure all previous layers are in place before we add a new

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -216,7 +216,7 @@ class Sequencer:
         return None
 
     def _process_dependencies(self, part: Part, step: Step) -> None:
-        # Process dependencies bootstraping the overlay
+        # Process dependencies bootstrapping the overlay
         prerequisite_step_bootstrap_ovl = (
             steps.ovl_bootstrap_dependency_prerequisite_step(step)
         )

--- a/craft_parts/steps.py
+++ b/craft_parts/steps.py
@@ -98,7 +98,7 @@ def dependency_prerequisite_step(step: Step) -> Step | None:
 
 
 def ovl_bootstrap_dependency_prerequisite_step(step: Step) -> Step | None:
-    """Obtain the step a given step may depend on when depending on a part bootstraping the overlay.
+    """Obtain the step a given step may depend on when depending on a part bootstrapping the overlay.
 
     :returns: The prerequisite step.
     """

--- a/craft_parts/steps.py
+++ b/craft_parts/steps.py
@@ -95,3 +95,17 @@ def dependency_prerequisite_step(step: Step) -> Step | None:
         return Step.STAGE
 
     return step
+
+
+def pop_dependency_prerequisite_step(step: Step) -> Step | None:
+    """Obtain the step a given step may depend on if depending on an overlay poppulating part.
+
+    :returns: The prerequisite step.
+    """
+    if step < Step.OVERLAY:
+        return None
+
+    if step <= Step.BUILD:
+        return Step.BUILD
+
+    return step

--- a/craft_parts/steps.py
+++ b/craft_parts/steps.py
@@ -97,8 +97,8 @@ def dependency_prerequisite_step(step: Step) -> Step | None:
     return step
 
 
-def pop_dependency_prerequisite_step(step: Step) -> Step | None:
-    """Obtain the step a given step may depend on if depending on an overlay poppulating part.
+def ovl_bootstrap_dependency_prerequisite_step(step: Step) -> Step | None:
+    """Obtain the step a given step may depend on when depending on a part bootstraping the overlay.
 
     :returns: The prerequisite step.
     """

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -24,11 +24,9 @@ from craft_parts import errors, features
 
 # Allow alphanumeric characters, hyphens and slashes, not starting or ending
 # with a hyphen or a slash
-VALID_PARTITION_REGEX = re.compile(
-    r"(?!-|/)(?P<partition_name>[a-z0-9-/]+)(?<!-|/)", re.ASCII
-)
+VALID_AREA_REGEX = re.compile(r"(?!-|/)(?P<area_name>[a-z0-9-/]+)(?<!-|/)", re.ASCII)
 VALID_NAMESPACED_PARTITION_REGEX = re.compile(
-    r"[a-z0-9]+/" + VALID_PARTITION_REGEX.pattern, re.ASCII
+    r"[a-z0-9]+/" + VALID_AREA_REGEX.pattern, re.ASCII
 )
 
 PARTITION_INVALID_MSG = (
@@ -91,10 +89,10 @@ def _is_valid_partition_name(partition: str) -> bool:
 
     :returns: true if the namespaced partition is valid
     """
-    m = re.fullmatch(VALID_PARTITION_REGEX, partition)
-    if not m:
+    match = re.fullmatch(VALID_AREA_REGEX, partition)
+    if not match:
         return False
-    return m.group("partition_name") != OVERLAY_IDENTIFIER
+    return match.group("area_name") != OVERLAY_IDENTIFIER
 
 
 def _is_valid_namespaced_partition_name(partition: str) -> bool:
@@ -104,7 +102,11 @@ def _is_valid_namespaced_partition_name(partition: str) -> bool:
 
     :returns: true if the namespaced partition is valid
     """
-    return bool(re.fullmatch(VALID_NAMESPACED_PARTITION_REGEX, partition))
+    match = re.fullmatch(VALID_NAMESPACED_PARTITION_REGEX, partition)
+    if not match:
+        return False
+
+    return match.group("area_name") != OVERLAY_IDENTIFIER
 
 
 def _validate_partition_naming_convention(partitions: Sequence[str]) -> None:

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -24,7 +24,9 @@ from craft_parts import errors, features
 
 # Allow alphanumeric characters, hyphens and slashes, not starting or ending
 # with a hyphen or a slash
-VALID_PARTITION_REGEX = re.compile(r"(?!-|/)[a-z0-9-/]+(?<!-|/)", re.ASCII)
+VALID_PARTITION_REGEX = re.compile(
+    r"(?!-|/)(?P<partition_name>[a-z0-9-/]+)(?<!-|/)", re.ASCII
+)
 VALID_NAMESPACED_PARTITION_REGEX = re.compile(
     r"[a-z0-9]+/" + VALID_PARTITION_REGEX.pattern, re.ASCII
 )
@@ -35,6 +37,7 @@ PARTITION_INVALID_MSG = (
 )
 
 DEFAULT_PARTITION = "default"
+OVERLAY_IDENTIFIER = "overlay"
 
 
 def validate_partition_names(partitions: Sequence[str] | None) -> None:
@@ -88,7 +91,10 @@ def _is_valid_partition_name(partition: str) -> bool:
 
     :returns: true if the namespaced partition is valid
     """
-    return bool(re.fullmatch(VALID_PARTITION_REGEX, partition))
+    m = re.fullmatch(VALID_PARTITION_REGEX, partition)
+    if not m:
+        return False
+    return m.group("partition_name") != OVERLAY_IDENTIFIER
 
 
 def _is_valid_namespaced_partition_name(partition: str) -> bool:

--- a/craft_parts/utils/path_utils.py
+++ b/craft_parts/utils/path_utils.py
@@ -49,7 +49,7 @@ def get_area_and_path(path: FlexiblePath, default_partition: str) -> AreaPathPai
 
     If the path begins with an area, that is used. Otherwise, the default
     partition is used.
-    If partitions or overlay feature is not enabled, the area will be None.
+    If partitions and overlay feature are not enabled, the area will be None.
     An area can either be a partition or the overlay.
 
     :param path: The filepath to parse.

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -485,6 +485,7 @@ organized
 organizing
 ormal
 os
+ovl
 overlayfs
 packageName
 packahe

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -13,6 +13,7 @@ AntPlugin
 AntPluginEnvironmentValidator
 AntPluginProperties
 AptCache
+AreaPathPair
 Autoconf
 Automake
 Autotools
@@ -224,7 +225,6 @@ PartSpec
 PartSpecificationError
 PartitionError
 PartitionNotFound
-PartitionPathPair
 PartitionUsageError
 PartitionUsageWarning
 PartsError

--- a/tests/unit/executor/test_organize.py
+++ b/tests/unit/executor/test_organize.py
@@ -189,7 +189,7 @@ def organize_and_assert(
             organize_files(
                 part_name="part-name",
                 file_map=organize_map,
-                install_dir_map=install_dirs,
+                dst_dir_map=install_dirs,
                 overwrite=overwrite,
                 default_partition="default",
             )
@@ -199,7 +199,7 @@ def organize_and_assert(
         organize_files(
             part_name="part-name",
             file_map=organize_map,
-            install_dir_map=install_dirs,
+            dst_dir_map=install_dirs,
             overwrite=overwrite,
             default_partition="default",
         )

--- a/tests/unit/features/partitions/executor/test_organize.py
+++ b/tests/unit/features/partitions/executor/test_organize.py
@@ -46,6 +46,17 @@ from tests.unit.executor.test_organize import organize_and_assert
                 r"Files can only be organized from the 'default' partition.*"
             ),
         },
+        # Raise an error for files sourced from the overlay
+        {
+            "organize_map": {
+                "(overlay)/foo": "(our/special-part)/foo1",
+            },
+            "expected": errors.FileOrganizeError,
+            "expected_message": (
+                r".*Cannot organize files from overlay. "
+                r"Files can only be organized from the 'default' partition.*"
+            ),
+        },
         # Files that should have the same name in two different partitions
         {
             "setup_files": ["foo", "bar"],
@@ -207,6 +218,7 @@ def test_organize(new_dir, data):
         "yourpart": new_dir / "partitions/yourpart/parts/part-name/install",
         "our/special-part": new_dir
         / "partitions/our/special-part/parts/part-name/install",
+        "overlay": new_dir / "overlay/overlay",
     }
 
     organize_and_assert(

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -61,7 +61,7 @@ def test_dirs_work_dir_resolving(partitions):
     partitions=strategies.lists(
         strategies.text(
             strategies.sampled_from(string.ascii_lowercase), min_size=1
-        ).filter(lambda x: x != "default"),
+        ).filter(lambda x: x not in {"default", "overlay"}),
         min_size=1,
         unique=True,
     )
@@ -80,7 +80,7 @@ def test_get_stage_dir_with_partitions(partitions):
     partitions=strategies.lists(
         strategies.text(
             strategies.sampled_from(string.ascii_lowercase), min_size=1
-        ).filter(lambda x: x != "default"),
+        ).filter(lambda x: x not in {"default", "overlay"}),
         min_size=1,
         unique=True,
     )

--- a/tests/unit/utils/test_partition_utils.py
+++ b/tests/unit/utils/test_partition_utils.py
@@ -79,6 +79,7 @@ def test_validate_partitions_success_feature_enabled(partitions):
         (["default", "-"], "Partition '-' is invalid."),
         (["default", "woop-"], "Partition 'woop-' is invalid."),
         (["default", "woop."], "Partition 'woop.' is invalid."),
+        (["default", "overlay"], "Partition 'overlay' is invalid."),
         (["default", "/"], "Namespaced partition '/' is invalid."),
         (["default", "test/!!!"], "Namespaced partition 'test/!!!' is invalid."),
         (["default", "test/-"], "Namespaced partition 'test/-' is invalid."),

--- a/tests/unit/utils/test_partition_utils.py
+++ b/tests/unit/utils/test_partition_utils.py
@@ -61,6 +61,7 @@ def test_validate_partitions_failure_feature_disabled(partitions, message):
         ["test1/mypart", "test1/mypart2"],
         ["test/foo-bar", "test/foo-baz"],
         ["test/foo-bar-baz", "test/foo-bar"],
+        ["overlay-but-not-exactly"],
     ],
 )
 def test_validate_partitions_success_feature_enabled(partitions):

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -175,6 +175,7 @@ def test_get_area_compatible_filepath_non_partition(path, path_class):
     assert actual_inner_path == path_class(path)
     assert isinstance(actual_inner_path, path_class)
 
+
 @pytest.mark.parametrize("path_class", PATH_CLASSES)
 @pytest.mark.usefixtures("enable_overlay_feature")
 def test_get_area_compatible_filepath_enabled_overlay(path_class):


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

If a part `foo` organizes content into the overlay AND at least one other part declares a dependency on this part, then the OVERLAY and BUILD steps of this `foo` part run before the OVERLAY step of other dependent parts.