### PR TITLE
style: fix ruff PTH211 errors

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -1169,11 +1169,7 @@ class PartHandler:
                     )
                 # The symlink already exists
                 continue
-            os.symlink(
-                src,
-                dst,
-                target_is_directory=True,
-            )
+            dst.symlink_to(src, target_is_directory=True)
 
     def _make_dirs(self) -> None:
         dirs = [

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -183,7 +183,7 @@ class AptCache(ContextDecorator):
             destination = Path(self.stage_cache, dpkg_path[1:])
             if not destination.exists():
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                os.symlink(dpkg_path, destination)
+                destination.symlink_to(dpkg_path)
         else:
             logger.warning("Cannot find 'dpkg' command needed to support multiarch")
 

--- a/tests/unit/features/partitions/executor/test_executor.py
+++ b/tests/unit/features/partitions/executor/test_executor.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+import pathlib
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -71,21 +71,19 @@ class TestExecutor:
 
         # Create symlinks if default partition aliased
         if info.is_default_partition_aliased:
-            info.alias_partition_dir.mkdir(parents=True, exist_ok=True)  # pyright: ignore[reportOptionalMemberAccess]
-            os.symlink(
-                new_path / "stage",
-                info.stage_alias_symlink,  # type: ignore[reportArgumentType]
-                target_is_directory=True,
+            assert isinstance(info.alias_partition_dir, pathlib.Path)
+            assert isinstance(info.stage_alias_symlink, pathlib.Path)
+            assert isinstance(info.prime_alias_symlink, pathlib.Path)
+            assert isinstance(info.parts_alias_symlink, pathlib.Path)
+            info.alias_partition_dir.mkdir(parents=True, exist_ok=True)
+            info.stage_alias_symlink.symlink_to(
+                new_path / "stage", target_is_directory=True
             )
-            os.symlink(
-                new_path / "prime",
-                info.prime_alias_symlink,  # type: ignore[reportArgumentType]
-                target_is_directory=True,
+            info.prime_alias_symlink.symlink_to(
+                new_path / "prime", target_is_directory=True
             )
-            os.symlink(
-                new_path / "parts",
-                info.parts_alias_symlink,  # type: ignore[reportArgumentType]
-                target_is_directory=True,
+            info.parts_alias_symlink.symlink_to(
+                new_path / "parts", target_is_directory=True
             )
 
         e = Executor(project_info=info, part_list=[p1, p2])

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import stat
 from pathlib import Path
 from textwrap import dedent
@@ -401,7 +402,7 @@ class TestFixSymlinks:
         os.makedirs("a")  # noqa: PTH103
         open("1", mode="w").close()  # noqa: PTH123
 
-        os.symlink(src, dst)
+        pathlib.Path(dst).symlink_to(src)
         normalize(new_dir, repository=DummyRepository)
 
         assert os.readlink(dst) == result  # noqa: PTH115

--- a/tests/unit/sources/test_local_source.py
+++ b/tests/unit/sources/test_local_source.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import shutil
 from pathlib import Path
 
@@ -72,7 +73,7 @@ class TestLocal:
         open(os.path.join("src", "dir", "file"), "w").close()  # noqa: PTH118, PTH123
 
         # Note that this is a symlink now instead of a directory
-        os.symlink("dummy", "destination")
+        pathlib.Path("destination").symlink_to("dummy")
 
         dirs = ProjectDirs(partitions=partitions)
         local = LocalSource("src", "destination", cache_dir=new_dir, project_dirs=dirs)
@@ -261,8 +262,8 @@ class TestLocal:
         # Create a source containing a directory, a file and symlinks to both.
         os.makedirs(os.path.join("src", "dir"))  # noqa: PTH103, PTH118
         open(os.path.join("src", "dir", "file"), "w").close()  # noqa: PTH118, PTH123
-        os.symlink("dir", os.path.join("src", "dir_symlink"))  # noqa: PTH118
-        os.symlink("file", os.path.join("src", "dir", "file_symlink"))  # noqa: PTH118
+        pathlib.Path("src", "dir_symlink").symlink_to("dir")
+        pathlib.Path("src", "dir", "file_symlink").symlink_to("file")
 
         dirs = ProjectDirs(partitions=partitions)
 

--- a/tests/unit/sources/test_tar_source.py
+++ b/tests/unit/sources/test_tar_source.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import tarfile
 from pathlib import Path
 from unittest.mock import call
@@ -111,13 +112,13 @@ class TestTarSource:
         file_to_tar = os.path.join("src", "test_prefix", "test.txt")  # noqa: PTH118
         open(file_to_tar, "w").close()  # noqa: PTH123
 
-        file_to_link = os.path.join("src", "test_prefix", "link.txt")  # noqa: PTH118
-        os.symlink("./test.txt", file_to_link)
+        file_to_link = pathlib.Path("src", "test_prefix", "link.txt")
+        file_to_link.symlink_to("./test.txt")
         assert os.path.islink(file_to_link)  # noqa: PTH114
 
         def check_for_symlink(tarinfo):
             assert tarinfo.issym()
-            assert file_to_link == tarinfo.name
+            assert file_to_link.as_posix() == tarinfo.name
             assert file_to_tar == os.path.normpath(
                 os.path.join(os.path.dirname(file_to_tar), tarinfo.linkname)  # noqa: PTH118, PTH120
             )

--- a/tests/unit/test_xattrs.py
+++ b/tests/unit/test_xattrs.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import sys
 from pathlib import Path
 
@@ -86,7 +87,7 @@ class TestXattrs:
     def test_symlink(self, test_file):
         test_symlink = test_file + "-symlink"
         try:
-            os.symlink(test_file, test_symlink)
+            pathlib.Path(test_symlink).symlink_to(test_file)
 
             result = xattrs.read_xattr(test_symlink, "attr")
             assert result is None

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pathlib
 import stat
 from pathlib import Path
 
@@ -96,7 +97,7 @@ class TestLinkOrCopyTree:
 
     def test_link_symlink_to_file(self):
         # Create a symlink to a file
-        os.symlink("2", os.path.join("foo", "2-link"))  # noqa: PTH118
+        pathlib.Path("foo", "2-link").symlink_to("2")
         file_utils.link_or_copy_tree("foo", "qux")
         # Verify that the symlink remains a symlink
         link = os.path.join("qux", "2-link")  # noqa: PTH118
@@ -104,7 +105,7 @@ class TestLinkOrCopyTree:
         assert os.readlink(link) == "2"  # noqa: PTH115
 
     def test_link_symlink_to_dir(self):
-        os.symlink("bar", os.path.join("foo", "bar-link"))  # noqa: PTH118
+        pathlib.Path("foo", "bar-link").symlink_to("bar")
         file_utils.link_or_copy_tree("foo", "qux")
 
         # Verify that the symlink remains a symlink


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Ruff 0.13 adds PTH211 as a lint rule. This fixes those.