### PR TITLE
chore: make the starcraft-reviewers team own the changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 # Documentation owners
 /docs/  @canonical/starcraft-authors @cmatsuoka
+/docs/reference/changelog.rst @canonical/starcraft-reviewers
 
 # Finally, all CODEOWNERS changes need to be approved by The Man, Himself.
 /.github/CODEOWNERS     @steinbro


### PR DESCRIPTION
Having the authors own the changelog is a heavy burden for them in our libraries that's minimally useful.

Per @medubelko, from now on, TA reviews for the changelog are opt-in when we decide we need their input.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
