### PR TITLE
fix: clean the package cache when underlying layers are cleaned

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -40,7 +40,6 @@ from craft_parts.parts import (
     Part,
     get_parts_with_overlay,
     has_overlay_visibility,
-    part_position,
 )
 from craft_parts.plugins import Plugin
 from craft_parts.state_manager import (
@@ -1072,7 +1071,7 @@ class PartHandler:
         _remove(self._part.part_state_dir / "layer_hash")
         # Clean the package cache if the part was below it and if the
         # cache was not directly on top of the base layer.
-        part_level = part_position(self._part, part_list=self._part_list)
+        part_level = self._part_list.index(self._part)
         if part_level < self._overlay_manager.cache_level:
             _remove(self._part.dirs.overlay_packages_dir)
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1093,20 +1093,6 @@ def sort_parts(part_list: list[Part]) -> list[Part]:
     return sorted_parts
 
 
-def part_position(part: Part, *, part_list: list[Part]) -> int:
-    """Return the position of a part in the part list.
-
-    :param part: The part to get the position of.
-    :param part_list: The list of parts to look into.
-
-    :returns: The part position
-    """
-    for i, p in enumerate(part_list):
-        if p.name == part.name:
-            return i
-    raise errors.InvalidPartName(part.name)
-
-
 def part_dependencies(
     part: Part, *, part_list: list[Part], recursive: bool = False
 ) -> set[Part]:

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -504,20 +504,6 @@ class TestPartHelpers:
             parts.part_list_by_name(["bar", "invalid"], [p1, p2, p3])
         assert raised.value.part_name == "invalid"
 
-    def test_part_position(self, partitions):
-        p1 = Part("foo", {}, partitions=partitions)
-        p2 = Part("bar", {}, partitions=partitions)
-        p3 = Part("baz", {}, partitions=partitions)
-
-        x = parts.part_position(p2, part_list=[p1, p2, p3])
-        assert x == 1
-
-        with pytest.raises(errors.InvalidPartName) as raised:
-            parts.part_position(
-                Part("invalid", {}, partitions=partitions), part_list=[p1, p2, p3]
-            )
-        assert raised.value.part_name == "invalid"
-
     def test_part_dependencies(self, partitions):
         p1 = Part("foo", {"after": ["bar", "baz"]}, partitions=partitions)
         p2 = Part("bar", {"after": ["qux"]}, partitions=partitions)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Make sure to clean the package cache layer when an underlying layer is cleaned. 

Fixes #1229
CRAFT-4728