### PR TITLE
feat: allow parts to organize to overlay

### DIFF
--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -166,6 +166,7 @@ class LifecycleManager:
             part_list.append(part)
 
         self._has_overlay = any(p.has_overlay for p in part_list)
+        self._organizes_to_overlay = any(p.organizes_to_overlay for p in part_list)
         self._needs_chisel = any(p.has_slices for p in part_list)
         self._has_chisel = any(p.has_chisel_as_build_snap for p in part_list)
 
@@ -176,7 +177,7 @@ class LifecycleManager:
             extra_build_snaps.append("chisel/latest/stable")
 
         # a base layer is mandatory if overlays are in use
-        if self._has_overlay:
+        if self._has_overlay or self._organizes_to_overlay:
             _ensure_overlay_supported()
 
             if not base_layer_dir:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -40,7 +40,11 @@ from craft_parts.packages import platform
 from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
-from craft_parts.utils.partition_utils import DEFAULT_PARTITION, get_partition_dir_map
+from craft_parts.utils.partition_utils import (
+    DEFAULT_PARTITION,
+    OVERLAY_PARTITION,
+    get_partition_dir_map,
+)
 from craft_parts.utils.path_utils import get_partition_and_path
 
 
@@ -564,7 +568,19 @@ class PartSpec(BaseModel):
             self.overlay_packages
             or self.overlay_script is not None
             or self.overlay_files != ["*"]
+            # Don't include organize to overlay in this verification.
         )
+
+    @property
+    def organizes_to_overlay(self) -> bool:
+        """Return whether the part organizes file to the overlay."""
+        if not Features().enable_partitions or not Features().enable_overlay:
+            return False
+        for dest in self.organize_files.values():
+            partition, _ = get_partition_and_path(dest, DEFAULT_PARTITION)
+            if partition == OVERLAY_PARTITION:
+                return True
+        return False
 
     @property
     def has_slices(self) -> bool:
@@ -702,13 +718,14 @@ class Part:
 
         With partitions disabled, the only partition name is ``None``
         """
-        return MappingProxyType(
-            get_partition_dir_map(
-                base_dir=self.dirs.work_dir,
-                partitions=self._partitions,
-                suffix=f"parts/{self.name}/install",
-            )
+        dir_map = get_partition_dir_map(
+            base_dir=self.dirs.work_dir,
+            partitions=self._partitions,
+            suffix=f"parts/{self.name}/install",
         )
+        if self.organizes_to_overlay:
+            dir_map[OVERLAY_PARTITION] = self.dirs.overlay_mount_dir
+        return MappingProxyType(dir_map)
 
     @property
     def part_state_dir(self) -> Path:
@@ -815,6 +832,11 @@ class Part:
     def has_overlay(self) -> bool:
         """Return whether this part declares overlay content."""
         return self.spec.has_overlay
+
+    @property
+    def organizes_to_overlay(self) -> bool:
+        """Return whether this part organizes files to overlay."""
+        return self.spec.organizes_to_overlay
 
     @property
     def has_slices(self) -> bool:
@@ -927,7 +949,10 @@ class Part:
             match = re.match(partition_pattern, filepath)
             if match:
                 partition = match.group("partition")
-                if str(partition) not in self._partitions:
+                if str(partition) == OVERLAY_PARTITION and Features().enable_overlay:
+                    # If overlays are enabled we can organize to (overlay)
+                    pass
+                elif str(partition) not in self._partitions:
                     error_list.append(
                         f"    unknown partition {partition!r} in {filepath!r}"
                     )
@@ -1093,7 +1118,7 @@ def get_parts_with_overlay(*, part_list: list[Part]) -> list[Part]:
 
     :return: A list of parts with overlay parameters.
     """
-    return [p for p in part_list if p.has_overlay]
+    return [p for p in part_list if p.has_overlay or p.organizes_to_overlay]
 
 
 def validate_part(data: dict[str, Any]) -> None:

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -35,6 +35,7 @@ PARTITION_INVALID_MSG = (
 )
 
 DEFAULT_PARTITION = "default"
+OVERLAY_PARTITION = "overlay"  # Pseudo-partition targeting the overlay
 
 
 def validate_partition_names(partitions: Sequence[str] | None) -> None:
@@ -71,11 +72,13 @@ def validate_partition_names(partitions: Sequence[str] | None) -> None:
     if len(partitions) != len(set(partitions)):
         raise errors.FeatureError("Partitions must be unique.")
 
-    for partition in partitions[1:]:
-        if partition == DEFAULT_PARTITION:
-            raise errors.FeatureError(
-                "Only the first partition can be named 'default'."
-            )
+    if DEFAULT_PARTITION in partitions[1:]:
+        raise errors.FeatureError("Only the first partition can be named 'default'.")
+
+    if OVERLAY_PARTITION in partitions:
+        raise errors.FeatureError(
+            "Reserved name 'overlay' cannot be used to name a partition."
+        )
 
     _validate_partition_naming_convention(partitions)
     _validate_partitions_conflicts(partitions)

--- a/docs/common/craft-parts/craft-parts.wordlist.txt
+++ b/docs/common/craft-parts/craft-parts.wordlist.txt
@@ -493,6 +493,7 @@ openjdk
 organization
 organize
 organized
+organizes
 organizing
 ormal
 os

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -16,6 +16,23 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+.. _release-2.22.0:
+
+2.22.0 (2025-MM-DD)
+-------------------
+
+New features:
+
+- Allow parts to organize content to the overlay. This is done by specifying the
+  target as the (overlay) pseudo-partition. To be able to organize to overlay
+  both overlays and partition features must be enabled.
+
+Bug fixes:
+
+Documentation:
+
+For a complete list of commits, check out the `2.22.0`_ release on GitHub.
+
 .. _release-2.21.0:
 
 2.21.0 (2025-08-29)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -23,9 +23,10 @@ Changelog
 
 New features:
 
-- Allow parts to organize content to the overlay. This is done by specifying the
-  target as the (overlay) pseudo-partition. To be able to organize to overlay
-  both overlays and partition features must be enabled.
+- Parts can now copy files to the project's overlay filesystem with the ``organize``
+  key. This is done by prefixing the file's destination path with the ``(overlay)``
+  pseudo-partition. To make use of this feature, the project must support both overlays
+  and partitions.
 
 Bug fixes:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,18 @@ def enable_partitions_feature():
 
 
 @pytest.fixture
+def enable_overlay_and_partitions_features():
+    assert Features().enable_partitions is False
+    assert Features().enable_overlay is False
+    Features.reset()
+    Features(enable_partitions=True, enable_overlay=True)
+
+    yield
+
+    Features.reset()
+
+
+@pytest.fixture
 def partitions():
     if Features().enable_partitions:
         return ["default", "mypart", "yourpart"]

--- a/tests/integration/lifecycle/test_organize_to_overlay.py
+++ b/tests/integration/lifecycle/test_organize_to_overlay.py
@@ -1,0 +1,76 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import textwrap
+from pathlib import Path
+
+import craft_parts
+import pytest
+import yaml
+from craft_parts import Action, ActionProperties, ActionType, Step
+
+basic_parts_yaml = textwrap.dedent(
+    """\
+    parts:
+      p1:
+        plugin: dump
+        source: source
+        organize:
+          '*': (overlay)/"""
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_feature(enable_overlay_and_partitions_features):
+    return
+
+
+def test_organize_to_overlay(new_dir, mocker):
+    mocker.patch("os.geteuid", return_value=0)
+
+    parts = yaml.safe_load(basic_parts_yaml)
+
+    base_layer_dir = Path("base")
+    base_layer_dir.mkdir()
+
+    source_dir = Path("source")
+    source_dir.mkdir()
+
+    # File to be organized into overlay
+    (source_dir / "foo.txt").touch()
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_demo",
+        cache_dir=new_dir,
+        partitions=["default"],
+        base_layer_dir=base_layer_dir,
+        base_layer_hash=b"hash",
+    )
+    actions = lf.plan(Step.PRIME)
+    assert actions == [
+        Action("p1", Step.PULL),
+        Action("p1", Step.OVERLAY),
+        Action("p1", Step.BUILD),
+        Action("p1", Step.STAGE),
+        Action("p1", Step.PRIME),
+    ]
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    assert Path("parts/p1/install/foo.txt").exists() is False
+    assert Path("parts/p1/layer/foo.txt").exists()
+    assert Path("prime/foo.txt").exists()

--- a/tests/unit/features/overlay_partitions/test_executor_organize.py
+++ b/tests/unit/features/overlay_partitions/test_executor_organize.py
@@ -1,0 +1,84 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2015-2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from craft_parts import errors
+from craft_parts.executor.organize import organize_files
+from tests.unit.executor.test_organize import organize_and_assert
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # simple_file
+        {
+            "setup_files": ["foo"],
+            "organize_map": {"foo": "bar"},
+            "expected": [(["bar"], "")],
+        },
+        # simple_dir_with_file
+        {
+            "setup_dirs": ["foodir"],
+            "setup_files": [os.path.join("foodir", "foo")],
+            "organize_map": {"foodir": "bardir"},
+            "expected": [(["bardir"], ""), (["foo"], "bardir")],
+        },
+        # organize into overlay
+        {
+            "setup_files": ["foo"],
+            "organize_map": {"foo": "(overlay)/bar"},
+            "expected": [([], ""), (["bar"], "../overlay_dir")],
+        },
+    ],
+)
+def test_organize(new_dir, data):
+    organize_and_assert(
+        tmp_path=new_dir,
+        setup_dirs=data.get("setup_dirs", []),
+        setup_files=data.get("setup_files", []),
+        setup_symlinks=data.get("setup_symlinks", []),
+        organize_map=data["organize_map"],
+        expected=data["expected"],
+        expected_message=data.get("expected_message"),
+        expected_overwrite=data.get("expected_overwrite"),
+        overwrite=False,
+        install_dirs={
+            "default": Path(new_dir / "install"),
+            "overlay": Path(new_dir / "overlay_dir"),
+        },
+    )
+
+    # Verify that it can be organized again by overwriting
+    organize_and_assert(
+        tmp_path=new_dir,
+        setup_dirs=data.get("setup_dirs", []),
+        setup_files=data.get("setup_files", []),
+        setup_symlinks=data.get("setup_symlinks", []),
+        organize_map=data["organize_map"],
+        expected=data["expected"],
+        expected_message=data.get("expected_message"),
+        expected_overwrite=data.get("expected_overwrite"),
+        overwrite=True,
+        install_dirs={
+            "default": Path(new_dir / "install"),
+            "overlay": Path(new_dir / "overlay_dir"),
+        },
+    )

--- a/tests/unit/features/overlay_partitions/test_parts.py
+++ b/tests/unit/features/overlay_partitions/test_parts.py
@@ -1,0 +1,68 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+import pytest
+from pathlib import Path
+
+from craft_parts import parts
+from craft_parts.parts import Part
+
+
+class TestPartData:
+    """Test basic part creation and representation."""
+
+    @pytest.mark.parametrize(
+        ("organize", "result"),
+        [
+            ({}, False),
+            ({"this": "that"}, False),
+            ({"foo": "(default)/bar"}, False),
+            ({"foo": "(overlay)/bar"}, True),
+            ({"this": "that", "foo": "(overlay)/bar"}, True),
+        ],
+    )
+    def test_part_organizes_to_overlay(self, partitions, organize, result):
+        p = Part("foo", {"organize": organize}, partitions=partitions)
+        assert p.organizes_to_overlay == result
+
+    def test_part_install_dirs(self, new_dir, partitions):
+        p = Part("foo", {"organize": {"foo": "bar"}}, partitions=partitions)
+        assert p.part_install_dirs == {
+            "default": Path(new_dir / "parts/foo/install"),
+            "mypart": Path(new_dir / "partitions/mypart/parts/foo/install"),
+            "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
+        }
+
+    def test_part_install_dirs_organize_to_overlay(self, new_dir, partitions):
+        p = Part("foo", {"organize": {"foo": "(overlay)/bar"}}, partitions=partitions)
+        assert p.part_install_dirs == {
+            "default": Path(new_dir / "parts/foo/install"),
+            "mypart": Path(new_dir / "partitions/mypart/parts/foo/install"),
+            "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
+            "overlay": Path(new_dir / "overlay/overlay"),
+        }
+
+    def test_get_parts_with_overlay(self, partitions):
+        p1 = Part("foo", {}, partitions=partitions)
+        p2 = Part("bar", {"overlay-packages": ["pkg1"]}, partitions=partitions)
+        p3 = Part("baz", {"overlay-script": "echo"}, partitions=partitions)
+        p4 = Part("qux", {"overlay": ["*"]}, partitions=partitions)
+        p5 = Part("quux", {"overlay": ["-etc/passwd"]}, partitions=partitions)
+        p6 = Part("quuux", {"organize": {"f1": "(overlay)/f1"}}, partitions=partitions)
+
+        p = parts.get_parts_with_overlay(part_list=[p1, p2, p3, p4, p5, p6])
+        assert p == [p2, p3, p5, p6]

--- a/tests/unit/features/overlay_partitions/test_parts.py
+++ b/tests/unit/features/overlay_partitions/test_parts.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pathlib
 import pytest
 from pathlib import Path
 

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
 from textwrap import dedent, indent
 
 import pytest
@@ -94,6 +95,13 @@ class TestPartData(test_parts.TestPartData):
                 suffix="parts/foo/install",
             ),
         )
+
+    def test_part_install_dirs(self, new_dir):
+        p = Part("foo", {"organize": {"foo": "bar"}}, partitions=["mypart", "yourpart"])
+        assert p.part_install_dirs == {
+            "mypart": Path(new_dir / "parts/foo/install"),  # aliased default part
+            "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
+        }
 
 
 class TestPartOrdering(test_parts.TestPartOrdering):

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -61,7 +61,7 @@ def test_dirs_work_dir_resolving(partitions):
     partitions=strategies.lists(
         strategies.text(
             strategies.sampled_from(string.ascii_lowercase), min_size=1
-        ).filter(lambda x: x != "default"),
+        ).filter(lambda x: x not in ("default", "overlay")),
         min_size=1,
         unique=True,
     )

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -16,6 +16,7 @@
 
 from copy import deepcopy
 from functools import partial
+from pathlib import Path
 
 import pydantic
 import pytest
@@ -337,6 +338,23 @@ class TestPartData:
     def test_part_has_overlay(self, partitions):
         p = Part("foo", {}, partitions=partitions)
         assert p.has_overlay is False
+
+    @pytest.mark.parametrize(
+        ("organize", "result"),
+        [
+            ({}, False),
+            ({"this": "that"}, False),
+        ],
+    )
+    def test_part_organizes_to_overlay(self, partitions, organize, result):
+        p = Part("foo", {"organize": organize}, partitions=partitions)
+        assert p.organizes_to_overlay == result
+
+    def test_part_install_dirs(self, new_dir):
+        p = Part("foo", {"organize": {"foo": "bar"}})
+        assert p.part_install_dirs == {
+            None: Path(new_dir / "parts/foo/install"),
+        }
 
     @pytest.mark.parametrize(
         ("tc_spec", "tc_result"),


### PR DESCRIPTION
Establish the `(overlay)` target to file organization. When a part
organizes to `(overlay)`, files are moved from the part's build directory
to the top of the mounted overlay stack.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

-----
