### PR TITLE
fix(overlay): detect conflicts between overlay and install

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -449,6 +449,38 @@ class PartFilesConflict(PartsError):
         super().__init__(brief=brief, details=details)
 
 
+class OverlayStageConflict(PartsError):
+    """A conflict between contents to be overlaid and to be staged from the build step."""
+
+    def __init__(
+        self,
+        *,
+        part_name: str,
+        overlay_part_name: str,
+        conflicting_files: list[str],
+        partition: str | None = None,
+    ) -> None:
+        self.part_name = part_name
+        self.overlay_part_name = overlay_part_name
+        self.conflicting_files = conflicting_files
+        self.partition = partition
+
+        indented_conflicting_files = (f"    {i}" for i in conflicting_files)
+        file_paths = "\n".join(sorted(indented_conflicting_files))
+        partition_info = f" for the {partition!r} partition" if partition else ""
+        brief = (
+            "Failed to stage: parts list the same file "
+            "with different contents or permissions."
+        )
+        details = (
+            f"Part {part_name!r} and the overlay of part {overlay_part_name!r} list the following "
+            f"files{partition_info}, but with different contents or permissions:\n"
+            f"{file_paths}"
+        )
+
+        super().__init__(brief=brief, details=details)
+
+
 class StageFilesConflict(PartsError):
     """Files from a part conflict with files already being staged.
 

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -450,7 +450,7 @@ class PartFilesConflict(PartsError):
 
 
 class OverlayStageConflict(PartsError):
-    """A conflict between contents to be overlaid and to be staged from the build step."""
+    """A conflict between contents to be staged from the overlay and from the build step."""
 
     def __init__(
         self,
@@ -469,7 +469,7 @@ class OverlayStageConflict(PartsError):
         file_paths = "\n".join(sorted(indented_conflicting_files))
         partition_info = f" for the {partition!r} partition" if partition else ""
         brief = (
-            "Failed to stage: parts list the same file "
+            "Failed to stage: parts list the same file or directory "
             "with different contents or permissions."
         )
         details = (

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -202,6 +202,7 @@ OverlayMountError
 OverlayPackageNotFound
 OverlayPermissionError
 OverlayPlatformError
+OverlayStageConflict
 OverlayState
 OverlayUnmountError
 Overlayfs

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -26,6 +26,13 @@ New features:
 - The jlink plugin now has a ``jlink-extra-modules`` parameter to add additional
   modules to OpenJDK image.
 
+Bug fixes:
+
+- Files and directories produced during the Build step are now correctly checked for
+  collisions with Overlay contents during staging. Conflicts can be resolved by using
+  the :ref:`stage <reference-part-properties-stage>` and
+  :ref:`overlay <reference-part-properties-overlay-files>` keys.
+
 For a complete list of commits, check out the `2.20.0`_ release on GitHub.
 
 .. _release-2.19.0:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -28,9 +28,9 @@ New features:
 
 Bug fixes:
 
-- Files and directories produced during the Build step are now correctly checked for
-  collisions with Overlay contents during staging. Conflicts can be resolved by using
-  the :ref:`stage <reference-part-properties-stage>` and
+- Files and directories produced during the build step are now correctly checked for
+  collisions with overlay contents during the staging step. Conflicts can be resolved 
+  with the :ref:`stage <reference-part-properties-stage>` and
   :ref:`overlay <reference-part-properties-overlay-files>` keys.
 
 For a complete list of commits, check out the `2.20.0`_ release on GitHub.

--- a/tests/integration/executor/test_collisions.py
+++ b/tests/integration/executor/test_collisions.py
@@ -13,13 +13,226 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import re
+import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 from craft_parts import LifecycleManager, Step
-from craft_parts.errors import PartFilesConflict
+from craft_parts.errors import OverlayStageConflict, PartFilesConflict
+
+# Different cases of part declarations that must result in a conflict between files/dirs
+# being staged from the regular build, and from the overlay.
+OVERLAY_MUST_COLLIDE_SCENARIOS = {
+    "simple": {
+        # Part A has a file in its install dir, part B overlays the same file
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "B",
+    },
+    "simple after": {
+        # Part A has a file in its install dir, part B overlays the same file; part A
+        # comes explicitly *after* B.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                after: [B]
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "B",
+    },
+    "two overlay parts": {
+        # Part A has a file in its install dir, part B overlays the same file, but
+        # part C comes *after* B and also overlays the file (hiding the one in B)
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  echo "from part C" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "C",
+    },
+    "three overlay parts": {
+        # Similar to "two overlay parts", but the part D that overwrites the conflicting
+        # file is "further away" from part B on the overlay stack
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  echo "from part C" >> $CRAFT_OVERLAY/not-a-conflict.txt
+              D:
+                after: [C]
+                plugin: nil
+                overlay-script: |
+                  echo "from part D" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "D",
+    },
+    "same part": {
+        # Part A has a file in its install dir, and overlays the same file
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from BUILD" >> $CRAFT_PART_INSTALL/conflict.txt
+                overlay-script: |
+                  echo "from OVERLAY" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+        "regular_part": "A",
+        "overlay_part": "A",
+    },
+    "file and directory": {
+        # Part A has a file in its install dir, and overlays the same name as a directory
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from BUILD" >> $CRAFT_PART_INSTALL/conflict
+                overlay-script: |
+                  mkdir $CRAFT_OVERLAY/conflict
+              """),
+        "regular_part": "A",
+        "overlay_part": "A",
+    },
+}
+
+
+# Cases where the overlay and install dirs create items with the same name, but that
+# must *not* result in a collision
+OVERLAY_MUST_NOT_COLLIDE_SCENARIOS = {
+    "simple": {
+        # Part A has a file in its install dir, part B overlays the same file with the
+        # same contents
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is conflict.txt" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "this is conflict.txt" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "layer-hides-file": {
+        # Part A has a file in its install dir, part B overlays the same file with
+        # different contents but part C removes the file from the overlay.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "this is from part B" >> $CRAFT_OVERLAY/conflict.txt
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  rm $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "layer-hides-dir": {
+        # Part A has a file in its install dir, part B overlays the same name as a dir,
+        # but part C removes the dir from the overlay.
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "this is from part A" >> $CRAFT_PART_INSTALL/conflict
+              B:
+                plugin: nil
+                overlay-script: |
+                  mkdir $CRAFT_OVERLAY/conflict
+              C:
+                after: [B]
+                plugin: nil
+                overlay-script: |
+                  rm -r $CRAFT_OVERLAY/conflict
+              """),
+    },
+    "filtered in stage": {
+        # Part A has a file in its install dir, part B overlays the same file; part A
+        # filters the file through a "stage" declaration
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+                stage:
+                  - "-conflict.txt"
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+              """),
+    },
+    "filtered in overlay": {
+        # Part A has a file in its install dir, part B overlays the same file; part B
+        # filters the file through an "overlay" declaration
+        "yaml": textwrap.dedent("""
+            parts:
+              A:
+                plugin: nil
+                override-build: |
+                  echo "from part A" >> $CRAFT_PART_INSTALL/conflict.txt
+              B:
+                plugin: nil
+                overlay-script: |
+                  echo "from part B" >> $CRAFT_OVERLAY/conflict.txt
+                overlay:
+                  - "-conflict.txt"
+              """),
+    },
+}
 
 
 class TestCollisions:
@@ -91,3 +304,58 @@ class TestCollisions:
                 "Parts 'part2' and 'part1' list the following files, but with different contents or permissions:\n"
                 "    file"
             )
+
+    @staticmethod
+    def _run_lifecycle(parts_yaml, new_dir, partitions):
+        """Create and run a lifecycle with overlay and optionally partitions."""
+        base_dir = Path("base")
+        base_dir.mkdir()
+
+        parts = yaml.safe_load(parts_yaml)
+        lf = LifecycleManager(
+            parts,
+            application_name="test_lifecycle",
+            cache_dir=new_dir,
+            base_layer_dir=base_dir,
+            base_layer_hash=b"hash",
+            partitions=partitions,
+        )
+
+        actions = lf.plan(Step.PRIME)
+        with lf.action_executor() as ctx:
+            ctx.execute(actions)
+
+    @pytest.mark.usefixtures(
+        "mock_overlay_support_prerequisites", "add_overlay_feature"
+    )
+    @pytest.mark.parametrize("scenario", list(OVERLAY_MUST_COLLIDE_SCENARIOS.keys()))
+    def test_overlay_must_collide(self, new_dir, partitions, scenario):
+        data = OVERLAY_MUST_COLLIDE_SCENARIOS[scenario]
+        parts_yaml = data["yaml"]
+        regular_part = data["regular_part"]
+        overlay_part = data["overlay_part"]
+
+        partition_message = ""
+        if partitions:
+            partition_message = " for the 'default' partition"
+
+        expected_message = re.escape(
+            f"Part {regular_part!r} and the overlay of part {overlay_part!r} "
+            f"list the following files{partition_message}, "
+            "but with different contents or permissions:"
+        )
+
+        with pytest.raises(OverlayStageConflict, match=expected_message):
+            self._run_lifecycle(parts_yaml, new_dir, partitions)
+
+    @pytest.mark.usefixtures(
+        "mock_overlay_support_prerequisites", "add_overlay_feature"
+    )
+    @pytest.mark.parametrize(
+        "scenario", list(OVERLAY_MUST_NOT_COLLIDE_SCENARIOS.keys())
+    )
+    def test_overlay_must_not_collide(self, new_dir, partitions, scenario):
+        data = OVERLAY_MUST_NOT_COLLIDE_SCENARIOS[scenario]
+        parts_yaml = data["yaml"]
+
+        self._run_lifecycle(parts_yaml, new_dir, partitions)

--- a/tests/integration/lifecycle/test_overlay.py
+++ b/tests/integration/lifecycle/test_overlay.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import textwrap
 from pathlib import Path
 
@@ -24,27 +23,13 @@ import yaml
 from craft_parts import Action, ActionType, Step
 
 
-@pytest.fixture(autouse=True)
-def setup_feature(enable_overlay_feature):
-    return
+# This fixture also enables the overlay Feature.
+pytestmark = pytest.mark.usefixtures("mock_overlay_support_prerequisites")
 
 
 @pytest.fixture
 def fake_call(mocker):
     return mocker.patch("subprocess.check_call")
-
-
-@pytest.fixture(autouse=True)
-def mock_overlay_support_prerequisites(mocker):
-    mocker.patch.object(sys, "platform", "linux")
-    mocker.patch("os.geteuid", return_value=0)
-    mock_refresh = mocker.patch(
-        "craft_parts.overlays.OverlayManager.refresh_packages_list"
-    )
-    yield
-    # Make sure that refresh_packages_list() was *not* called, as it's an expensive call that
-    # overlays without packages do not need.
-    assert not mock_refresh.called
 
 
 class TestOverlayLayerOrder:


### PR DESCRIPTION
This commit enhances the collision detection in the Stage step to also take into account contents coming from the overlay. The standard collision detection was done by comparing the contents of the install directories for the existing parts - this behavior persists, but now we *also* take into account the contents of each overlay-enabled part's layer directory, considering the layer stack to only report collisions between items that would *actually* be staged.

To validate the implementation, this commit adds extensive integration tests for scenarios that *must* collide, plus scenarios that *must not*.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
