### PR TITLE
fix: remove noisy logging

### DIFF
--- a/craft_parts/executor/migration.py
+++ b/craft_parts/executor/migration.py
@@ -314,7 +314,6 @@ def filter_dangling_whiteouts(
         if overlays.is_oci_whiteout_file(Path(file)):
             backing_file = base_dir / overlays.oci_whited_out_file(Path(file))
             if not backing_file.exists():
-                logger.debug("filter whiteout file '%s'", file)
                 files.remove(file)
                 whiteouts.add(file)
 
@@ -324,7 +323,6 @@ def filter_dangling_whiteouts(
         if opaque_marker in files:
             backing_file = base_dir / directory
             if not backing_file.exists():
-                logger.debug("filter whiteout file '%s'", opaque_marker)
                 files.remove(opaque_marker)
                 whiteouts.add(opaque_marker)
 
@@ -345,7 +343,6 @@ def filter_all_whiteouts(
 
     for file in list(files):
         if overlays.is_oci_whiteout(Path(file)):
-            logger.debug("filter whiteout file '%s'", file)
             files.remove(file)
             whiteouts.add(file)
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -1024,7 +1024,6 @@ class PartHandler:
             primed_whiteout = prime_dir / whiteout
             try:
                 primed_whiteout.unlink()
-                logger.debug("unlinked '%s'", str(primed_whiteout))
             except OSError as err:
                 logger.debug("error unlinking '%s': %s", str(primed_whiteout), err)
 

--- a/craft_parts/overlays/overlays.py
+++ b/craft_parts/overlays/overlays.py
@@ -78,7 +78,6 @@ def visible_in_layer(lower_dir: Path, upper_dir: Path) -> tuple[set[str], set[st
                 # Don't descend into this directory, overridden by opaque
                 directories.remove(directory)
 
-    logger.debug("layer visibility files=%r, dirs=%r", visible_files, visible_dirs)
     return visible_files, visible_dirs
 
 
@@ -90,7 +89,6 @@ def _is_path_visible(root: Path, relpath: Path) -> bool:
 
     :returns: Whether the final element of the path is visible.
     """
-    logger.debug("check if path is visible: root=%s, relpath=%s", root, relpath)
     levels = len(relpath.parts)
 
     for level in range(levels):


### PR DESCRIPTION

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

These calls to logging.debug() became extremely noisy when dealing with layers with many files (a common thing with Imagecraft). This lead to unwieldy output, preventing effective debugging, and so being counter-productive.
