### PR TITLE
docs: improve the file migration explanation

### DIFF
--- a/docs/common/craft-parts/explanation/file-migration.rst
+++ b/docs/common/craft-parts/explanation/file-migration.rst
@@ -33,33 +33,42 @@ initially migrated files from part-specific directories, and is called the
 Simple file migration
 ---------------------
 
-During the execution of the lifecycle, files from the part's install directory
-are migrated to the stage area and from there to prime. In the following diagram,
-files are represented as circles with letters. The green circles correspond to
-files from part 1, while blue circles represent files from part 2.
+During the execution of the lifecycle, files from the part's install directory are
+migrated to the stage area and from there to prime.
 
-.. image:: /common/craft-parts/images/simple_migration.svg
+When files from a specific part need to be migrated from stage to prime or removed from
+stage or prime, the migration tracking state contains the list of files to migrate or
+remove.
 
-Files A and B originate from part 1, while files C and D
-originate from part 2. They are staged into a common area, and then migrated
-to the prime directory. Note that file D is filtered out when priming, and
-is not part of the final primed contents. The migration tracking state for parts
-1 and 2 is obtained from the contents of each of the parts' install directories
-while they're still separate (marked with red ellipses in the diagram).
+.. figure:: /common/craft-parts/images/simple_migration.svg
+    :align: left
+    :alt: A diagram showing the migration tracking state of files from two parts,
+        described in more detail below.
 
-When files from a specific part need to be migrated from stage to prime or
-removed from stage or prime, the migration tracking state contains the list
-of files to migrate or remove.
+    The migration of files between lifecycle steps. Each labelled circle is a file.
+    Each black rectangle is a directory.
+
+    Files A and B originate from Part 1, while files C and D originate from part 2.
+    They are staged into a common area, and then migrated to the prime directory.
+    Observe that file D is filtered out when priming, and isn't in the final primed
+    contents.
+
+    The migration tracking state for parts 1 and 2 is obtained from the contents of
+    each part's install directories while they're still separate, as indicated by the
+    red ellipses.
 
 
 File migration with partitions
 ------------------------------
 
+When the partitions feature is enabled, files can be organized from a part's
 install directory to a different partition. In this case, files are migrated
 When the partitions feature is in use, files can be organized from a part's
 to the partition's own stage and prime directories.
 
 .. image:: /common/craft-parts/images/partition_migration.svg
+    :alt: A diagram showing the migration tracking state of files when partitions are
+        in use, described in more detail below.
 
 When partitions are used, an operation to remove or migrate files from a
 specific part happens across all partitions. In this example, if files from
@@ -76,15 +85,23 @@ install directory and the overlay area. In the diagram, files from the overlay
 are represented as squares, and files from the build install are represented
 as circles.
 
-.. image:: /common/craft-parts/images/overlay_migration.svg
+When the overlays are in use, files can originate from both the part's install
+directory and the overlay area.
 
-If overlays are used, it's important to note that the files originating from
-the overlay form a set that are moved or deleted as a group. In the example
-above, if files from part 1 are to be deleted from prime, only files ``A``
-and ``B`` are removed. Overlay files are only removed when files from all parts
-containing overlay files are removed. Conversely, when files are migrated, the
-entire set of overlay files is migrated along with the first part that contains
-overlay files.
+.. figure:: /common/craft-parts/images/overlay_migration.svg
+    :align: left
+    :alt: A diagram showing the migration tracking state of files when overlays
+        are in use, described in more detail below.
+
+    File migration involving overlays. Files from the overlay are represented as
+    squares, and files from the build install are represented as circles.
+
+If overlays are used, it's important to note that the files originating from the
+overlay form a set that are moved or deleted as one. In the previous diagram, if
+files from part 1 are to be deleted from prime, only files A and B are removed.
+Overlay files are only removed when files from all parts containing overlay
+files are removed. Conversely, when files are migrated, the entire set of
+overlay files is migrated along with the first part that contains overlay files.
 
 If a part depends on another part, cleaning the latter will also cause the
 former to be cleaned.
@@ -98,6 +115,8 @@ be moved to other partitions using mount maps. This operation also generates a
 migration state to keep track of the files originating part.
 
 .. image:: /common/craft-parts/images/partition_overlay_migration.svg
+    :alt: A diagram showing the migration tracking state of files when both overlays
+        and partitions are in use, described in more detail below.
 
 The same constraints for overlay file removal and migration apply, extended to
 all partitions. In the example above, if files from part 1 are to be removed


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Addresses the remaining points from @medubelko's review in #1152. In particular,

- A couple of paragraph rephrasings were accepted wholesale
- `image::`s that needed a caption were converted to `figure::`s.
- Alt text was added to all images. For this, the site recommended for alt text guidelines did not contain information about complex images/diagrams, so I used [W3's alt text guidelines](https://www.w3.org/WAI/tutorials/images/complex/)