### PR TITLE
style: add easy noqa fixes

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -246,7 +246,8 @@ class XAttributeError(PartsError):
         self,
         key: str,
         path: str,
-        is_write: bool = False,  # noqa: FBT001, FBT002
+        *,
+        is_write: bool = False,
     ) -> None:
         self.key = key
         self.path = path

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -1026,7 +1026,6 @@ class PartHandler:
                 primed_whiteout.unlink()
                 logger.debug("unlinked '%s'", str(primed_whiteout))
             except OSError as err:
-                # XXX: fuse-overlayfs creates a .wh..opq file in part layer dir?  # noqa: FIX003
                 logger.debug("error unlinking '%s': %s", str(primed_whiteout), err)
 
     def clean_step(self, step: Step) -> None:

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -376,9 +376,9 @@ def _verify_marked_install(package: apt.package.Package) -> None:
 
     broken_deps: list[str] = []
     for package_dependencies in package.candidate.dependencies:
-        for dep in package_dependencies:
-            if not dep.target_versions:
-                broken_deps.append(dep.name)  # noqa: PERF401
+        broken_deps.extend(
+            [dep.name for dep in package_dependencies if not dep.target_versions]
+        )
     raise errors.PackageBroken(package.name, deps=broken_deps)
 
 

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -377,7 +377,7 @@ def _verify_marked_install(package: apt.package.Package) -> None:
     broken_deps: list[str] = []
     for package_dependencies in package.candidate.dependencies:
         broken_deps.extend(
-            [dep.name for dep in package_dependencies if not dep.target_versions]
+            dep.name for dep in package_dependencies if not dep.target_versions
         )
     raise errors.PackageBroken(package.name, deps=broken_deps)
 

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -21,7 +21,9 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import Any, override
+from typing import Any
+
+from typing_extensions import override
 
 from craft_parts import xattrs
 

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -21,7 +21,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, override
 
 from craft_parts import xattrs
 
@@ -79,8 +79,6 @@ class BaseRepository(abc.ABC):
 
         :param package_names: A list with the names of the packages to download.
         """
-
-    # XXX: list-only functionality can be a method called by install_build_packages  # noqa: FIX003
 
     @classmethod
     @abc.abstractmethod
@@ -181,58 +179,68 @@ RepositoryType = type[BaseRepository]
 class DummyRepository(BaseRepository):
     """A dummy repository."""
 
+    @override
     @classmethod
     def configure(cls, application_package_name: str) -> None:
         """Set up the repository."""
 
+    @override
     @classmethod
-    def get_package_libraries(cls, package_name: str) -> set[str]:  # noqa: ARG003
+    def get_package_libraries(cls, package_name: str) -> set[str]:
         """Return a list of libraries in package_name."""
         return set()
 
+    @override
     @classmethod
-    def get_packages_for_source_type(cls, source_type: str) -> set[str]:  # noqa: ARG003
+    def get_packages_for_source_type(cls, source_type: str) -> set[str]:
         """Return a list of packages required to to work with source_type."""
         return set()
 
+    @override
     @classmethod
     def refresh_packages_list(cls) -> None:
         """Refresh the build packages cache."""
 
+    @override
     @classmethod
     def download_packages(cls, package_names: list[str]) -> None:
         """Download the specified packages to the local package cache."""
 
+    @override
     @classmethod
     def install_packages(
         cls,
-        package_names: list[str],  # noqa: ARG003
+        package_names: list[str],
         *,
-        list_only: bool = False,  # noqa: ARG003
-        refresh_package_cache: bool = True,  # noqa: ARG003
+        list_only: bool = False,
+        refresh_package_cache: bool = True,
     ) -> list[str]:
         """Install packages on the host system."""
         logger.debug("Package manager not defined, not installing any packages")
         return []
 
+    @override
     @classmethod
-    def is_package_installed(cls, package_name: str) -> bool:  # noqa: ARG003
+    def is_package_installed(cls, package_name: str) -> bool:
         """Inform if a packahe is installed on the host system."""
         return False
 
+    @override
     @classmethod
     def get_installed_packages(cls) -> list[str]:
         """Obtain a list of the installed packages and their versions."""
         return []
 
+    @override
     @classmethod
     def fetch_stage_packages(
         cls,
-        **kwargs: Any,  # noqa: ARG003
+        **kwargs: Any,
     ) -> list[str]:
         """Fetch stage packages to stage_packages_path."""
         return []
 
+    @override
     @classmethod
     def unpack_stage_packages(
         cls,

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -610,7 +610,6 @@ class Ubuntu(BaseRepository):
             return []
 
         if _is_list_of_slices(package_names):
-            # TODO: fetching of Chisel slices is not supported yet.  # noqa: FIX002
             return package_names
 
         # Have static type checkers ignore until we can use PEP 612 (Python 3.10)

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -28,7 +28,7 @@ import tempfile
 from collections.abc import Callable, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from craft_parts.utils import deb_utils, file_utils, os_utils
 
@@ -282,11 +282,14 @@ _IGNORE_FILTERS: dict[str, set[str]] = {
 }
 
 
-def _apt_cache_wrapper(method: Any) -> Callable[..., Any]:  # noqa: ANN401
+_T_wrapper = TypeVar("_T_wrapper")
+
+
+def _apt_cache_wrapper(method: Callable[..., _T_wrapper]) -> Callable[..., _T_wrapper]:
     """Decorate a method to handle apt availability."""
 
     @functools.wraps(method)
-    def wrapped(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    def wrapped(*args: Any, **kwargs: Any) -> _T_wrapper:
         if not _APT_CACHE_AVAILABLE:
             raise errors.PackageBackendNotSupported("apt")
         return method(*args, **kwargs)

--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -23,6 +23,7 @@ import pathlib
 import subprocess
 import sys
 from collections.abc import Sequence
+from http import HTTPStatus
 from typing import (
     Any,
     cast,
@@ -135,7 +136,7 @@ class SnapPackage:
                         http_error.response.status_code,
                         retry_count,
                     )
-                    if http_error.response.status_code == 404:  # noqa: PLR2004
+                    if http_error.response.status_code == HTTPStatus.NOT_FOUND:
                         raise errors.SnapUnavailable(
                             snap_name=self.name, snap_channel=self.channel
                         ) from http_error

--- a/craft_parts/packages/yum.py
+++ b/craft_parts/packages/yum.py
@@ -141,10 +141,6 @@ class YUMRepository(BaseRepository):
             else:
                 logger.debug("Requested packages already installed: %s", package_names)
 
-        # XXX Facundo 2023-02-07: the information returned by this method is not used  # noqa: FIX003
-        # anywhere, so we should clean it up and just return None (here, and in the
-        # Ubuntu repository too, where a further cleaning should be done) -- related
-        # to this, `list_only` should go away.
         return []
 
     @classmethod

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -22,7 +22,7 @@ import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, TypeVar
 
 from pydantic import (
     BaseModel,
@@ -47,6 +47,8 @@ from craft_parts.utils.partition_utils import (
     get_partition_dir_map,
 )
 from craft_parts.utils.path_utils import get_partition_and_path
+
+_T_validate = TypeVar("_T_validate")
 
 
 class PartSpec(BaseModel):
@@ -523,7 +525,7 @@ class PartSpec(BaseModel):
 
     @field_validator("overlay_packages", "overlay_files", "overlay_script")
     @classmethod
-    def validate_overlay_feature(cls, item: Any) -> Any:  # noqa: ANN401
+    def validate_overlay_feature(cls, item: _T_validate) -> _T_validate:
         """Check if overlay attributes specified when feature is disabled."""
         if not Features().enable_overlay:
             raise ValueError("overlays not supported")

--- a/craft_parts/pydantic_schema.py
+++ b/craft_parts/pydantic_schema.py
@@ -98,7 +98,6 @@ class Part(pydantic.BaseModel):
         plugin_defs = plugin_json_schema.pop("$defs")
         for model in plugin_defs.values():
             # Allow extra parts properties for the plugin.
-            # TODO: These should get their own models.  # noqa: FIX002
             model["patternProperties"] = {  # type:ignore[index]
                 r"^source\-": {},
                 r"^override\-": {"type": "string"},

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -64,7 +64,6 @@ class InvalidSourceOption(SourceError):  # noqa: N818
         super().__init__(brief=brief, resolution=resolution)
 
 
-# TODO: Merge this with InvalidSourceOption above  # noqa: FIX002
 class InvalidSourceOptions(SourceError):  # noqa: N818
     """A source option is not allowed for the given source type.
 

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -52,7 +52,6 @@ class GitSourceModel(BaseSourceModel, frozen=True):  # type: ignore[misc]
     source_depth: int = 0
     source_submodules: list[str] | None = None
 
-    # TODO: make these mutually exclusive fields declarative with a jsonschema too.  # noqa: FIX002
     @pydantic.model_validator(mode="after")
     def _validate_mutually_exclusive_fields(self) -> Self:
         if self.source_tag and self.source_branch:

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -39,6 +39,9 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+MAX_COMMIT_LENGTH = 40
+
+
 class GitSourceModel(BaseSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a git-based source."""
 
@@ -175,7 +178,7 @@ class GitSource(SourceHandler):
     def _expand_commit(self, commit: str) -> str:
         """Expand a commit hash to full length."""
         # short-circuit if the commit is already full length
-        if len(commit) == 40:  # noqa: PLR2004 (magic-value)
+        if len(commit) == MAX_COMMIT_LENGTH:
             return commit
 
         try:
@@ -196,7 +199,7 @@ class GitSource(SourceHandler):
                 raise errors.VCSError(
                     message=f"Failed to parse commit {commit!r}.",
                     resolution=(
-                        "Ensure 'source-commit' is correct, provide a full-length (40 character) commit, "
+                        f"Ensure 'source-commit' is correct, provide a full-length ({MAX_COMMIT_LENGTH} character) commit, "
                         "or remove the 'source-depth' key from the part."
                     ),
                 ) from err

--- a/craft_parts/sources/local_source.py
+++ b/craft_parts/sources/local_source.py
@@ -42,8 +42,6 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
-# TODO: change file operations to use pathlib  # noqa: FIX002
-
 
 class LocalSourceModel(BaseSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a generic local source."""

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -19,10 +19,11 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, override
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import override
 
 from craft_parts.infos import ProjectOptions
 from craft_parts.utils import os_utils

--- a/craft_parts/state_manager/step_state.py
+++ b/craft_parts/state_manager/step_state.py
@@ -19,7 +19,7 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, override
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -169,8 +169,9 @@ class StepState(MigrationState, ABC):
             self.project_options_of_interest(other_project_options),
         )
 
+    @override
     @classmethod
-    def unmarshal(cls, data: dict[str, Any]) -> "StepState":  # noqa: ARG003
+    def unmarshal(cls, data: dict[str, Any]) -> "StepState":
         """Create and populate a new state object from dictionary data."""
         raise RuntimeError("this must be implemented by the step-specific class.")
 

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -274,9 +274,6 @@ def umount(mountpoint: str, *args: str) -> None:
             )
 
 
-# TODO: consolidate os-release strategy with craft-providers/charmcraft  # noqa: FIX002
-
-
 class OsRelease:
     """A class to intelligently determine the OS on which we're running."""
 

--- a/craft_parts/xattrs.py
+++ b/craft_parts/xattrs.py
@@ -16,6 +16,7 @@
 
 """Helpers to read and write filesystem extended attributes."""
 
+import errno
 import logging
 import os
 import sys
@@ -49,7 +50,7 @@ def read_xattr(path: str, key: str) -> str | None:
     except OSError as error:
         # No label present with:
         # OSError: [Errno 61] No data available: b'<path>'
-        if error.errno == 61:  # noqa: PLR2004
+        if error.errno == errno.ENODATA:
             return None
 
         # Chain unknown variants of OSError.
@@ -79,7 +80,7 @@ def write_xattr(path: str, key: str, value: str) -> None:
     except OSError as error:
         # Label is too long for filesystem:
         # OSError: [Errno 7] Argument list too long: b'<path>'
-        if error.errno == 7:  # noqa: PLR2004
+        if error.errno == errno.E2BIG:
             raise errors.XAttributeTooLong(path=path, key=key, value=value) from error
 
         # Chain unknown variants of OSError.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,6 +383,8 @@ classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
     "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
     "PLR2004", # Allow magic values in tests
     "SLF",     # Allow accessing private members from tests.
+    # Custom configurations for craft-parts
+    "FBT",     # Many fixtures return bools
 ]
 "__init__.py" = [
     "I001", # isort leaves init files alone by default, this makes ruff ignore them too.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,9 +256,6 @@ def http_server(request):
     server_thread.join()
 
 
-# XXX: check windows compatibility, explore if fixture setup can skip itself  # noqa: FIX003
-
-
 @pytest.fixture(scope="class")
 def fake_snapd():
     """Provide a fake snapd server."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,8 +292,8 @@ def dependency_fixture(new_dir):
 
     def create_dependency_fixture(
         name: str,
-        broken: bool = False,  # noqa: FBT001, FBT002
-        invalid: bool = False,  # noqa: FBT001, FBT002
+        broken: bool = False,
+        invalid: bool = False,
         output: str | None = None,
     ) -> Path:
         """Creates a mock executable dependency.

--- a/tests/integration/features/partitions/executor/test_collisions.py
+++ b/tests/integration/features/partitions/executor/test_collisions.py
@@ -1,4 +1,4 @@
-# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-  # noqa: INP001
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright 2024 Canonical Ltd.
 #
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 from craft_parts import LifecycleManager, Step
 from craft_parts.errors import PartFilesConflict
+
 from tests.integration.executor import test_collisions
 
 

--- a/tests/integration/packages/test_snaps.py
+++ b/tests/integration/packages/test_snaps.py
@@ -1,4 +1,4 @@
-# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-  # noqa: INP001
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright 2024 Canonical Ltd.
 #

--- a/tests/integration/plugins/test_make.py
+++ b/tests/integration/plugins/test_make.py
@@ -1,1 +1,0 @@
-# TODO: add make plugin integration test after executor lands  # noqa: FIX002

--- a/tests/integration/plugins/test_poetry.py
+++ b/tests/integration/plugins/test_poetry.py
@@ -138,7 +138,7 @@ def test_poetry_plugin_override_get_system_interpreter(
 def test_poetry_plugin_no_system_interpreter(
     new_dir,
     partitions,
-    remove_symlinks: bool,  # noqa: FBT001
+    remove_symlinks: bool,
     parts_dict,
 ):
     """Check that the build fails if a payload interpreter is needed but not found."""

--- a/tests/integration/plugins/test_python.py
+++ b/tests/integration/plugins/test_python.py
@@ -159,7 +159,7 @@ def test_python_plugin_override_get_system_interpreter(new_dir, partitions):
 def test_python_plugin_no_system_interpreter(
     new_dir,
     partitions,
-    remove_symlinks: bool,  # noqa: FBT001
+    remove_symlinks: bool,
 ):
     """Check that the build fails if a payload interpreter is needed but not found."""
 

--- a/tests/integration/plugins/test_uv.py
+++ b/tests/integration/plugins/test_uv.py
@@ -128,7 +128,7 @@ def test_uv_plugin_no_system_interpreter(
     new_dir,
     partitions,
     uv_parts_simple,
-    remove_symlinks: bool,  # noqa: FBT001
+    remove_symlinks: bool,
 ):
     """Check that the build fails if a payload interpreter is needed but not found."""
 

--- a/tests/unit/executor/test_migration.py
+++ b/tests/unit/executor/test_migration.py
@@ -357,8 +357,6 @@ class TestFileMigration:
 
         assert new_mode == stat.S_IMODE(Path(stage_dir, "foo").stat().st_mode)
 
-    # TODO: add test_migrate_files_preserves_file_mode_chown_permissions  # noqa: FIX002
-
     def test_migrate_files_preserves_directory_mode(self, partitions):
         install_dir = Path("install")
         stage_dir = Path("stage")
@@ -557,7 +555,6 @@ class TestHelpers:
         assert foo_path.is_file()
         assert bar_path.is_file()
 
-        # TODO: also test files shared with overlay  # noqa: FIX002
         for partition in partitions or (None,):
             migration.clean_shared_area(
                 part_name="p1",

--- a/tests/unit/features/overlay/test_parts.py
+++ b/tests/unit/features/overlay/test_parts.py
@@ -77,7 +77,7 @@ class TestPartSpecs:
 
     def test_unmarshal_not_dict(self):
         with pytest.raises(TypeError) as raised:
-            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
+            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues]
         assert str(raised.value) == "part data is not a dictionary"
 
     def test_unmarshal_mix_packages_slices(self, mocker):
@@ -403,7 +403,7 @@ class TestPartUnmarshal:
 
     def test_part_spec_not_dict(self):
         with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
+            Part("foo", False)  # type: ignore[reportGeneralTypeIssues]
         assert raised.value.part_name == "foo"
         assert raised.value.message == "part data is not a dictionary"
 

--- a/tests/unit/features/partitions/sources/test_local_source.py
+++ b/tests/unit/features/partitions/sources/test_local_source.py
@@ -1,4 +1,4 @@
-# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-  # noqa: INP001
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
 # Copyright 2024 Canonical Ltd.
 #
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+
 from tests.unit.sources import test_local_source
 
 

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -61,9 +61,8 @@ class TestHelpers:
         assert overlays.oci_whited_out_file(Path(oci_name)) == Path(name)
 
     def test_oci_whited_out_file_error(self):
-        with pytest.raises(ValueError) as raised:  # noqa: PT011
+        with pytest.raises(ValueError, match="argument is not an OCI whiteout file"):
             overlays.oci_whited_out_file(Path("whatever"))
-        assert str(raised.value) == "argument is not an OCI whiteout file"
 
     @pytest.mark.parametrize(
         ("name", "oci_name"),

--- a/tests/unit/overlays/test_overlays.py
+++ b/tests/unit/overlays/test_overlays.py
@@ -61,7 +61,7 @@ class TestHelpers:
         assert overlays.oci_whited_out_file(Path(oci_name)) == Path(name)
 
     def test_oci_whited_out_file_error(self):
-        with pytest.raises(ValueError, match="argument is not an OCI whiteout file"):
+        with pytest.raises(ValueError, match="^argument is not an OCI whiteout file$"):
             overlays.oci_whited_out_file(Path("whatever"))
 
     @pytest.mark.parametrize(

--- a/tests/unit/packages/conftest.py
+++ b/tests/unit/packages/conftest.py
@@ -21,7 +21,7 @@ import pytest
 def fake_apt_cache(mocker):
     def get_installed_version(
         package_name,
-        resolve_virtual_packages=False,  # noqa: FBT002
+        resolve_virtual_packages=False,
     ):  # pylint: disable=unused-argument
         if "installed" in package_name:
             return "1.0"

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -98,26 +98,24 @@ class TestGetPlugin:
         project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(project_info=project_info, part=part)
 
-        with pytest.raises(ValueError) as raised:  # noqa: PT011
+        with pytest.raises(ValueError, match="plugin not registered: 'invalid'"):
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
                 properties=None,  # type: ignore[reportGeneralTypeIssues]
             )
-        assert str(raised.value) == "plugin not registered: 'invalid'"
 
     def test_get_plugin_unspecified(self, new_dir):
         part = Part("foo", {})
         project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(project_info=project_info, part=part)
 
-        with pytest.raises(ValueError) as raised:  # noqa: PT011
+        with pytest.raises(ValueError, match="plugin not registered: 'foo'"):
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
                 properties=None,  # type: ignore[reportGeneralTypeIssues]
             )
-        assert str(raised.value) == "plugin not registered: 'foo'"
 
 
 class FooPlugin(plugins.Plugin):
@@ -142,7 +140,7 @@ class TestPluginRegistry:
     """Verify plugin register/unregister functions."""
 
     def test_register_unregister(self):
-        with pytest.raises(ValueError):  # noqa: PT011
+        with pytest.raises(ValueError, match="plugin not registered: 'plugin1'"):
             plugins.get_plugin_class("plugin1")
 
         plugins.register(
@@ -168,12 +166,12 @@ class TestPluginRegistry:
 
         # assert plugins are unregistered
         for plugin in ["plugin1", "plugin2", "plugin3"]:
-            with pytest.raises(ValueError):  # noqa: PT011
+            with pytest.raises(ValueError, match=f"plugin not registered: {plugin!r}"):
                 plugins.get_plugin_class(plugin)
 
         # unregister all plugins
         plugins.unregister_all()
-        with pytest.raises(ValueError):  # noqa: PT011
+        with pytest.raises(ValueError, match="plugin not registered: 'plugin4'"):
             plugins.get_plugin_class("plugin4")
 
 

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -98,7 +98,7 @@ class TestGetPlugin:
         project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(project_info=project_info, part=part)
 
-        with pytest.raises(ValueError, match="plugin not registered: 'invalid'"):
+        with pytest.raises(ValueError, match="^plugin not registered: 'invalid'$"):
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
@@ -110,7 +110,7 @@ class TestGetPlugin:
         project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
         part_info = PartInfo(project_info=project_info, part=part)
 
-        with pytest.raises(ValueError, match="plugin not registered: 'foo'"):
+        with pytest.raises(ValueError, match="^plugin not registered: 'foo'$"):
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
@@ -140,7 +140,7 @@ class TestPluginRegistry:
     """Verify plugin register/unregister functions."""
 
     def test_register_unregister(self):
-        with pytest.raises(ValueError, match="plugin not registered: 'plugin1'"):
+        with pytest.raises(ValueError, match="^plugin not registered: 'plugin1'$"):
             plugins.get_plugin_class("plugin1")
 
         plugins.register(
@@ -171,7 +171,7 @@ class TestPluginRegistry:
 
         # unregister all plugins
         plugins.unregister_all()
-        with pytest.raises(ValueError, match="plugin not registered: 'plugin4'"):
+        with pytest.raises(ValueError, match="^plugin not registered: 'plugin4'$"):
             plugins.get_plugin_class("plugin4")
 
 

--- a/tests/unit/sources/test_checksum.py
+++ b/tests/unit/sources/test_checksum.py
@@ -39,9 +39,8 @@ def test_split_checksum_happy(tc_checksum, tc_algorithm, tc_digest):
 
 @pytest.mark.parametrize("tc_checksum", ["", "something"])
 def test_split_checksum_error(tc_checksum):
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match=f"invalid checksum format: {tc_checksum!r}"):
         checksum.split_checksum(tc_checksum)
-    assert str(raised.value) == f"invalid checksum format: '{tc_checksum}'"
 
 
 @pytest.mark.parametrize(
@@ -60,23 +59,24 @@ def test_verify_checksum_happy(tc_checksum, tc_checkfile):
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_invalid_algorithm():
     Path("checkfile").write_text("content")
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match="unsupported algorithm 'invalid'"):
         checksum.verify_checksum("invalid/digest", Path("checkfile"))
-    assert str(raised.value) == "unsupported algorithm 'invalid'"
 
 
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_value_error():
     Path("checkfile").write_text("content")
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match="invalid checksum format: 'invalid'"):
         checksum.verify_checksum("invalid", Path("checkfile"))
-    assert str(raised.value) == "invalid checksum format: 'invalid'"
 
 
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_digest_error():
     Path("checkfile").write_text("content")
-    with pytest.raises(errors.ChecksumMismatch) as raised:
+    expected_digest = "digest"
+    actual_digest = "9a0364b9e99bb480dd25e1f0284c8555"
+    with pytest.raises(
+        errors.ChecksumMismatch,
+        match=f"Expected digest {expected_digest}, obtained {actual_digest}",
+    ):
         checksum.verify_checksum("md5/digest", Path("checkfile"))
-    assert raised.value.expected == "digest"
-    assert raised.value.obtained == "9a0364b9e99bb480dd25e1f0284c8555"

--- a/tests/unit/sources/test_checksum.py
+++ b/tests/unit/sources/test_checksum.py
@@ -59,14 +59,14 @@ def test_verify_checksum_happy(tc_checksum, tc_checkfile):
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_invalid_algorithm():
     Path("checkfile").write_text("content")
-    with pytest.raises(ValueError, match="unsupported algorithm 'invalid'"):
+    with pytest.raises(ValueError, match="^unsupported algorithm 'invalid'$"):
         checksum.verify_checksum("invalid/digest", Path("checkfile"))
 
 
 @pytest.mark.usefixtures("new_dir")
 def test_verify_checksum_value_error():
     Path("checkfile").write_text("content")
-    with pytest.raises(ValueError, match="invalid checksum format: 'invalid'"):
+    with pytest.raises(ValueError, match="^invalid checksum format: 'invalid'$"):
         checksum.verify_checksum("invalid", Path("checkfile"))
 
 
@@ -77,6 +77,6 @@ def test_verify_checksum_digest_error():
     actual_digest = "9a0364b9e99bb480dd25e1f0284c8555"
     with pytest.raises(
         errors.ChecksumMismatch,
-        match=f"Expected digest {expected_digest}, obtained {actual_digest}",
+        match=rf"^Expected digest {expected_digest}, obtained {actual_digest}\.$",
     ):
         checksum.verify_checksum("md5/digest", Path("checkfile"))

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -70,7 +70,7 @@ class TestBuildState:
         assert err[0]["type"] == "value_error"
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="state data is not a dictionary"):
+        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
             BuildState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -70,9 +70,8 @@ class TestBuildState:
         assert err[0]["type"] == "value_error"
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError) as raised:
-            BuildState.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-        assert str(raised.value) == "state data is not a dictionary"
+        with pytest.raises(TypeError, match="state data is not a dictionary"):
+            BuildState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -60,9 +60,8 @@ class TestPrimeState:
         assert state.marshal() == state_data
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError) as raised:
-            PrimeState.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-        assert str(raised.value) == "state data is not a dictionary"
+        with pytest.raises(TypeError, match="state data is not a dictionary"):
+            PrimeState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -60,7 +60,7 @@ class TestPrimeState:
         assert state.marshal() == state_data
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="state data is not a dictionary"):
+        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
             PrimeState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -62,7 +62,7 @@ class TestPullState:
         assert state.marshal() == state_data
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="state data is not a dictionary"):
+        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
             PullState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -62,9 +62,8 @@ class TestPullState:
         assert state.marshal() == state_data
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError) as raised:
-            PullState.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-        assert str(raised.value) == "state data is not a dictionary"
+        with pytest.raises(TypeError, match="state data is not a dictionary"):
+            PullState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -68,7 +68,7 @@ class TestStageState:
         assert err[0]["type"] == "value_error"
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="state data is not a dictionary"):
+        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
             StageState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -68,9 +68,8 @@ class TestStageState:
         assert err[0]["type"] == "value_error"
 
     def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError) as raised:
-            StageState.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-        assert str(raised.value) == "state data is not a dictionary"
+        with pytest.raises(TypeError, match="state data is not a dictionary"):
+            StageState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/test_filesystem_mounts.py
+++ b/tests/unit/test_filesystem_mounts.py
@@ -40,7 +40,9 @@ def test_filesystem_mount_item_marshal_unmarshal():
 
 
 def test_filesystem_mount_item_unmarshal_not_dict():
-    with pytest.raises(TypeError, match="Filesystem input data must be a dictionary."):
+    with pytest.raises(
+        TypeError, match=r"^Filesystem input data must be a dictionary\.$"
+    ):
         FilesystemMountItem.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
@@ -90,7 +92,7 @@ def test_filesystem_mount_marshal_unmarshal():
 
 
 def test_filesystem_mount_unmarshal_not_list():
-    with pytest.raises(TypeError, match="Filesystem entry must be a list."):
+    with pytest.raises(TypeError, match=r"^Filesystem entry must be a list\.$"):
         FilesystemMount.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
@@ -223,7 +225,7 @@ def test_filesystem_mounts_marshal_unmarshal():
 
 
 def test_filesystem_mounts_unmarshal_not_dict():
-    with pytest.raises(TypeError, match="filesystems is not a dictionary"):
+    with pytest.raises(TypeError, match="^filesystems is not a dictionary$"):
         FilesystemMounts.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 

--- a/tests/unit/test_filesystem_mounts.py
+++ b/tests/unit/test_filesystem_mounts.py
@@ -40,9 +40,8 @@ def test_filesystem_mount_item_marshal_unmarshal():
 
 
 def test_filesystem_mount_item_unmarshal_not_dict():
-    with pytest.raises(TypeError) as raised:
-        FilesystemMountItem.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-    assert str(raised.value) == "Filesystem input data must be a dictionary."
+    with pytest.raises(TypeError, match="Filesystem input data must be a dictionary."):
+        FilesystemMountItem.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.parametrize(
@@ -91,9 +90,8 @@ def test_filesystem_mount_marshal_unmarshal():
 
 
 def test_filesystem_mount_unmarshal_not_list():
-    with pytest.raises(TypeError) as raised:
-        FilesystemMount.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-    assert str(raised.value) == "Filesystem entry must be a list."
+    with pytest.raises(TypeError, match="Filesystem entry must be a list."):
+        FilesystemMount.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.parametrize(
@@ -225,9 +223,8 @@ def test_filesystem_mounts_marshal_unmarshal():
 
 
 def test_filesystem_mounts_unmarshal_not_dict():
-    with pytest.raises(TypeError) as raised:
-        FilesystemMounts.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-    assert str(raised.value) == "filesystems is not a dictionary"
+    with pytest.raises(TypeError, match="filesystems is not a dictionary"):
+        FilesystemMounts.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
 
 def test_filesystem_mounts_iterable():

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -499,7 +499,7 @@ def test_project_info_set_project_var_other_part_name_raw(path):
 def test_project_info_set_invalid_project_vars():
     info = ProjectInfo(application_name="test", cache_dir=Path())
 
-    with pytest.raises(ValueError, match="'var' not in project variables"):
+    with pytest.raises(ValueError, match="^'var' not in project variables$"):
         info.set_project_var("var", "bar")
 
 
@@ -706,7 +706,7 @@ def test_part_info_set_invalid_project_vars():
     part = Part("p1", {})
     x = PartInfo(project_info=info, part=part)
 
-    with pytest.raises(ValueError, match="'var' not in project variables"):
+    with pytest.raises(ValueError, match="^'var' not in project variables$"):
         x.set_project_var("var", "bar")
 
 
@@ -882,7 +882,7 @@ def test_step_info_set_invalid_project_vars():
     part_info = PartInfo(project_info=info, part=part)
     x = StepInfo(part_info=part_info, step=Step.PULL)
 
-    with pytest.raises(ValueError, match="'var' not in project variables"):
+    with pytest.raises(ValueError, match="^'var' not in project variables$"):
         x.set_project_var("var", "bar")
 
 

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -355,9 +355,8 @@ def test_project_info_set_project_var_bad_name(path):
     """Error on invalid project variable names."""
     info = ProjectInfo(application_name="test", cache_dir=Path())
 
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match=f"{path!r} is not a valid variable name"):
         info.set_project_var(path, "foo")
-    assert str(raised.value) == f"{path!r} is not a valid variable name"
 
 
 @pytest.mark.parametrize(
@@ -500,9 +499,8 @@ def test_project_info_set_project_var_other_part_name_raw(path):
 def test_project_info_set_invalid_project_vars():
     info = ProjectInfo(application_name="test", cache_dir=Path())
 
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match="'var' not in project variables"):
         info.set_project_var("var", "bar")
-    assert str(raised.value) == "'var' not in project variables"
 
 
 def test_project_info_default():
@@ -708,9 +706,8 @@ def test_part_info_set_invalid_project_vars():
     part = Part("p1", {})
     x = PartInfo(project_info=info, part=part)
 
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match="'var' not in project variables"):
         x.set_project_var("var", "bar")
-    assert str(raised.value) == "'var' not in project variables"
 
 
 def test_part_info_get_project_var():
@@ -885,9 +882,8 @@ def test_step_info_set_invalid_project_vars():
     part_info = PartInfo(project_info=info, part=part)
     x = StepInfo(part_info=part_info, step=Step.PULL)
 
-    with pytest.raises(ValueError) as raised:  # noqa: PT011
+    with pytest.raises(ValueError, match="'var' not in project variables"):
         x.set_project_var("var", "bar")
-    assert str(raised.value) == "'var' not in project variables"
 
 
 def test_step_info_get_project_var():

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -76,7 +76,7 @@ class TestPartSpecs:
         assert spec.marshal() == data_copy
 
     def test_unmarshal_not_dict(self, partitions):
-        with pytest.raises(TypeError, match="part data is not a dictionary"):
+        with pytest.raises(TypeError, match="^part data is not a dictionary$"):
             PartSpec.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
     def test_unmarshal_mix_packages_slices(self, mocker):

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -76,9 +76,8 @@ class TestPartSpecs:
         assert spec.marshal() == data_copy
 
     def test_unmarshal_not_dict(self, partitions):
-        with pytest.raises(TypeError) as raised:
-            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
-        assert str(raised.value) == "part data is not a dictionary"
+        with pytest.raises(TypeError, match="part data is not a dictionary"):
+            PartSpec.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
 
     def test_unmarshal_mix_packages_slices(self, mocker):
         """
@@ -443,7 +442,7 @@ class TestPartUnmarshal:
 
     def test_part_spec_not_dict(self, partitions):
         with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", False, partitions=partitions)  # type: ignore[reportGeneralTypeIssues] # noqa: FBT003
+            Part("foo", None, partitions=partitions)  # type: ignore[reportGeneralTypeIssues]
         assert raised.value.part_name == "foo"
         assert raised.value.message == "part data is not a dictionary"
 

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -259,9 +259,6 @@ class TestMove:
         )
 
 
-# TODO: test NonBlockingRWFifo  # noqa: FIX002
-
-
 def test_create_similar_directory_permissions(tmp_path, mock_chown):
     source = tmp_path / "source"
     source.mkdir()


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes the easy, low-hanging fruit `noqa`s. These were found by regex-searching for `# noqa: (?!PTH)[A-Z]+\d+`. Any `noqa`s that still appear under that search, I decided were reasonable to keep or should be addressed in a separate PR.

All of the `TODO`/`XXX` comments that were removed had a new issue opened for them, except for a few that are explained in comments below