### PR TITLE
feat: supress detached head message

### DIFF
--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -270,7 +270,12 @@ class GitSource(SourceHandler):
 
     def _clone_new(self) -> None:
         """Clone a git repository, using submodules, branch, and depth if defined."""
-        command = [get_git_command(), "clone"]
+        command = [
+            get_git_command(),
+            "-c",
+            "advice.detachedHead=false",
+            "clone",
+        ]
         if self.source_submodules is None:
             command.append("--recursive")
         else:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

when cloning a git source the logs are overly verbose:

```
2025-10-08 10:21:24.717 :: Cloning into '/root/parts/go-github-juju-fslock/src'...
2025-10-08 10:21:25.607 :: From https://github.com/juju/fslock
2025-10-08 10:21:25.607 :: * branch            4d5c94c67b4b207e1ab4ebca6b4e47f174618b86 -> FETCH_HEAD
2025-10-08 10:21:25.619 Executing: /snap/sourcecraft/712/libexec/sourcecraft/craft.git -C /root/parts/go-github-juju-fslock/src checkout 4d5c94c67b4b207e1ab4ebca6b4e47f174618b86
2025-10-08 10:21:25.623 :: Note: switching to '4d5c94c67b4b207e1ab4ebca6b4e47f174618b86'.
2025-10-08 10:21:25.623 ::
2025-10-08 10:21:25.623 :: You are in 'detached HEAD' state. You can look around, make experimental
2025-10-08 10:21:25.623 :: changes and commit them, and you can discard any commits you make in this
2025-10-08 10:21:25.623 :: state without impacting any branches by switching back to a branch.
2025-10-08 10:21:25.623 ::
2025-10-08 10:21:25.623 :: If you want to create a new branch to retain commits you create, you may
2025-10-08 10:21:25.623 :: do so (now or later) by using -c with the switch command. Example:
2025-10-08 10:21:25.623 ::
2025-10-08 10:21:25.623 :: git switch -c <new-branch-name>
2025-10-08 10:21:25.624 ::
2025-10-08 10:21:25.624 :: Or undo this operation with:
2025-10-08 10:21:25.624 ::
2025-10-08 10:21:25.624 :: git switch -
2025-10-08 10:21:25.624 ::
2025-10-08 10:21:25.624 :: Turn off this advice by setting config variable advice.detachedHead to false
2025-10-08 10:21:25.624 ::
2025-10-08 10:21:25.625 :: HEAD is now at 4d5c94c change readme
```

This PR suppresses that message
