### PR TITLE
fix(ci): make the trivy job really scan the venv

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -13,3 +13,5 @@ jobs:
   python-scans:
     name: Security scan
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
+    with:
+      packages: python-apt-dev


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
