### PR TITLE
fix?(RepositoryProxy): make RepositoryProxy mockable

### DIFF
--- a/craft_parts/packages/__init__.py
+++ b/craft_parts/packages/__init__.py
@@ -70,7 +70,7 @@ class _RepositoryProxy:
     def __delattr__(self, attr: str) -> None:
         repo = _get_repository_for_platform()
         logger.debug(
-            "delete repository attribute: attr=%s, value=%s, repo:%s", attr, value, repo
+            "delete repository attribute: attr=%s, repo:%s", attr, repo
         )
         delattr(repo, attr)
 


### PR DESCRIPTION
This makes the RepositoryProxy act more like a regular object by allowing the deletion of attributes. If I'm correct, this was the cause of the unit tests blowing up in https://github.com/canonical/snapcraft/pull/5725

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
