### PR TITLE
docs: finalize changelog for 2.27.0

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -17,18 +17,20 @@ Changelog
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
 
-2.27.0 (2025-MM-DD)
+2.27.0 (2025-11-28)
 -------------------
 
 New features:
 
 - Add new ``jlink-multi-release`` and ``jlink-modules`` keys to the JLink plugin.
+- The Meson plugin now calls ``meson setup`` during build.
 
 Bug fixes:
 
 - Shallow clones of git sources are now possible when using ``source-commit`` with
   ``source-depth``.
-
+- Ignored outdated files are now still 'pulled', otherwise git will always consider
+  the repository dirty.
 
 .. _release-2.26.0:
 
@@ -60,8 +62,6 @@ New features:
 
 - Validate that filesystem mounts are ordered in increasing ``mount`` nesting.
   A ``mount`` value cannot be a parent of any preceding ``mount`` values.
-
-- The Meson plugin now calls ``meson setup`` during build.
 
 Bug fixes:
 


### PR DESCRIPTION
The 'meson setup' entry was under 2.25.0, but as far as I can tell this was in error and the code is only now getting released.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
