### PR TITLE
style: switch from the `overrides` package to `typing.override`

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 from io import StringIO
 from typing import TYPE_CHECKING
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.utils.formatting_utils import humanize_list
 

--- a/craft_parts/plugins/ant_plugin.py
+++ b/craft_parts/plugins/ant_plugin.py
@@ -23,7 +23,7 @@ from collections.abc import Iterator
 from typing import Literal, cast
 from urllib.parse import urlsplit
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -23,7 +23,7 @@ import textwrap
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-from overrides import override
+from typing_extensions import override
 
 from .validator import PluginEnvironmentValidator
 

--- a/craft_parts/plugins/cargo_use_plugin.py
+++ b/craft_parts/plugins/cargo_use_plugin.py
@@ -23,7 +23,7 @@ import shutil
 import sys
 from typing import Literal
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 

--- a/craft_parts/plugins/cmake_plugin.py
+++ b/craft_parts/plugins/cmake_plugin.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/dotnet_plugin.py
+++ b/craft_parts/plugins/dotnet_plugin.py
@@ -19,7 +19,7 @@
 import logging
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from . import validator
 from .base import Plugin

--- a/craft_parts/plugins/dotnet_v2_plugin.py
+++ b/craft_parts/plugins/dotnet_v2_plugin.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Literal, cast
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.utils.formatting_utils import humanize_list
 

--- a/craft_parts/plugins/dump_plugin.py
+++ b/craft_parts/plugins/dump_plugin.py
@@ -21,7 +21,7 @@ This plugin just dumps the content from a specified part source.
 
 from typing import Literal
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/go_plugin.py
+++ b/craft_parts/plugins/go_plugin.py
@@ -19,7 +19,7 @@
 import logging
 from typing import TYPE_CHECKING, Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 

--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -19,7 +19,7 @@
 import logging
 from typing import Literal
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .go_plugin import GoPluginEnvironmentValidator

--- a/craft_parts/plugins/gradle_plugin.py
+++ b/craft_parts/plugins/gradle_plugin.py
@@ -21,9 +21,8 @@ from textwrap import dedent
 from typing import Literal, cast
 from urllib.parse import urlparse
 
-from overrides import override
 from pydantic import model_validator
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from . import validator
 from .java_plugin import JavaPlugin

--- a/craft_parts/plugins/java_plugin.py
+++ b/craft_parts/plugins/java_plugin.py
@@ -23,7 +23,7 @@ import os
 import subprocess
 import tempfile
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 

--- a/craft_parts/plugins/jlink_plugin.py
+++ b/craft_parts/plugins/jlink_plugin.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/maven_plugin.py
+++ b/craft_parts/plugins/maven_plugin.py
@@ -20,7 +20,7 @@ import pathlib
 import re
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 from craft_parts.utils.maven import create_maven_settings, update_pom

--- a/craft_parts/plugins/maven_use_plugin.py
+++ b/craft_parts/plugins/maven_use_plugin.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import re
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 from craft_parts.utils.maven import create_maven_settings, update_pom

--- a/craft_parts/plugins/meson_plugin.py
+++ b/craft_parts/plugins/meson_plugin.py
@@ -20,7 +20,7 @@ import logging
 import shlex
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from . import validator
 from .base import Plugin

--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -22,7 +22,7 @@ automatically included, e.g. stage-packages.
 
 from typing import Literal
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -24,9 +24,8 @@ from textwrap import dedent
 from typing import Any, Literal, cast
 
 import requests
-from overrides import override
 from pydantic import model_validator
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from craft_parts.errors import InvalidArchitecture
 

--- a/craft_parts/plugins/poetry_plugin.py
+++ b/craft_parts/plugins/poetry_plugin.py
@@ -22,7 +22,7 @@ import subprocess
 from typing import Literal
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.plugins import validator
 

--- a/craft_parts/plugins/qmake_plugin.py
+++ b/craft_parts/plugins/qmake_plugin.py
@@ -20,7 +20,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from .base import Plugin
 from .properties import PluginProperties

--- a/craft_parts/plugins/rust_plugin.py
+++ b/craft_parts/plugins/rust_plugin.py
@@ -24,7 +24,7 @@ from textwrap import dedent
 from typing import Literal, cast
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.constraints import UniqueList
 

--- a/craft_parts/plugins/scons_plugin.py
+++ b/craft_parts/plugins/scons_plugin.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, cast
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 

--- a/craft_parts/plugins/uv_plugin.py
+++ b/craft_parts/plugins/uv_plugin.py
@@ -20,7 +20,7 @@ import shlex
 from typing import Literal
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import errors
 from craft_parts.plugins import validator

--- a/craft_parts/pydantic_schema.py
+++ b/craft_parts/pydantic_schema.py
@@ -19,7 +19,7 @@ from functools import reduce
 from typing import Annotated, Any, TypeAlias, cast
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts import plugins, sources
 from craft_parts.plugins.nil_plugin import NilPluginProperties
@@ -49,7 +49,7 @@ class Part(pydantic.BaseModel):
     @override
     def model_json_schema(
         cls,
-        by_alias: bool = True,  # noqa: FBT001, FBT002
+        by_alias: bool = True,
         ref_template: str = pydantic.json_schema.DEFAULT_REF_TEMPLATE,
         schema_generator: type[
             pydantic.json_schema.GenerateJsonSchema
@@ -120,7 +120,7 @@ class PartsFile(pydantic.BaseModel):
     @override
     def model_json_schema(
         cls,
-        by_alias: bool = True,  # noqa: FBT001, FBT002
+        by_alias: bool = True,
         ref_template: str = pydantic.json_schema.DEFAULT_REF_TEMPLATE,
         schema_generator: type[
             pydantic.json_schema.GenerateJsonSchema

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -27,7 +27,7 @@ from typing import Any, ClassVar
 
 import pydantic
 import requests
-from overrides import overrides
+from typing_extensions import override
 
 from craft_parts.dirs import ProjectDirs
 from craft_parts.utils import os_utils, url_utils
@@ -250,7 +250,7 @@ class FileSourceHandler(SourceHandler):
     ) -> None:
         """Process the source file to extract its payload."""
 
-    @overrides
+    @override
     def pull(self) -> None:
         """Retrieve this source from its origin."""
         source_file = None

--- a/craft_parts/sources/file_source.py
+++ b/craft_parts/sources/file_source.py
@@ -19,7 +19,7 @@
 from pathlib import Path
 from typing import Any, Literal
 
-from overrides import overrides
+from typing_extensions import override
 
 from craft_parts.dirs import ProjectDirs
 
@@ -58,11 +58,11 @@ class FileSource(FileSourceHandler):
             **kwargs,
         )
 
-    @overrides
+    @override
     def provision(
         self,
         dst: Path,
-        keep: bool = False,  # noqa: FBT001, FBT002
+        keep: bool = False,
         src: Path | None = None,
     ) -> None:
         """Process the source file to extract its payload."""

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -24,8 +24,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import pydantic
-from overrides import overrides
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from craft_parts.utils.git import get_git_command
 
@@ -322,7 +321,7 @@ class GitSource(SourceHandler):
 
         return f"file://{Path(self.source).resolve()}"
 
-    @overrides
+    @override
     def pull(self) -> None:
         """Retrieve the local or remote source files."""
         if self.is_local():

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import pydantic
-from overrides import overrides
+from typing_extensions import override
 
 from craft_parts.dirs import ProjectDirs
 from craft_parts.utils import file_utils
@@ -96,7 +96,7 @@ class LocalSource(SourceHandler):
         self._updated_files: set[str] = set()
         self._updated_directories: set[str] = set()
 
-    @overrides
+    @override
     def pull(self) -> None:
         """Retrieve the local source files."""
         if not Path(self.source_abspath).exists():
@@ -109,7 +109,7 @@ class LocalSource(SourceHandler):
             copy_function=self.copy_function,
         )
 
-    @overrides
+    @override
     def check_if_outdated(
         self, target: str, *, ignore_files: list[str] | None = None
     ) -> bool:
@@ -168,7 +168,7 @@ class LocalSource(SourceHandler):
 
         return len(self._updated_files) > 0 or len(self._updated_directories) > 0
 
-    @overrides
+    @override
     def get_outdated_files(self) -> tuple[list[str], list[str]]:
         """Obtain lists of outdated files and directories.
 
@@ -179,7 +179,7 @@ class LocalSource(SourceHandler):
         """
         return (sorted(self._updated_files), sorted(self._updated_directories))
 
-    @overrides
+    @override
     def update(self) -> None:
         """Update pulled source.
 

--- a/craft_parts/sources/rpm_source.py
+++ b/craft_parts/sources/rpm_source.py
@@ -23,7 +23,7 @@ import tarfile
 from pathlib import Path
 from typing import Literal
 
-from overrides import override
+from typing_extensions import override
 
 from . import errors
 from .base import (
@@ -53,7 +53,7 @@ class RpmSource(FileSourceHandler):
     def provision(
         self,
         dst: Path,
-        keep: bool = False,  # noqa: FBT001, FBT002
+        keep: bool = False,
         src: Path | None = None,
     ) -> None:
         """Extract rpm file contents to the part source dir."""

--- a/craft_parts/sources/snap_source.py
+++ b/craft_parts/sources/snap_source.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 import yaml
-from overrides import overrides
+from typing_extensions import override
 
 from craft_parts.utils import file_utils
 
@@ -54,11 +54,11 @@ class SnapSource(FileSourceHandler):
 
     source_model = SnapSourceModel
 
-    @overrides
+    @override
     def provision(
         self,
         dst: Path,
-        keep: bool = False,  # noqa: FBT001, FBT002
+        keep: bool = False,
         src: Path | None = None,
     ) -> None:
         """Provision the snap source.

--- a/craft_parts/sources/tar_source.py
+++ b/craft_parts/sources/tar_source.py
@@ -23,7 +23,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal
 
-from overrides import overrides
+from typing_extensions import override
 
 from .base import (
     BaseFileSourceModel,
@@ -48,11 +48,11 @@ class TarSource(FileSourceHandler):
 
     source_model = TarSourceModel
 
-    @overrides
+    @override
     def provision(
         self,
         dst: Path,
-        keep: bool = False,  # noqa: FBT001, FBT002
+        keep: bool = False,
         src: Path | None = None,
     ) -> None:
         """Extract tarball contents to the part source dir."""

--- a/craft_parts/state_manager/build_state.py
+++ b/craft_parts/state_manager/build_state.py
@@ -19,7 +19,7 @@
 from typing import Annotated, Any
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 

--- a/craft_parts/state_manager/overlay_state.py
+++ b/craft_parts/state_manager/overlay_state.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 

--- a/craft_parts/state_manager/prime_state.py
+++ b/craft_parts/state_manager/prime_state.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -18,7 +18,7 @@
 
 from typing import Any
 
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 

--- a/craft_parts/state_manager/stage_state.py
+++ b/craft_parts/state_manager/stage_state.py
@@ -19,7 +19,7 @@
 from typing import Annotated, Any
 
 import pydantic
-from overrides import override
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dependencies = [
     "lxml>=5.3.0",
-    "overrides!=7.6.0",
     "pydantic>=2.0.0",
     "pyxdg",
     "PyYAML",

--- a/tests/integration/lifecycle/test_plugin_property_state.py
+++ b/tests/integration/lifecycle/test_plugin_property_state.py
@@ -23,7 +23,7 @@ import pytest
 import yaml
 from craft_parts import Action, ActionType, Part, Step, plugins
 from craft_parts.state_manager import states
-from overrides import override
+from typing_extensions import override
 
 
 def setup_function():

--- a/tests/integration/plugins/test_dotnet.py
+++ b/tests/integration/plugins/test_dotnet.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import yaml
 from craft_parts import LifecycleManager, Step
 from craft_parts.plugins import dotnet_plugin
-from overrides import override
+from typing_extensions import override
 
 
 def test_dotnet_plugin(new_dir, partitions):

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -25,8 +25,8 @@ from typing import Any
 import craft_parts.plugins.plugins
 import pytest
 from craft_parts import LifecycleManager, Step, errors, plugins
-from overrides import override
 from pytest_check.context_manager import CheckContextManager
+from typing_extensions import override
 
 
 def setup_function():

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -23,7 +23,7 @@ import craft_parts.plugins.plugins
 import pytest
 import yaml
 from craft_parts import LifecycleManager, Step, errors, plugins
-from overrides import override
+from typing_extensions import override
 
 
 def setup_function():

--- a/tests/integration/plugins/test_uv.py
+++ b/tests/integration/plugins/test_uv.py
@@ -26,7 +26,7 @@ import craft_parts.plugins.plugins
 import pytest
 import yaml
 from craft_parts import LifecycleManager, Step, errors, plugins
-from overrides import override
+from typing_extensions import override
 
 
 def setup_function():

--- a/tests/unit/plugins/test_base_python.py
+++ b/tests/unit/plugins/test_base_python.py
@@ -21,7 +21,7 @@ import pytest
 from craft_parts import Part, PartInfo, ProjectInfo
 from craft_parts.plugins.base import BasePythonPlugin
 from craft_parts.plugins.properties import PluginProperties
-from overrides import override
+from typing_extensions import override
 
 
 class FakePythonPluginProperties(PluginProperties, frozen=True):

--- a/tests/unit/plugins/test_gradle_plugin.py
+++ b/tests/unit/plugins/test_gradle_plugin.py
@@ -24,7 +24,7 @@ from craft_parts.plugins.gradle_plugin import (
     GradlePlugin,
     GradlePluginEnvironmentValidator,
 )
-from overrides import override
+from typing_extensions import override
 
 
 @pytest.fixture

--- a/tests/unit/plugins/test_java_plugin.py
+++ b/tests/unit/plugins/test_java_plugin.py
@@ -17,7 +17,7 @@ import pytest
 from craft_parts import Part, PartInfo, ProjectInfo
 from craft_parts.plugins import PluginProperties
 from craft_parts.plugins.java_plugin import JavaPlugin
-from overrides import override
+from typing_extensions import override
 
 
 class DummyJavaPlugin(JavaPlugin):

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -27,7 +27,7 @@ from craft_parts.sources.base import (
     FileSourceHandler,
     SourceHandler,
 )
-from overrides import overrides
+from typing_extensions import override
 
 # pylint: disable=attribute-defined-outside-init
 
@@ -94,11 +94,11 @@ class BarFileSource(FileSourceHandler):
 
     source_model = BarFileSourceModel
 
-    @overrides
+    @override
     def provision(
         self,
         dst: Path,
-        keep: bool = False,  # noqa: FBT001, FBT002
+        keep: bool = False,
         src: Path | None = None,
     ) -> None:
         """Extract source payload."""

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,6 @@ name = "craft-parts"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
-    { name = "overrides" },
     { name = "pydantic" },
     { name = "pyxdg" },
     { name = "pyyaml" },
@@ -464,7 +463,6 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "lxml", specifier = ">=5.3.0" },
-    { name = "overrides", specifier = "!=7.6.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyxdg" },
     { name = "pyyaml" },
@@ -1053,15 +1051,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
-name = "overrides"
-version = "7.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The overrides package doesn't work with Python 3.14 (https://github.com/mkorpela/overrides/issues/127) and we weren't using its fancy runtime features anyway - this performs the same work for us with linters.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
