### PR TITLE
docs: add docs on maven's version rewriting feature

### DIFF
--- a/docs/common/craft-parts/reference/plugins/maven_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_use_plugin.rst
@@ -68,7 +68,7 @@ version couldn't be interpreted as a semantic version, the latest locally-availa
 release following semantic versioning is selected.
 
 Finally, if no releases with semantic versions exist locally, the release that comes
-last alphabetically is used.
+last alphabetically is selected.
 
 How it works
 ------------


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

The maven-use plugin got some upgrades recently for how it selected what version to select when patching versions. The logic described can be seen here in code: https://github.com/canonical/craft-parts/blob/de525c33d03fe68a650029c87ab85b3020af3827/craft_parts/utils/maven/common.py#L483