### PR TITLE
test(gradle_plugin): disable daemon in integration test

### DIFF
--- a/tests/integration/plugins/test_gradle.py
+++ b/tests/integration/plugins/test_gradle.py
@@ -51,6 +51,8 @@ def test_gradle_plugin(new_dir, testing_source_dir, partitions, use_gradlew):
             plugin: gradle
             gradle-task: testWrite build
             gradle-init-script: init.gradle
+            gradle-parameters:
+                - --no-daemon
             source: {testing_source_dir}
             build-packages: [openjdk-21-jdk]
             build-snaps:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
This PR disables the Gradle daemon in the integration test