### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 *       @cmatsuoka
 
 # Documentation owners
-/docs/  @medubelko @jahn-junior @cmatsuoka
+/docs/  @canonical/starcraft-authors @cmatsuoka
 
 # Finally, all CODEOWNERS changes need to be approved by The Man, Himself.
-/.github/CODEOWNERS     @sergiusens
+/.github/CODEOWNERS     @steinbro


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Adds the starcraft-authors group to codeowners and assigns @steinbro as the codeownersowner.