### PR TITLE
docs: remove Craft Parts links from docstrings

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -56,9 +56,6 @@ class PartSpec(BaseModel):
 
     During the build step, the plugin prepares the part's files with the build system
     of its language or framework.
-
-    For more details on plugin-specific keys and dependencies, see `Plugins
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/reference/plugins/>`_.
     """
 
     source: str | None = Field(
@@ -360,11 +357,6 @@ class PartSpec(BaseModel):
         description="The files to copy from the part's overly filesystem to the stage directory.",
         examples=["[bin, usr/bin]", "[-etc/cloud/cloud.cfg.d/90_dpkg.cfg]"],
     )
-    """The files to copy from the part's overlay filesystem to the stage directory.
-
-    For more details on file paths, see `Specifying paths
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/explanation/filesets/#filesets-specifying-paths>`_.
-    """
 
     stage_files: list[RelativePathStr] = Field(
         default_factory=lambda: ["*"],
@@ -377,9 +369,6 @@ class PartSpec(BaseModel):
 
     Paths support wildcards (``*``) and must be relative to the working directory where
     they will be used.
-
-    For more details on file paths, see `Specifying paths
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/explanation/filesets/#filesets-specifying-paths>`_.
     """
 
     prime_files: list[RelativePathStr] = Field(
@@ -393,9 +382,6 @@ class PartSpec(BaseModel):
 
     Paths support wildcards (``*``) and must be relative to the working directory where
     they will be used.
-
-    For more details on file paths, see `Specifying paths
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/explanation/filesets/#filesets-specifying-paths>`_.
     """
 
     override_pull: str | None = Field(
@@ -406,10 +392,6 @@ class PartSpec(BaseModel):
     """The commands to run instead of the default behavior of the pull step.
 
     The standard pull step actions can be performed by calling ``craftctl default``.
-
-    For more details on overriding lifecycle steps and using craftctl, see
-    `Override a step
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/how-to/customise-the-build-with-craftctl/#override-a-step>`_.
     """
 
     overlay_script: str | None = Field(
@@ -435,10 +417,6 @@ class PartSpec(BaseModel):
     """The commands to run instead of the default behavior of the build step.
 
     The standard build step actions can be performed by calling ``craftctl default``.
-
-    For more details on overriding lifecycle steps and using craftctl, see
-    `Override a step
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/how-to/customise-the-build-with-craftctl/#override-a-step>`_.
     """
 
     override_stage: str | None = Field(
@@ -451,10 +429,6 @@ class PartSpec(BaseModel):
     """The commands to run instead of the default behavior of the stage step.
 
     The standard stage step actions can be performed by calling ``craftctl default``.
-
-    For more details on overriding lifecycle steps and using craftctl, see
-    `Override a step
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/how-to/customise-the-build-with-craftctl/#override-a-step>`_
     """
 
     override_prime: str | None = Field(
@@ -467,10 +441,6 @@ class PartSpec(BaseModel):
     """The commands to run instead of the default behavior of the prime step.
 
     The standard prime step actions can be performed by calling ``craftctl default``.
-
-    For more details on overriding lifecycle steps and using craftctl, see
-    `Override a step
-    <https://canonical-craft-parts.readthedocs-hosted.com/latest/common/craft-parts/how-to/customise-the-build-with-craftctl/#override-a-step>`_
     """
 
     permissions: list[Permissions] = Field(

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -399,6 +399,7 @@ distros
 dl
 dnf
 docstring
+docstrings
 dotnet
 dst
 emacs

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -26,6 +26,11 @@ New features:
 - The jlink plugin now has a ``jlink-extra-modules`` parameter to add additional
   modules to OpenJDK image.
 
+Documentation:
+
+- Remove all intralinking in the ``PartSpec`` model's docstrings. This allows downstream
+  apps that consume these docstrings to provide their own internal references.
+
 For a complete list of commits, check out the `2.20.0`_ release on GitHub.
 
 .. _release-2.19.0:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -33,8 +33,9 @@ Bug fixes:
 
 Documentation:
 
-- Remove all intralinking in the ``PartSpec`` model's docstrings. This allows downstream
-  apps that consume these docstrings to provide their own internal references.
+- Remove all intralinking in the ``PartSpec`` model's docstrings. This allows
+  downstream apps that consume these docstrings to provide their own internal
+  references.
 
 For a complete list of commits, check out the `2.20.0`_ release on GitHub.
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Remove Craft Parts links from field docstrings

These links should be replaced downstream as internal references to ensure that they are properly versioned and resistant to breakage.