### PR TITLE
refactor: split _check_for_stage_collisions_per_partition

### DIFF
--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -295,6 +295,7 @@ SourceModel
 SourceNotFound
 SourceUpdateUnsupported
 SSL
+StageCandidate
 StageContents
 StageFilesConflict
 StagePackageNotFound


### PR DESCRIPTION
The function did both a) gather the files and permissions per part and b) check the sets of files for each part for conflicts. Split the first bit into a separate function, with no behavior changes, so that we can next include the overlay in conflict resolution.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
