### PR TITLE
fix: enable python bytecode in the uv plugin

### DIFF
--- a/craft_parts/plugins/uv_plugin.py
+++ b/craft_parts/plugins/uv_plugin.py
@@ -133,6 +133,7 @@ class UvPlugin(BasePythonPlugin):
         venv_dir = str(self._get_venv_directory().resolve())
         return super().get_build_environment() | {
             "VIRTUAL_ENV": venv_dir,
+            "UV_COMPILE_BYTECODE": "1",
             "UV_PROJECT_ENVIRONMENT": venv_dir,
             "UV_FROZEN": "true",
             "UV_PYTHON_DOWNLOADS": "never",

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -17,6 +17,18 @@ Changelog
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
 
+.. _release-2.28.0:
+
+2.28.0 (unreleased)
+-------------------
+
+New features:
+
+- The ``uv`` plugin now compiles Python bytecode. Use ``UV_COMPILE_BYTECODE=0`` to
+  disable this feature.
+
+.. _release-2.27.0:
+
 2.27.0 (2025-11-28)
 -------------------
 

--- a/tests/integration/plugins/test_uv.py
+++ b/tests/integration/plugins/test_uv.py
@@ -66,11 +66,16 @@ def test_uv_plugin(new_dir, partitions, uv_parts_simple):
     with lf.action_executor() as ctx:
         ctx.execute(actions)
 
-    primed_script = Path(lf.project_info.prime_dir, "bin", "mytestuv")
+    prime_dir = Path(lf.project_info.prime_dir)
+    primed_script = prime_dir / "bin" / "mytestuv"
     assert primed_script.exists()
 
     output = subprocess.getoutput(str(primed_script))
     assert output == "it works with uv too!"
+
+    pycache = list(prime_dir.glob("lib/python*/site-packages/__pycache__"))
+    assert pycache != []
+    assert all(path.is_dir() for path in pycache)
 
 
 def test_uv_plugin_symlink(new_dir, partitions, uv_parts_simple):


### PR DESCRIPTION
This brings the `uv` plugin in line with `python` (version 1 and 2) and `poetry`.

In snaps, launching python can still be slow by default because bytecode is not generated for the standard library when extracting `stage-packages`.

- [ ] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?