### PR TITLE
docs: clean up 'Part Properties'

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -387,7 +387,11 @@ class PartSpec(BaseModel):
     override_pull: str | None = Field(
         default=None,
         description="The commands to run instead of the default behavior of the pull step.",
-        examples=["|\ncraftctl default\nrm $CRAFT_PART_SRC/pyproject.toml"],
+        examples=[
+            """|
+              craftctl default
+              rm $CRAFT_PART_SRC/pyproject.toml"""
+        ],
     )
     """The commands to run instead of the default behavior of the pull step.
 
@@ -398,7 +402,10 @@ class PartSpec(BaseModel):
         default=None,
         description="The commands to run after the part's overlay packages are installed.",
         examples=[
-            "|\nrm -f ${CRAFT_OVERLAY}/usr/bin/vi ${CRAFT_OVERLAY}/usr/bin/vim*\nrm -f ${CRAFT_OVERLAY}/usr/bin/emacs*\nrm -f ${CRAFT_OVERLAY}/bin/nano"
+            """|
+              rm -f ${CRAFT_OVERLAY}/usr/bin/vi ${CRAFT_OVERLAY}/usr/bin/vim*
+              rm -f ${CRAFT_OVERLAY}/usr/bin/emacs*
+              rm -f ${CRAFT_OVERLAY}/bin/nano"""
         ],
     )
     """The commands to run after the part's overlay packages are installed.
@@ -411,7 +418,10 @@ class PartSpec(BaseModel):
         default=None,
         description="The commands to run instead of the default behavior of the build step.",
         examples=[
-            "|\ncd cmd/webhook\nmkdir $CRAFT_PART_INSTALL/ko-app\ngo build -o $CRAFT_PART_INSTALL/ko-app/webhook -a ."
+            """|
+              cd cmd/webhook
+              mkdir $CRAFT_PART_INSTALL/ko-app
+              go build -o $CRAFT_PART_INSTALL/ko-app/webhook -a ."""
         ],
     )
     """The commands to run instead of the default behavior of the build step.
@@ -423,7 +433,9 @@ class PartSpec(BaseModel):
         default=None,
         description="The commands to run instead of the default behavior of the stage step.",
         examples=[
-            '|\ncraftctl default\nchown -R 499 "${CRAFT_PART_INSTALL}/entrypoint.sh"'
+            '''|
+              craftctl default
+              chown -R 499 "${CRAFT_PART_INSTALL}/entrypoint.sh"'''
         ],
     )
     """The commands to run instead of the default behavior of the stage step.
@@ -435,7 +447,10 @@ class PartSpec(BaseModel):
         default=None,
         description="The commands to run instead of the default behavior of the prime step.",
         examples=[
-            "|\ncraftctl default\nmkdir -p $CRAFT_PRIME/var/lib/mysql\nmkdir -p $CRAFT_PRIME/var/lib/mysqld"
+            """|
+              craftctl default
+              mkdir -p $CRAFT_PRIME/var/lib/mysql
+              mkdir -p $CRAFT_PRIME/var/lib/mysqld"""
         ],
     )
     """The commands to run instead of the default behavior of the prime step.

--- a/docs/common/craft-parts/reference/part_properties.rst
+++ b/docs/common/craft-parts/reference/part_properties.rst
@@ -10,7 +10,9 @@ a part.
 Top-level keys
 --------------
 
-.. kitbash-field:: parts.PartSpec plugin
+.. py:currentmodule:: craft_parts.parts
+
+.. kitbash-field:: PartSpec plugin
     :label: reference-part-properties-plugin
 
 
@@ -22,34 +24,34 @@ Pull step keys
 The following keys define the part's external dependencies and how they are retrieved
 from the declared location.
 
-.. kitbash-field:: parts.PartSpec source
+.. kitbash-field:: PartSpec source
     :label: reference-part-properties-source
 
-.. kitbash-field:: parts.PartSpec source_type
+.. kitbash-field:: PartSpec source_type
     :label: reference-part-properties-source-type
 
-.. kitbash-field:: parts.PartSpec source_checksum
+.. kitbash-field:: PartSpec source_checksum
     :label: reference-part-properties-source-checksum
 
-.. kitbash-field:: parts.PartSpec source_branch
+.. kitbash-field:: PartSpec source_branch
     :label: reference-part-properties-source-branch
 
-.. kitbash-field:: parts.PartSpec source_tag
+.. kitbash-field:: PartSpec source_tag
     :label: reference-part-properties-source-tag
 
-.. kitbash-field:: parts.PartSpec source_commit
+.. kitbash-field:: PartSpec source_commit
     :label: reference-part-properties-source-commit
 
-.. kitbash-field:: parts.PartSpec source_depth
+.. kitbash-field:: PartSpec source_depth
     :label: reference-part-properties-source-depth
 
-.. kitbash-field:: parts.PartSpec source_submodules
+.. kitbash-field:: PartSpec source_submodules
     :label: reference-part-properties-source-submodules
 
-.. kitbash-field:: parts.PartSpec source_subdir
+.. kitbash-field:: PartSpec source_subdir
     :label: reference-part-properties-source-subdir
 
-.. kitbash-field:: parts.PartSpec override_pull
+.. kitbash-field:: PartSpec override_pull
     :label: reference-part-properties-override-pull
 
 
@@ -62,13 +64,13 @@ For craft applications that support filesystem overlays, the following keys modi
 part's overlay layer and determine how the layer's contents are represented in the stage
 directory.
 
-.. kitbash-field:: parts.PartSpec overlay_files
+.. kitbash-field:: PartSpec overlay_files
     :label: reference-part-properties-overlay-files
 
-.. kitbash-field:: parts.PartSpec overlay_packages
+.. kitbash-field:: PartSpec overlay_packages
     :label: reference-part-properties-overlay-packages
 
-.. kitbash-field:: parts.PartSpec overlay_script
+.. kitbash-field:: PartSpec overlay_script
     :label: reference-part-properties-overlay-script
 
 
@@ -80,25 +82,25 @@ Build step keys
 The following keys modify the build step's behavior and the contents of the part's
 build environment.
 
-.. kitbash-field:: parts.PartSpec after
+.. kitbash-field:: PartSpec after
     :label: reference-part-properties-after
 
-.. kitbash-field:: parts.PartSpec disable_parallel
+.. kitbash-field:: PartSpec disable_parallel
     :label: reference-part-properties-disable-parallel
 
-.. kitbash-field:: parts.PartSpec build_environment
+.. kitbash-field:: PartSpec build_environment
     :label: reference-part-properties-build-environment
 
-.. kitbash-field:: parts.PartSpec build_packages
+.. kitbash-field:: PartSpec build_packages
     :label: reference-part-properties-build-packages
 
-.. kitbash-field:: parts.PartSpec build_snaps
+.. kitbash-field:: PartSpec build_snaps
     :label: reference-part-properties-build-snaps
 
-.. kitbash-field:: parts.PartSpec organize_files
+.. kitbash-field:: PartSpec organize_files
     :label: reference-part-properties-organize
 
-.. kitbash-field:: parts.PartSpec override_build
+.. kitbash-field:: PartSpec override_build
     :label: reference-part-properties-override-build
 
 
@@ -110,17 +112,17 @@ Stage step keys
 The following keys modify the stage step's behavior and determine how files from the
 part's build directory are represented in the stage directory.
 
-.. kitbash-field:: parts.PartSpec stage_files
+.. kitbash-field:: PartSpec stage_files
     :override-type: list[str]
     :label: reference-part-properties-stage
 
-.. kitbash-field:: parts.PartSpec stage_packages
+.. kitbash-field:: PartSpec stage_packages
     :label: reference-part-properties-stage-packages
 
-.. kitbash-field:: parts.PartSpec stage_snaps
+.. kitbash-field:: PartSpec stage_snaps
     :label: reference-part-properties-stage-snaps
 
-.. kitbash-field:: parts.PartSpec override_stage
+.. kitbash-field:: PartSpec override_stage
     :label: reference-part-properties-override-stage
 
 
@@ -132,11 +134,11 @@ Prime step keys
 The following keys modify the prime step's behavior and determine how the contents
 of the stage directory are reflected in the final payload.
 
-.. kitbash-field:: parts.PartSpec prime_files
+.. kitbash-field:: PartSpec prime_files
     :override-type: list[str]
     :label: reference-part-properties-prime
 
-.. kitbash-field:: parts.PartSpec override_prime
+.. kitbash-field:: PartSpec override_prime
     :label: reference-part-properties-override-prime
 
 
@@ -145,13 +147,15 @@ of the stage directory are reflected in the final payload.
 Permissions keys
 ----------------
 
-.. kitbash-field:: parts.PartSpec permissions
+.. kitbash-field:: PartSpec permissions
     :label: reference-part-properties-permissions
 
-.. kitbash-field:: permissions.Permissions path
+.. py:currentmodule:: craft_parts.permissions
 
-.. kitbash-field:: permissions.Permissions owner
+.. kitbash-field:: Permissions path
 
-.. kitbash-field:: permissions.Permissions group
+.. kitbash-field:: Permissions owner
 
-.. kitbash-field:: permissions.Permissions mode
+.. kitbash-field:: Permissions group
+
+.. kitbash-field:: Permissions mode

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,9 +114,6 @@ github_repository = "craft-parts"
 project_dir = pathlib.Path(__file__).parents[1].resolve()
 sys.path.insert(0, str(project_dir.absolute()))
 
-model_dir = (project_dir / "craft_parts").resolve()
-sys.path.append(str(model_dir.absolute()))
-
 def run_apidoc(_):
     import os
     import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ apt-questing = [
 ]
 docs = [
     "canonical-sphinx",
-    "pydantic-kitbash==0.0.6",
+    "pydantic-kitbash==0.0.7",
     "setuptools",  # Missing from sphinxcontrib-details-directive,
     # see https://github.com/sphinx-contrib/sphinxcontrib-details-directive/issues/5
     "sphinx",

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ requires-dist = [
     { name = "mypy", extras = ["reports"], marker = "extra == 'dev'", specifier = "~=1.14.1" },
     { name = "overrides", specifier = "!=7.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-kitbash", marker = "extra == 'docs'", specifier = "==0.0.6" },
+    { name = "pydantic-kitbash", marker = "extra == 'docs'", specifier = "==0.0.7" },
     { name = "pydocstyle", marker = "extra == 'dev'" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "~=5.3" },
     { name = "pylint", marker = "extra == 'tics'" },
@@ -1166,7 +1166,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-kitbash"
-version = "0.0.6"
+version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -1174,9 +1174,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/48066291bb9db968d42d6419fa666be077c893d17cdca0eac44cedb2e3d1/pydantic_kitbash-0.0.6.tar.gz", hash = "sha256:60b18ce727f06b6c5a3f8db5675bb6c423449bb59832c3e04cfef4b1568a84e9", size = 124406, upload-time = "2025-07-03T19:24:33.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/b9/630281fa690b2449e70d59ce221c91d9633571c4a7c2dcd8469a59a8c7cc/pydantic_kitbash-0.0.7.tar.gz", hash = "sha256:14eda8a87401b09d746e1ad4157248d8c0d1841803bf609600143e567a687551", size = 131893, upload-time = "2025-08-01T16:26:32.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/4e/4f492ee0d832eb9d8ebd9915e35bff6fd09d658bc6fdb1f31d70495492cf/pydantic_kitbash-0.0.6-py3-none-any.whl", hash = "sha256:e16fa65ebfebe7d295e9b476641e253e02b18686e52bedc2ec65c46421d9875d", size = 13156, upload-time = "2025-07-03T19:24:32.342Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/4a05fbb8f72ae86060430e55349e1d504ee73973e9a767aeb9ecaf85a447/pydantic_kitbash-0.0.7-py3-none-any.whl", hash = "sha256:4ab60369cb8b3cbf289724df295a514bb309d2cb669d1d0c6d1eafaacf530ec5", size = 13645, upload-time = "2025-08-01T16:26:29.879Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

* Update Kitbash to v0.0.7
* Fix multiline field examples
* Remove `craft_parts` module from `sys.path`
* Clean up 'Part Properties' by declaring `..py:currentmodule::`