### PR TITLE
fix: explicitly use build output directory

### DIFF
--- a/tests/integration/plugins/test_gradle/init.gradle
+++ b/tests/integration/plugins/test_gradle/init.gradle
@@ -1,7 +1,7 @@
 allprojects {
     tasks.register('testWrite') {
         doLast {
-            def outputFile = new File("${System.getProperty('user.dir')}/test.txt")
+            def outputFile = layout.buildDirectory.file("test.txt").get().asFile
             outputFile.text = "hello world"
         }
     }


### PR DESCRIPTION
Instead of user.dir which may be reset by the Gradle daemon use gradle build output directory to write the test file

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
