### PR TITLE
feat: support nested project variables

### DIFF
--- a/craft_parts/__init__.py
+++ b/craft_parts/__init__.py
@@ -22,7 +22,7 @@ from .dirs import ProjectDirs
 from .errors import PartsError
 from .executor import expand_environment
 from .features import Features
-from .infos import PartInfo, ProjectInfo, StepInfo
+from .infos import PartInfo, ProjectInfo, ProjectVar, ProjectVarInfo, StepInfo
 from .lifecycle_manager import LifecycleManager
 from .parts import (
     Part,
@@ -51,10 +51,12 @@ __all__ = [
     "Action",
     "ActionProperties",
     "ActionType",
-    "ProjectDirs",
-    "PartsError",
-    "ProjectInfo",
     "PartInfo",
+    "PartsError",
+    "ProjectDirs",
+    "ProjectInfo",
+    "ProjectVar",
+    "ProjectVarInfo",
     "StepInfo",
     "LifecycleManager",
     "Part",

--- a/craft_parts/actions.py
+++ b/craft_parts/actions.py
@@ -16,14 +16,16 @@
 
 """Definitions of lifecycle actions and action types."""
 
+from __future__ import annotations
+
 import enum
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from craft_parts.steps import Step
+from craft_parts.infos import ProjectVarInfo
 
 if TYPE_CHECKING:
-    from craft_parts.infos import ProjectVar
+    from craft_parts.steps import Step
 
 
 @enum.unique
@@ -82,5 +84,5 @@ class Action:
     step: Step
     action_type: ActionType = ActionType.RUN
     reason: str | None = None
-    project_vars: dict[str, "ProjectVar"] | None = None
+    project_vars: ProjectVarInfo = field(default_factory=ProjectVarInfo)
     properties: ActionProperties = field(default=ActionProperties())

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -210,11 +210,9 @@ class Executor:
             logger.debug("Skip execution of %s (because %s)", action, action.reason)
             # update project variables if action is skipped
             if action.project_vars:
-                for var, pvar in action.project_vars.items():
-                    if pvar.updated:
-                        self._project_info.set_project_var(
-                            var, pvar.value, raw_write=True, part_name=action.part_name
-                        )
+                self._project_info.project_vars.update_from(
+                    action.project_vars, action.part_name
+                )
             return
 
         if action.step == Step.STAGE:

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -135,7 +135,7 @@ class ProjectVar(pydantic.BaseModel):
         """Create a dictionary containing the project var data.
 
         :param attr: If provided, return the bare attribute instead of a
-        dictionary of all attributes.
+            dictionary of all attributes.
 
         :return: The newly created dictionary or a specific attribute.
         """
@@ -188,9 +188,9 @@ class ProjectVarInfo(pydantic.RootModel):
         """Create a dictionary containing the project var info data.
 
         :param attr: The name of a ProjectVar attribute to return in place
-        of the ProjectVar itself. This is useful for:
-          - the StateManager in craft-parts which only needs part names
-          - a PackageService in a downstream application which only needs values
+            of the ProjectVar itself. This is useful for:
+            - the StateManager in craft-parts which only needs part names
+            - a PackageService in a downstream application which only needs values
 
         :return: The newly created dictionary.
         """

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import logging
 import platform
 import re
+import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 import pydantic
 from typing_extensions import Self
@@ -37,14 +38,13 @@ from craft_parts.filesystem_mounts import (
 from craft_parts.utils.partition_utils import DEFAULT_PARTITION, is_default_partition
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Sequence, ValuesView
 
     from craft_parts.parts import Part
     from craft_parts.state_manager import states
     from craft_parts.steps import Step
 
 logger = logging.getLogger(__name__)
-
 
 # Architecture name translation from platform to deb/snap.
 _PLATFORM_MACHINE_TO_DEB = {
@@ -90,8 +90,53 @@ _var_name_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 class ProjectVar(pydantic.BaseModel):
     """A project variable that can be updated using craftctl."""
 
-    value: str
+    model_config = pydantic.ConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+        alias_generator=lambda s: s.replace("_", "-"),
+        populate_by_name=True,
+    )
+
+    value: Annotated[
+        str | None,
+        pydantic.Field(
+            # to handle unquoted versions
+            coerce_numbers_to_str=True,
+        ),
+    ] = None
+    """The value of the project variable."""
+
     updated: bool = False
+    """Whether the variable has already been updated."""
+
+    part_name: str | None = None
+    """The name of the part that can update the project variable."""
+
+    @classmethod
+    def unmarshal(cls, data: dict[str, Any]) -> ProjectVar:
+        """Create and populate a new ProjectVar object from a dict.
+
+        The unmarshal method validates entries in the input dict, populating
+        the corresponding fields in the data object.
+
+        :param data: The dict to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dict.
+        :raise pydantic.ValidationError: If the data fails validation.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("Project variable must be a dictionary.")
+
+        return cls.model_validate(data)
+
+    def marshal(self) -> dict[str, Any]:
+        """Create a dictionary containing the project var data.
+
+        :return: The newly created dictionary.
+        """
+        return self.model_dump(mode="json", by_alias=True)
 
 
 class ProjectVarInfo(pydantic.RootModel):
@@ -101,14 +146,18 @@ class ProjectVarInfo(pydantic.RootModel):
     Data is accessed with structured paths.
     """
 
-    root: dict[str, ProjectVar | ProjectVarInfo]
+    root: dict[str, ProjectVar | ProjectVarInfo] = {}
     """A nested dictionary of ProjectVars."""
 
-    def __getitem__(self, item: str) -> ProjectVar | ProjectVarInfo:
-        return self.root[item]
+    def __getitem__(self, key: str) -> ProjectVar | ProjectVarInfo:
+        return self.root[key]
 
     def __setitem__(self, key: str, value: ProjectVar | ProjectVarInfo) -> None:
         self.root[key] = value
+
+    def values(self) -> ValuesView[ProjectVar | ProjectVarInfo]:
+        """Get values of the project vars."""
+        return self.root.values()
 
     @classmethod
     def unmarshal(cls, data: dict[str, Any]) -> ProjectVarInfo:
@@ -135,6 +184,26 @@ class ProjectVarInfo(pydantic.RootModel):
         :return: The newly created dictionary.
         """
         return cast(dict[str, Any], self.model_dump(by_alias=True))
+
+    def marshal_one_attribute(self, attr: str) -> dict[str, Any]:
+        """Marshal the data, but only return one attribute of the ProjectVar.
+
+        This is useful for:
+          - the StateManager in craft-parts which only needs part names
+          - a PackageService in a downstream application which only needs values
+
+        :param attr: The name of the ProjectVar attribute to retain.
+
+        :returns: A nested dictionary of the attribute.
+        """
+        result: dict[str, Any] = {}
+        for key, value in self.root.items():
+            if isinstance(value, ProjectVarInfo):
+                result[key] = value.marshal_one_attribute(attr)
+            elif isinstance(value, ProjectVar):
+                dumped = value.model_dump(include={attr})
+                result[key] = dumped.get(attr)
+        return result
 
     def has_key(self, *keys: str) -> bool:
         """Check if a key exists.
@@ -283,6 +352,33 @@ class ProjectVarInfo(pydantic.RootModel):
 
         self._set(*remaining, data=data_at_key, value=value, overwrite=overwrite)
 
+    def update_from(self, other: ProjectVarInfo, part_name: str) -> None:
+        """Update ProjectVars from another ProjectVarInfo instance for a particular part.
+
+        This is useful when updating the Lifecycle's ProjectVarInfo with data from a state file.
+
+        :param part_name: Only ProjectVars with this part name are updated.
+
+        :raises TypeError: If the structure is not identical.
+        """
+        for key, other_value in other.root.items():
+            self_value = self.root.get(key)
+
+            if isinstance(self_value, ProjectVar) and isinstance(
+                other_value, ProjectVar
+            ):
+                if other_value.updated and other_value.part_name == part_name:
+                    self_value.value = other_value.value
+                    self_value.updated = True
+            elif isinstance(self_value, ProjectVarInfo) and isinstance(
+                other_value, ProjectVarInfo
+            ):
+                self_value.update_from(other_value, part_name)
+            else:
+                raise TypeError(
+                    "Cannot update ProjectVarInfo because the structure doesn't match."
+                )
+
     def _validate_keys(self, *keys: str) -> None:
         """Validate the keys.
 
@@ -316,7 +412,10 @@ class ProjectInfo:
     :param project_name: The name of the project.
     :param project_vars_part_name: Project variables can be set only if
         the part name matches this name.
-    :param project_vars: A dictionary containing the project variables.
+    :param project_vars: A nested dictionary containing project variables and the
+        part that can update each variable. Project variables can also be defined with
+        a deprecated API where `project_vars` must be a flat (not-nested) dictionary and
+        `project_vars_part_name` defines the part that can update all project variables.
     :param custom_args: Any additional arguments defined by the application
         when creating a :class:`LifecycleManager`.
     :param partitions: A list of partitions.
@@ -335,7 +434,7 @@ class ProjectInfo:
         project_dirs: ProjectDirs | None = None,
         project_name: str | None = None,
         project_vars_part_name: str | None = None,
-        project_vars: dict[str, str] | None = None,
+        project_vars: dict[str, str] | ProjectVarInfo | None = None,
         partitions: list[str] | None = None,
         filesystem_mounts: FilesystemMounts | None = None,
         base_layer_dir: Path | None = None,
@@ -348,8 +447,6 @@ class ProjectInfo:
         if not project_dirs:
             project_dirs = ProjectDirs(partitions=partitions)
 
-        pvars = project_vars or {}
-
         self._application_name = application_name
         self._cache_dir = Path(cache_dir).expanduser().resolve()
         self._host_arch = _get_host_architecture()
@@ -360,7 +457,9 @@ class ProjectInfo:
         self._dirs = project_dirs
         self._project_name = project_name
         self._project_vars_part_name = project_vars_part_name
-        self._project_vars = {k: ProjectVar(value=v) for k, v in pvars.items()}
+        self._project_vars = self._get_project_var_info(
+            project_vars, project_vars_part_name
+        )
         self._partitions = partitions
         self._filesystem_mounts = filesystem_mounts
         self._custom_args = custom_args
@@ -369,6 +468,46 @@ class ProjectInfo:
         self.global_environment: dict[str, str] = {}
 
         self.execution_finished = False
+
+    def _get_project_var_info(
+        self,
+        project_vars: dict[str, str] | ProjectVarInfo | None,
+        part_name: str | None,
+    ) -> ProjectVarInfo:
+        """Get a ProjectVarInfo.
+
+        :param project_vars: Either a ProjectVarInfo instance or a dictionary containing
+        project variables. The latter type is deprecated.
+        :param part_name: The name of the part that can set the variables. This is a deprecated
+        parameter and is ignored when using a ProjectVarInfo is provided.
+
+        :returns: A ProjectVarInfo instance.
+
+        :raises RuntimeError: If the deprecated API is mixed with the new API.
+        """
+        if isinstance(project_vars, ProjectVarInfo):
+            if part_name:
+                raise RuntimeError(
+                    "Cannot handle 'project_vars' of type ProjectVarInfo and 'project_vars_part_name'. "
+                    "Do not provide the deprecated 'project_vars_part_name' parameter."
+                )
+            return project_vars
+
+        if project_vars:
+            warnings.warn(
+                DeprecationWarning(
+                    "Using deprecated API to define project variables. "
+                    "Provide ProjectVarInfo instead."
+                ),
+                stacklevel=2,
+            )
+
+        return ProjectVarInfo.unmarshal(
+            {
+                key: ProjectVar(value=value, part_name=part_name).marshal()
+                for key, value in (project_vars or {}).items()
+            }
+        )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
         if hasattr(self._dirs, name):
@@ -460,8 +599,20 @@ class ProjectInfo:
         return self._project_name
 
     @property
+    def project_vars(self) -> ProjectVarInfo:
+        """Return the project vars."""
+        return self._project_vars
+
+    @property
     def project_vars_part_name(self) -> str | None:
         """Return the name of the part that can set project vars."""
+        warnings.warn(
+            DeprecationWarning(
+                "'ProjectInfo.project_vars_part_name' is deprecated. "
+                "Use 'ProjectInfo.project_vars' instead."
+            ),
+            stacklevel=2,
+        )
         return self._project_vars_part_name
 
     @property
@@ -584,27 +735,26 @@ class ProjectInfo:
             part name is specified and the variable is set from a different part.
         """
         self._ensure_valid_variable_name(name)
+        keys = name.split(".")
+        project_var = self._project_vars.get(*keys)
 
         if raw_write:
-            self._project_vars[name].value = value
-            self._project_vars[name].updated = True
+            self._project_vars.set(*keys, value=value, overwrite=raw_write)
             return
 
-        if self._project_vars[name].updated:
+        if project_var.updated:
             raise RuntimeError(f"variable {name!r} can be set only once")
 
-        if self._project_vars_part_name == part_name:
-            self._project_vars[name].value = value
-            self._project_vars[name].updated = True
-        elif not self._project_vars_part_name:
+        if project_var.part_name == part_name:
+            self._project_vars.set(*keys, value=value)
+        elif not project_var.part_name:
             raise RuntimeError(
                 f"variable {name!r} can only be set in a part that "
                 "adopts external metadata"
             )
         else:
             raise RuntimeError(
-                f"variable {name!r} can only be set "
-                f"in part {self._project_vars_part_name!r}"
+                f"variable {name!r} can only be set in part {project_var.part_name!r}"
             )
 
     def get_project_var(self, name: str, *, raw_read: bool = False) -> str:
@@ -626,17 +776,18 @@ class ProjectInfo:
                 f"cannot consume variable {name!r} during lifecycle execution"
             )
 
-        return self._project_vars[name].value
+        return self._project_vars.get(*name.split(".")).value or ""
 
     def _ensure_valid_variable_name(self, name: str) -> None:
         """Raise an error if variable name is invalid.
 
         :param name: The variable name to verify.
         """
-        if not _var_name_pattern.match(name):
-            raise ValueError(f"{name!r} is not a valid variable name")
+        for item in name.split("."):
+            if not _var_name_pattern.match(item):
+                raise ValueError(f"{name!r} is not a valid variable name")
 
-        if name not in self._project_vars:
+        if not self._project_vars.has_key(*name.split(".")):
             raise ValueError(f"{name!r} not in project variables")
 
 
@@ -655,8 +806,8 @@ class ProjectOptions(pydantic.BaseModel):
     application_name: str = ""
     arch_triplet: str = ""
     target_arch: str = ""
-    project_vars: dict[str, ProjectVar] = {}
     project_vars_part_name: str | None = None
+    project_vars: ProjectVarInfo = ProjectVarInfo()
 
     @classmethod
     def from_project_info(cls, project_info: ProjectInfo) -> Self:

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -30,7 +30,7 @@ from craft_parts.actions import Action
 from craft_parts.dirs import ProjectDirs
 from craft_parts.features import Features
 from craft_parts.filesystem_mounts import FilesystemMounts, validate_filesystem_mounts
-from craft_parts.infos import ProjectInfo
+from craft_parts.infos import ProjectInfo, ProjectVarInfo
 from craft_parts.overlays import LayerHash
 from craft_parts.parts import Part, part_by_name
 from craft_parts.state_manager import states
@@ -76,7 +76,7 @@ class LifecycleManager:
         change if a different base image is used.
     :param project_vars_part_name: Project variables can only be set in the part
         matching this name.
-    :param project_vars: A dictionary containing project variables.
+    :param project_vars: A ProjectVarInfo instance or a dictionary containing project variables.
     :param partitions: A list of partitions to use when the partitions feature is
         enabled. The first partition will be considered the default. Partitions may
         have an optional namespace prefix separated by a forward slash. Partition names
@@ -108,7 +108,7 @@ class LifecycleManager:
         base_layer_dir: Path | None = None,
         base_layer_hash: bytes | None = None,
         project_vars_part_name: str | None = None,
-        project_vars: dict[str, str] | None = None,
+        project_vars: dict[str, str] | ProjectVarInfo | None = None,
         partitions: list[str] | None = None,
         filesystem_mounts: dict[str, Any] | None = None,
         **custom_args: Any,  # custom passthrough args

--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from craft_parts import errors, parts, steps
 from craft_parts.actions import Action, ActionProperties, ActionType
 from craft_parts.features import Features
-from craft_parts.infos import ProjectInfo, ProjectOptions, ProjectVar
+from craft_parts.infos import ProjectInfo, ProjectOptions, ProjectVarInfo
 from craft_parts.overlays import LayerHash, LayerStateManager
 from craft_parts.parts import Part, part_list_by_name, sort_parts
 from craft_parts.state_manager import StateManager, states
@@ -210,10 +210,8 @@ class Sequencer:
             project_vars=self._get_project_vars(part, current_step),
         )
 
-    def _get_project_vars(self, part: Part, step: Step) -> dict[str, ProjectVar] | None:
-        if part.name == self._project_info.project_vars_part_name:
-            return self._sm.project_vars(part, step)
-        return None
+    def _get_project_vars(self, part: Part, step: Step) -> ProjectVarInfo | None:
+        return self._sm.project_vars(part, step)
 
     def _process_dependencies(self, part: Part, step: Step) -> None:
         prerequisite_step = steps.dependency_prerequisite_step(step)
@@ -368,10 +366,14 @@ class Sequencer:
         *,
         action_type: ActionType = ActionType.RUN,
         reason: str | None = None,
-        project_vars: dict[str, ProjectVar] | None = None,
+        project_vars: ProjectVarInfo | None = None,
         properties: ActionProperties | None = None,
     ) -> None:
         logger.debug("add action %s:%s(%s)", part.name, step, action_type)
+
+        if not project_vars:
+            project_vars = ProjectVarInfo()
+
         if not properties:
             properties = ActionProperties()
 

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -89,8 +89,4 @@ class BuildState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {
-            "project_vars": project_options.project_vars.marshal_one_attribute(
-                "part-name"
-            )
-        }
+        return {"project_vars": project_options.project_vars.marshal("part_name")}

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -90,5 +90,7 @@ class BuildState(StepState):
         :return: A dictionary containing project options of interest.
         """
         return {
-            "project_vars_part_name": project_options.project_vars_part_name,
+            "project_vars": project_options.project_vars.marshal_one_attribute(
+                "part-name"
+            )
         }

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -79,4 +79,8 @@ class OverlayState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {"project_vars_part_name": project_options.project_vars_part_name}
+        return {
+            "project_vars": project_options.project_vars.marshal_one_attribute(
+                "part-name"
+            )
+        }

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -79,8 +79,4 @@ class OverlayState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {
-            "project_vars": project_options.project_vars.marshal_one_attribute(
-                "part-name"
-            )
-        }
+        return {"project_vars": project_options.project_vars.marshal(attr="part_name")}

--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -83,5 +83,7 @@ class PrimeState(StepState):
         :return: A dictionary containing project options of interest.
         """
         return {
-            "project_vars_part_name": project_options.project_vars_part_name,
+            "project_vars": project_options.project_vars.marshal_one_attribute(
+                "part-name"
+            )
         }

--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -82,8 +82,4 @@ class PrimeState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {
-            "project_vars": project_options.project_vars.marshal_one_attribute(
-                "part-name"
-            )
-        }
+        return {"project_vars": project_options.project_vars.marshal(attr="part_name")}

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -94,8 +94,4 @@ class PullState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {
-            "project_vars": project_options.project_vars.marshal_one_attribute(
-                "part-name"
-            )
-        }
+        return {"project_vars": project_options.project_vars.marshal("part_name")}

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -95,5 +95,7 @@ class PullState(StepState):
         :return: A dictionary containing project options of interest.
         """
         return {
-            "project_vars_part_name": project_options.project_vars_part_name,
+            "project_vars": project_options.project_vars.marshal_one_attribute(
+                "part-name"
+            )
         }

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -86,8 +86,4 @@ class StageState(StepState):
 
         :return: A dictionary containing project options of interest.
         """
-        return {
-            "project_vars": project_options.project_vars.marshal_one_attribute(
-                "part-name"
-            )
-        }
+        return {"project_vars": project_options.project_vars.marshal(attr="part_name")}

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -87,5 +87,7 @@ class StageState(StepState):
         :return: A dictionary containing project options of interest.
         """
         return {
-            "project_vars_part_name": project_options.project_vars_part_name,
+            "project_vars": project_options.project_vars.marshal_one_attribute(
+                "part-name"
+            )
         }

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, cast
 
 from craft_parts import parts, sources, steps
 from craft_parts.features import Features
-from craft_parts.infos import ProjectInfo, ProjectOptions, ProjectVar
+from craft_parts.infos import ProjectInfo, ProjectOptions, ProjectVarInfo
 from craft_parts.parts import Part
 from craft_parts.steps import Step
 
@@ -264,7 +264,7 @@ class StateManager:
 
         return False
 
-    def project_vars(self, part: Part, step: Step) -> dict[str, ProjectVar] | None:
+    def project_vars(self, part: Part, step: Step) -> ProjectVarInfo | None:
         """Obtain the project variables for a given part and step.
 
         :param part: The part corresponding to the state to retrieve.
@@ -274,7 +274,7 @@ class StateManager:
         """
         stw = self._state_db.get(part_name=part.name, step=step)
         if not stw:
-            return {}
+            return ProjectVarInfo()
 
         return stw.state.project_options.project_vars or None
 

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -143,6 +143,7 @@ LayerHash
 LayerMount
 LayerStateManager
 Lifecycle
+Lifecycle's
 LifecycleManager
 LocalSource
 LocalSourceModel
@@ -214,6 +215,7 @@ PackageCacheMount
 PackageFetchError
 PackageListRefreshError
 PackageNotFound
+PackageService
 PackagesDownloadError
 PackagesError
 PackagesNotFound
@@ -353,6 +355,7 @@ armv
 artifact
 artifactId
 artifacts
+attr
 apache
 autogen
 autotools

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -32,7 +32,7 @@ New features:
   dependency versions available on the host, aligning with how Maven normally behaves.
   This change makes the plugin a drop-in replacement for Maven in private networks.
 
-- Adds support for nested project variables. Nested project variables are managed with
+- Add support for nested project variables, which can be referenced with
   craftctl using dot notation. For example, ``craftctl set var.subvar=foo`` sets the
   nested project variable ``var.subvar`` to ``foo``.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -16,7 +16,6 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
-
 .. _release-2.21.0:
 
 2.21.0 (2025-MM-DD)
@@ -32,6 +31,13 @@ New features:
   With Craft Parts 2.21.0, the plugin now deterministically detects and matches the
   dependency versions available on the host, aligning with how Maven normally behaves.
   This change makes the plugin a drop-in replacement for Maven in private networks.
+
+- Adds support for nested project variables. Nested project variables are managed with
+  craftctl using dot notation. For example, ``craftctl set var.subvar=foo`` sets the
+  nested project variable ``var.subvar`` to ``foo``.
+
+- Previously, all project variables had to be set by the same part. Now, each project
+  variable can be set by a different part.
 
 Bug fixes:
 

--- a/tests/integration/lifecycle/test_plugin_changesets.py
+++ b/tests/integration/lifecycle/test_plugin_changesets.py
@@ -20,7 +20,14 @@ from typing import Literal
 
 import craft_parts
 import yaml
-from craft_parts import Action, ActionProperties, ActionType, Step, plugins
+from craft_parts import (
+    Action,
+    ActionProperties,
+    ActionType,
+    ProjectVarInfo,
+    Step,
+    plugins,
+)
 
 
 def setup_function():
@@ -122,7 +129,7 @@ def test_changesets(new_dir, mocker, capfd):
             Step.BUILD,
             action_type=ActionType.UPDATE,
             reason="'PULL' step changed",
-            project_vars=None,
+            project_vars=ProjectVarInfo(),
             properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
         ),
     ]
@@ -203,7 +210,7 @@ def test_changesets_reload_state(new_dir, mocker, capfd):
             Step.BUILD,
             action_type=ActionType.UPDATE,
             reason="'PULL' step changed",
-            project_vars=None,
+            project_vars=ProjectVarInfo(),
             properties=ActionProperties(changed_files=["foo"], changed_dirs=[]),
         ),
     ]

--- a/tests/unit/state_manager/conftest.py
+++ b/tests/unit/state_manager/conftest.py
@@ -17,7 +17,7 @@
 from typing import Any
 
 import pytest
-from craft_parts.infos import ProjectOptions
+from craft_parts.infos import ProjectOptions, ProjectVarInfo
 
 
 @pytest.fixture
@@ -56,6 +56,5 @@ def project_options() -> ProjectOptions:
         application_name="test",
         arch_triplet="",
         target_arch="amd64",
-        project_vars={},
-        project_vars_part_name=None,
+        project_vars=ProjectVarInfo(),
     )

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -30,7 +30,7 @@ def test_action_representation():
     action = Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="is tired")
     assert f"{action!r}" == (
         "Action(part_name='foo', step=Step.PULL, action_type=ActionType.SKIP, "
-        "reason='is tired', project_vars=None, properties=ActionProperties("
+        "reason='is tired', project_vars=ProjectVarInfo(root={}), properties=ActionProperties("
         "changed_files=None, changed_dirs=None))"
     )
 

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -16,6 +16,7 @@
 
 import logging
 import re
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from unittest.mock import call
 
@@ -31,6 +32,16 @@ from craft_parts.infos import (
 )
 from craft_parts.parts import Part
 from craft_parts.steps import Step
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:Using deprecated API to define project variables."
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:'ProjectInfo.project_vars_part_name' is deprecated."
+    ),
+]
+
 
 _MOCK_NATIVE_ARCH = "arm64"
 
@@ -81,8 +92,13 @@ def test_project_info(mocker, new_dir, tc_arch, tc_target_arch, tc_triplet, tc_c
         "arch_triplet": tc_triplet,
         "target_arch": tc_target_arch,
         "project_vars_part_name": "adopt",
-        "project_vars": {"a": ProjectVar(value="b")},
+        "project_vars": ProjectVarInfo.unmarshal(
+            {"a": {"value": "b", "part-name": "adopt"}}
+        ),
     }
+    assert x.project_vars == ProjectVarInfo.unmarshal(
+        {"a": ProjectVar(value="b", part_name="adopt").marshal()}
+    )
     assert x.project_vars_part_name == "adopt"
     assert x.global_environment == {}
 
@@ -141,7 +157,9 @@ def test_project_info_translated_arch(  # pylint: disable=too-many-arguments
         "arch_triplet": tc_triplet,
         "target_arch": tc_target_arch,
         "project_vars_part_name": "adopt",
-        "project_vars": {"a": ProjectVar(value="b")},
+        "project_vars": ProjectVarInfo.unmarshal(
+            {"a": ProjectVar(value="b", part_name="adopt").marshal()}
+        ),
     }
     assert x.global_environment == {}
 
@@ -191,98 +209,292 @@ def test_project_info_invalid_custom_args():
     assert str(raised.value) == "'ProjectInfo' has no attribute 'custom1'"
 
 
-def test_project_info_set_project_var():
+@pytest.mark.parametrize(
+    ("kwargs", "project_vars", "expectation"),
+    [
+        pytest.param(
+            {
+                "project_vars": ProjectVarInfo.unmarshal(
+                    {"var": ProjectVar(value="foo").marshal()}
+                ),
+            },
+            ProjectVarInfo.unmarshal({"var": ProjectVar(value="foo").marshal()}),
+            does_not_raise(),
+            id="no part name",
+        ),
+        pytest.param(
+            {
+                "project_vars": ProjectVarInfo.unmarshal(
+                    {"var": ProjectVar(value="foo", part_name="part1").marshal()}
+                ),
+            },
+            ProjectVarInfo.unmarshal(
+                {"var": ProjectVar(value="foo", part_name="part1").marshal()}
+            ),
+            does_not_raise(),
+            id="with part name",
+        ),
+        pytest.param(
+            {"project_vars": {"var": "foo"}},
+            ProjectVarInfo.unmarshal({"var": ProjectVar(value="foo").marshal()}),
+            does_not_raise(),
+            id="deprecated api with no part name",
+        ),
+        pytest.param(
+            {"project_vars": {"var": "foo"}, "project_vars_part_name": "part1"},
+            ProjectVarInfo.unmarshal(
+                {"var": ProjectVar(value="foo", part_name="part1").marshal()}
+            ),
+            does_not_raise(),
+            id="deprecated api with part name",
+        ),
+        pytest.param(
+            {
+                "project_vars": ProjectVarInfo.unmarshal(
+                    {"var": ProjectVar(value="foo").marshal()}
+                ),
+                "project_vars_part_name": "part1",
+            },
+            None,
+            pytest.raises(
+                RuntimeError,
+                match="Cannot handle 'project_vars' of type ProjectVarInfo and 'project_vars_part_name'",
+            ),
+            id="error for mixed APIs",
+        ),
+    ],
+)
+def test_project_info_init(kwargs, project_vars, expectation):
+    """Initialize project variables with the current and deprecated APIs."""
+    with expectation:
+        assert (
+            ProjectInfo(
+                application_name="test", cache_dir=Path(), **kwargs
+            ).project_options["project_vars"]
+            == project_vars
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var(path):
+    """Set a project variable."""
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar")
-    assert info.get_project_var("var", raw_read=True) == "bar"
+    info.set_project_var(path, "baz")
+
+    assert info.get_project_var(path, raw_read=True) == "baz"
 
 
-def test_project_info_set_project_raw_write():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_raw_write(path):
+    """Force-set a project variable with 'raw-write'."""
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar")
-    info.set_project_var("var", "bar", raw_write=True)
+    info.set_project_var(path, "baz")
+    info.set_project_var(path, "baz", raw_write=True)
+
     with pytest.raises(RuntimeError) as raised:
-        info.set_project_var("var", "bar")
+        info.set_project_var(path, "bar")
 
-    assert str(raised.value) == "variable 'var' can be set only once"
+    assert str(raised.value) == f"variable {path!r} can be set only once"
 
 
-def test_project_info_set_project_var_bad_name():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("bad-name", id="hyphen"),
+        pytest.param("bad.bad-name", id="nested hyphen"),
+        pytest.param(".badname", id="starts with dot"),
+        pytest.param("badname.", id="ends with dot"),
+        pytest.param("bad..name", id="multiple dots"),
+        pytest.param("..badname", id="starts with multiple dots"),
+        pytest.param("badname..", id="ends with multiple dots"),
+        pytest.param("0badname", id="starts with digit"),
+        pytest.param("bad.0badname", id="nested starts with digit"),
+        pytest.param(".", id="dot"),
+        pytest.param("..", id="dotdot"),
+        pytest.param("...", id="et cetera"),
+    ],
+)
+def test_project_info_set_project_var_bad_name(path):
+    """Error on invalid project variable names."""
     info = ProjectInfo(application_name="test", cache_dir=Path())
 
     with pytest.raises(ValueError) as raised:  # noqa: PT011
-        info.set_project_var("bad-name", "foo")
-    assert str(raised.value) == "'bad-name' is not a valid variable name"
+        info.set_project_var(path, "foo")
+    assert str(raised.value) == f"{path!r} is not a valid variable name"
 
 
-def test_project_info_set_project_var_part_name():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var_part_name(path):
+    """Set a project variable from its part."""
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_vars_part_name="part1",
-        project_vars={"var": "foo"},
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo", part_name="part1").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar", part_name="part1").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar", part_name="part1")
-    assert info.get_project_var("var", raw_read=True) == "bar"
+    info.set_project_var(path, "baz", part_name="part1")
+    assert info.get_project_var(path, raw_read=True) == "baz"
 
 
-def test_project_info_set_project_var_no_part_name():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var_no_part_name(path):
+    """Error when setting a variable that has no part, from a part."""
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_vars={"var": "foo"},
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
     )
 
     with pytest.raises(RuntimeError) as raised:
-        info.set_project_var("var", "bar", part_name="part2")
+        info.set_project_var(path, "baz", part_name="part2")
 
     assert str(raised.value) == (
-        "variable 'var' can only be set in a part that adopts external metadata"
+        f"variable {path!r} can only be set in a part that adopts external metadata"
     )
 
 
-def test_project_info_set_project_var_other_part_name():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var_other_part_name(path):
+    """Error when setting a variable from the wrong part."""
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_vars_part_name="part1",
-        project_vars={"var": "foo"},
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo", part_name="part1").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar", part_name="part1").marshal(),
+                },
+            }
+        ),
     )
 
     with pytest.raises(RuntimeError) as raised:
-        info.set_project_var("var", "bar", part_name="part2")
+        info.set_project_var(path, "bar", part_name="part2")
 
-    assert str(raised.value) == "variable 'var' can only be set in part 'part1'"
+    assert str(raised.value) == f"variable {path!r} can only be set in part 'part1'"
 
 
-def test_project_info_set_project_var_no_part_name_raw():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var_no_part_name_raw(path):
+    """Force-set a project variable with no part, from a part."""
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_vars={"var": "foo"},
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar", part_name="part2", raw_write=True)
-    assert info.get_project_var("var", raw_read=True) == "bar"
+    info.set_project_var(path, "baz", part_name="part2", raw_write=True)
+    assert info.get_project_var(path, raw_read=True) == "baz"
 
 
-def test_project_info_set_project_var_other_part_name_raw():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_set_project_var_other_part_name_raw(path):
+    """Force-set a project variable with a part, from a different part."""
     info = ProjectInfo(
         application_name="test",
         cache_dir=Path(),
-        project_vars_part_name="part1",
-        project_vars={"var": "foo"},
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo", part_name="part1").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar", part_name="part1").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar", part_name="part2", raw_write=True)
-    assert info.get_project_var("var", raw_read=True) == "bar"
+    info.set_project_var(path, "baz", part_name="part2", raw_write=True)
+
+    assert info.get_project_var(path, raw_read=True) == "baz"
 
 
 def test_project_info_set_invalid_project_vars():
@@ -291,14 +503,6 @@ def test_project_info_set_invalid_project_vars():
     with pytest.raises(ValueError) as raised:  # noqa: PT011
         info.set_project_var("var", "bar")
     assert str(raised.value) == "'var' not in project variables"
-
-
-def test_project_info_get_project_var_bad_name():
-    info = ProjectInfo(application_name="test", cache_dir=Path())
-
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
-        info.get_project_var("bad-name")
-    assert str(raised.value) == "'bad-name' is not a valid variable name"
 
 
 def test_project_info_default():
@@ -311,33 +515,62 @@ def test_project_info_cache_dir_resolving():
     assert info.cache_dir == Path.home() / "y"
 
 
-def test_project_info_get_project_var():
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_get_project_var(path):
+    """Get a project variable with raw_read."""
     info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
+        application_name="test",
+        cache_dir=Path(),
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
     )
 
-    info.set_project_var("var", "bar")
-    assert info.get_project_var("var", raw_read=True) == "bar"
+    info.set_project_var(path, "baz")
+    value = info.get_project_var(path, raw_read=True)
+
+    assert value == "baz"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("a", id="top level"),
+        pytest.param("b.c", id="nested"),
+    ],
+)
+def test_project_info_get_project_var_during_lifecycle(path):
+    """Error when getting a project var before the lifecycle completes."""
+    info = ProjectInfo(
+        application_name="test",
+        cache_dir=Path(),
+        project_vars=ProjectVarInfo.unmarshal(
+            {
+                "a": ProjectVar(value="foo").marshal(),
+                "b": {
+                    "c": ProjectVar(value="bar").marshal(),
+                },
+            }
+        ),
+    )
+
+    info.set_project_var(path, "baz")
     with pytest.raises(RuntimeError) as raised:
-        info.get_project_var("var")
+        info.get_project_var(path)
 
     assert str(raised.value) == (
-        "cannot consume variable 'var' during lifecycle execution"
-    )
-
-
-def test_project_info_consume_project_var_during_lifecycle():
-    info = ProjectInfo(
-        application_name="test", cache_dir=Path(), project_vars={"var": "foo"}
-    )
-
-    info.set_project_var("var", "bar")
-    assert info.get_project_var("var", raw_read=True) == "bar"
-    with pytest.raises(RuntimeError) as raised:
-        info.get_project_var("var")
-
-    assert str(raised.value) == (
-        "cannot consume variable 'var' during lifecycle execution"
+        f"cannot consume variable {path!r} during lifecycle execution"
     )
 
 
@@ -712,7 +945,12 @@ class TestProjectVarInfo:
             "e": {
                 "value": "value3",
                 "updated": False,
+                "part-name": "part3",
             },
+            # coerce an int
+            "f": {"value": 1},
+            # coerce a float
+            "g": {"value": 1.0},
         }
 
         info = ProjectVarInfo.unmarshal(data)
@@ -720,21 +958,34 @@ class TestProjectVarInfo:
 
         assert new_data == {
             "a": {
-                "b": {
-                    "value": "value1",
-                    "updated": False,
-                },
+                "b": ProjectVar(
+                    value="value1",
+                    updated=False,
+                    part_name=None,
+                ).marshal(),
                 "c": {
-                    "d": {
-                        "value": "value2",
-                        "updated": True,
-                    },
+                    "d": ProjectVar(
+                        value="value2",
+                        updated=True,
+                        part_name=None,
+                    ).marshal(),
                 },
             },
-            "e": {
-                "value": "value3",
-                "updated": False,
-            },
+            "e": ProjectVar(
+                value="value3",
+                updated=False,
+                part_name="part3",
+            ).marshal(),
+            "f": ProjectVar(
+                value="1",
+                updated=False,
+                part_name=None,
+            ).marshal(),
+            "g": ProjectVar(
+                value="1.0",
+                updated=False,
+                part_name=None,
+            ).marshal(),
         }
 
     def test_unmarshal_error(self):
@@ -744,9 +995,72 @@ class TestProjectVarInfo:
         with pytest.raises(TypeError, match=expected_error):
             ProjectVarInfo.unmarshal("invalid")  # pyright: ignore[reportArgumentType]
 
+    @pytest.mark.parametrize(
+        ("attr", "expected"),
+        [
+            (
+                "value",
+                {
+                    "a": {
+                        "b": "value1",
+                        "c": {"d": "value2"},
+                    },
+                    "e": "value3",
+                },
+            ),
+            (
+                "updated",
+                {
+                    "a": {
+                        "b": False,
+                        "c": {"d": True},
+                    },
+                    "e": False,
+                },
+            ),
+            (
+                "part_name",
+                {
+                    "a": {
+                        "b": None,
+                        "c": {"d": None},
+                    },
+                    "e": "part3",
+                },
+            ),
+        ],
+    )
+    def test_marshal_one_attribute(self, attr, expected):
+        """Unmarshal one attribute of the project vars."""
+        data = {
+            "a": {
+                "b": {
+                    "value": "value1",
+                },
+                "c": {
+                    "d": {
+                        "value": "value2",
+                        "updated": True,
+                    }
+                },
+            },
+            "e": {
+                "value": "value3",
+                "updated": False,
+                "part-name": "part3",
+            },
+        }
+
+        info = ProjectVarInfo.unmarshal(data)
+        new_data = info.marshal_one_attribute(attr)
+
+        assert new_data == expected
+
     def test_has_key(self, mock_logger):
         """Check if a key exists."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
 
         assert info.has_key("a", "b")
         assert not info.has_key("a")
@@ -770,15 +1084,29 @@ class TestProjectVarInfo:
     )
     def test_no_keys_error(self, func, kwargs):
         """Error if no keys are provided."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = "No keys provided."
 
         with pytest.raises(KeyError, match=expected_error):
             getattr(info, func)(**kwargs)
 
+    def test_values(self):
+        """Get the values of a ProjectVarInfo."""
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
+
+        values = info.values()
+
+        assert list(values) == list(info.root.values())
+
     def test_get_and_set(self, mock_logger):
         """Test getting and setting a value from ProjectVarInfo."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
 
         info.set("a", "b", value="new-value")
         var = info.get("a", "b")
@@ -793,7 +1121,9 @@ class TestProjectVarInfo:
 
     def test_get_invalid_path_error(self):
         """Error if an item the path doesn't exist."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to get value for 'a.non-existent': 'non-existent' doesn't exist."
         )
@@ -803,7 +1133,9 @@ class TestProjectVarInfo:
 
     def test_get_invalid_path_top_level_error(self):
         """Error if the top level item in the path doesn't exist."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to get value for 'foo.bar.baz': 'foo' doesn't exist."
         )
@@ -813,7 +1145,9 @@ class TestProjectVarInfo:
 
     def test_get_into_project_var_error(self):
         """Error if traversing into a ProjectVar to get a value."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to get value for 'a.b.updated': can't traverse into node at 'b'."
         )
@@ -824,7 +1158,9 @@ class TestProjectVarInfo:
 
     def test_get_not_project_var_error(self):
         """Error if getting an intermediate node instead of an end node (a ProjectVar)."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to get value for 'a': value isn't a ProjectVar."
         )
@@ -835,7 +1171,9 @@ class TestProjectVarInfo:
 
     def test_set_into_project_var_error(self):
         """Error if traversing into a ProjectVar to set a value."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to set 'a.b.updated' to 'new-value': can't traverse into node at 'b'."
         )
@@ -846,7 +1184,9 @@ class TestProjectVarInfo:
 
     def test_set_not_project_var_error(self):
         """Error if setting an intermediate node instead of an end node (a ProjectVar)."""
-        info = ProjectVarInfo.unmarshal({"a": {"b": {"value": "value"}}})
+        info = ProjectVarInfo.unmarshal(
+            {"a": {"b": ProjectVar(value="value").marshal()}}
+        )
         expected_error = re.escape(
             "Failed to set 'a' to 'new-value': value isn't a ProjectVar."
         )
@@ -858,7 +1198,7 @@ class TestProjectVarInfo:
     def test_set_overwrite(self, mock_logger):
         """Overwrite an item that already exists."""
         info = ProjectVarInfo.unmarshal(
-            {"a": {"b": {"value": "value", "updated": True}}}
+            {"a": {"b": ProjectVar(value="value", updated=True).marshal()}}
         )
 
         info.set("a", "b", value="new-value", overwrite=True)
@@ -879,7 +1219,7 @@ class TestProjectVarInfo:
     def test_set_overwrite_error(self, kwargs, mock_logger):
         """Error if overwrite is false."""
         info = ProjectVarInfo.unmarshal(
-            {"a": {"b": {"value": "value", "updated": True}}}
+            {"a": {"b": ProjectVar(value="value", updated=True).marshal()}}
         )
         expected_error = re.escape(
             "Failed to set 'a.b' to 'new-value': key 'b' already exists and overwrite is false."
@@ -887,3 +1227,125 @@ class TestProjectVarInfo:
 
         with pytest.raises(ValueError, match=expected_error):
             info.set("a", "b", value="new-value", **kwargs)
+
+    @pytest.mark.parametrize(
+        ("part_name", "expected"),
+        [
+            pytest.param(
+                "part1",
+                ProjectVarInfo.unmarshal(
+                    {
+                        "a": {
+                            "b": ProjectVar(value="value1").marshal(),
+                        },
+                        "c": {
+                            "d": ProjectVar(
+                                value="value2",
+                                updated=True,
+                                part_name="part2",
+                            ).marshal(),
+                        },
+                        "e": ProjectVar(
+                            value="value3",
+                            updated=False,
+                            part_name="part3",
+                        ).marshal(),
+                    },
+                ),
+                # no values updated because no ProjectVars use part1
+                id="update-part1",
+            ),
+            pytest.param(
+                "part2",
+                ProjectVarInfo.unmarshal(
+                    {
+                        "a": {
+                            "b": ProjectVar(value="value1").marshal(),
+                        },
+                        "c": {
+                            "d": ProjectVar(
+                                # value is updated because updated=True and the part name matches
+                                value="updated-value2",
+                                updated=True,
+                                part_name="part2",
+                            ).marshal(),
+                        },
+                        "e": ProjectVar(
+                            value="value3",
+                            updated=False,
+                            part_name="part3",
+                        ).marshal(),
+                    },
+                ),
+                id="update-part2",
+            ),
+            pytest.param(
+                "part3",
+                ProjectVarInfo.unmarshal(
+                    {
+                        "a": {
+                            "b": ProjectVar(value="value1").marshal(),
+                        },
+                        "c": {
+                            "d": ProjectVar(
+                                value="value2",
+                                updated=True,
+                                part_name="part2",
+                            ).marshal(),
+                        },
+                        "e": ProjectVar(
+                            # value isn't updated because updated=False
+                            value="value3",
+                            updated=False,
+                            part_name="part3",
+                        ).marshal(),
+                    },
+                ),
+                id="update-part3",
+            ),
+        ],
+    )
+    def test_update_from(self, part_name, expected):
+        """Update from another ProjectVarInfo class."""
+        info = ProjectVarInfo.unmarshal(
+            {
+                "a": {
+                    "b": ProjectVar(value="value1").marshal(),
+                },
+                "c": {
+                    "d": ProjectVar(
+                        value="value2",
+                        updated=True,
+                        part_name="part2",
+                    ).marshal(),
+                },
+                "e": ProjectVar(
+                    value="value3",
+                    updated=False,
+                    part_name="part3",
+                ).marshal(),
+            },
+        )
+        other = ProjectVarInfo.unmarshal(
+            {
+                "a": {
+                    "b": ProjectVar(value="updated-value1").marshal(),
+                },
+                "c": {
+                    "d": ProjectVar(
+                        value="updated-value2",
+                        updated=True,
+                        part_name="part2",
+                    ).marshal(),
+                },
+                "e": ProjectVar(
+                    value="updated-value3",
+                    updated=False,
+                    part_name="part3",
+                ).marshal(),
+            },
+        )
+
+        info.update_from(other, part_name)
+
+        assert info == expected

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -1032,27 +1032,28 @@ class TestProjectVarInfo:
     )
     def test_marshal_one_attribute(self, attr, expected):
         """Unmarshal one attribute of the project vars."""
-        data = {
-            "a": {
-                "b": {
-                    "value": "value1",
+        info = ProjectVarInfo.unmarshal(
+            {
+                "a": {
+                    "b": ProjectVar(
+                        value="value1",
+                    ).marshal(),
+                    "c": {
+                        "d": ProjectVar(
+                            value="value2",
+                            updated=True,
+                        ).marshal(),
+                    },
                 },
-                "c": {
-                    "d": {
-                        "value": "value2",
-                        "updated": True,
-                    }
-                },
-            },
-            "e": {
-                "value": "value3",
-                "updated": False,
-                "part-name": "part3",
-            },
-        }
+                "e": ProjectVar(
+                    value="value3",
+                    updated=False,
+                    part_name="part3",
+                ).marshal(),
+            }
+        )
 
-        info = ProjectVarInfo.unmarshal(data)
-        new_data = info.marshal_one_attribute(attr)
+        new_data = info.marshal(attr)
 
         assert new_data == expected
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----

Uses the new `ProjectVarInfo` class to manage project variables. This enables setting nested project variables.  For example, `craftctl set var.subvar=foo` sets the nested project variable `var.subvar` to `foo`.

Used downstream in https://github.com/canonical/craft-application/pull/872
(SNAPCRAFT-1052)