### PR TITLE
fix(docs): fix a typo

### DIFF
--- a/docs/common/craft-parts/reference/step_execution_environment.rst
+++ b/docs/common/craft-parts/reference/step_execution_environment.rst
@@ -27,7 +27,7 @@ processing and execution of user-defined scriptlets:
       - ``amd64``
       - ``riscv64``
   * - ``CRAFT_ARCH_BUILD_ON``
-    - The architecture of the machine running the build. For example:
+    - The architecture of the host running the build. For example:
 
       - ``amd64``
       - ``riscv64``


### PR DESCRIPTION
We weren't differentiating CRAFT_ARCH_BUILD_ON and CRAFT_ARCH_BUILD_FOR even though we were on the triplets.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
