### PR TITLE
fix(tests): ignore dotnet v2 integration tests on too-old systems

### DIFF
--- a/tests/integration/plugins/test_dotnet_v2.py
+++ b/tests/integration/plugins/test_dotnet_v2.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import platform
 import subprocess
 from pathlib import Path
 
@@ -28,6 +29,10 @@ pytestmark = [
     pytest.mark.skipif(
         _get_host_architecture() not in dotnet_v2_plugin._DEBIAN_ARCH_TO_DOTNET_RID,
         reason="No dotnet runtime for this architecture.",
+    ),
+    pytest.mark.skipif(
+        platform.libc_ver()[1] < "2.34",
+        reason="glibc too old. This plugin is only expected to work with jammy or later.",
     ),
 ]
 


### PR DESCRIPTION
The dotnet snap only officially supports jammy and newer, so we skip those tests if we're running on a system that's too old (e.g. focal).

This is based on glibc version since that's what's actually used here.

Fixes #1405 

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
