### PR TITLE
feat: Enforce filesystem mounts to be ordered in increasing mount nesting

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -21,6 +21,10 @@ Changelog
 2.25.0 (unreleased)
 -------------------
 
+New features:
+
+- Enforce filesystem mounts to be ordered in increasing ``mount`` depth.
+
 Documentation:
 
 - The Git submodule containing documentation components has been renamed to

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -23,7 +23,8 @@ Changelog
 
 New features:
 
-- Enforce filesystem mounts to be ordered in increasing ``mount`` depth.
+- Validate that filesystem mounts are ordered in increasing ``mount`` nesting.
+  A ``mount`` value cannot be a parent of any preceding ``mount`` values.
 
 Documentation:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes #1342 
CRAFT-4803