### PR TITLE
chore: update docs code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,8 @@
 *       @cmatsuoka
 
 # Documentation owners
-/docs/  @canonical/starcraft-authors @cmatsuoka
+/docs/  @canonical/starcraft-authors
+/docs/reference/changelog.rst  @canonical/starcraft-reviewers
 
 # Finally, all CODEOWNERS changes need to be approved by The Man, Himself.
 /.github/CODEOWNERS     @steinbro


### PR DESCRIPTION
This is the standard filtering we'd like for docs.

Authors aren't needed for every changelog PR.

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?