### PR TITLE
feature(pro_sources): craftctl chroot cmd

### DIFF
--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -41,7 +41,7 @@ class CraftCtl:
 
         :raises RuntimeError: If the command is not handled.
         """
-        if cmd in ["default", "set"]:
+        if cmd in ["default", "set", "chroot"]:
             _client(cmd, args)
             return None
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -469,7 +469,7 @@ class StepHandler:
             cmd_name, cmd_args, step=step, scriptlet_name=scriptlet_name
         )
 
-    def _process_api_commands(
+    def _process_api_commands(  # noqa: PLR0912
         self, cmd_name: str, cmd_args: list[str], *, step: Step, scriptlet_name: str
     ) -> str:
         """Invoke API command actions."""

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -25,6 +25,8 @@ New features:
 
 - Validate that filesystem mounts are ordered in increasing ``mount`` nesting.
   A ``mount`` value cannot be a parent of any preceding ``mount`` values.
+- Introduced a new sub command called ``chroot`` to ``craftctl`` which allows users to
+  run a command inside the overlay of a part.
 
 Documentation:
 

--- a/tests/integration/lifecycle/test_craftctl.py
+++ b/tests/integration/lifecycle/test_craftctl.py
@@ -701,3 +701,38 @@ def test_craftctl_project_vars_write_once_from_state(new_dir, partitions, capfd)
     captured = capfd.readouterr()
     assert "variable 'myvar' can be set only once" in captured.err
     assert lf.project_info.get_project_var("myvar2") == "val2"
+
+
+def test_craftctl_chroot(new_dir, partitions, mocker):
+    mocker.patch("craft_parts.lifecycle_manager._ensure_overlay_supported")
+    chroot = mocker.patch("craft_parts.overlays.chroot.chroot")
+
+    parts_yaml = textwrap.dedent(
+        """\
+        parts:
+          foo:
+            plugin: nil
+            overlay-script: |
+              
+              craftctl chroot foo bar
+        """
+    )
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_chroot",
+        cache_dir=new_dir,
+        base_layer_dir=new_dir,
+        base_layer_hash=b"hash",
+        project_vars_part_name="foo",
+    )
+    with lf.action_executor() as ctx:
+        ctx.execute(Action("foo", Step.OVERLAY))
+
+    chroot.assert_called_once_with(
+        mocker.ANY,
+        mocker.ANY,
+        args=(["foo", "bar"],),
+        use_host_sources=True,
+    )

--- a/tests/integration/lifecycle/test_craftctl.py
+++ b/tests/integration/lifecycle/test_craftctl.py
@@ -713,7 +713,6 @@ def test_craftctl_chroot(new_dir, partitions, mocker):
           foo:
             plugin: nil
             overlay-script: |
-              
               craftctl chroot foo bar
         """
     )


### PR DESCRIPTION
This PR is part of Rockcraft's `pro_sources` feature set and includes the following features:
- A `chroot` sub command for `craftctl` to enable modification to the overlay during the `overlay-script`