### PR TITLE
fix(docs): move gradle-use-daemon to keys section

### DIFF
--- a/docs/common/craft-parts/reference/plugins/gradle_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/gradle_plugin.rst
@@ -50,14 +50,6 @@ gradle-task
 The `Gradle task <https://docs.gradle.org/current/userguide/more_about_tasks.html>`_
 to build the project.
 
-Attributes
-----------
-
-This plugin supports the ``self-contained`` build attribute. Declaring this attribute
-redirects all dependency resolution to a local Maven repository by overriding repository
-settings. All dependencies, including plugins, must then be provided as build packages or
-in an earlier part.
-
 
 gradle-use-daemon
 ~~~~~~~~~~~~~~~~~
@@ -66,6 +58,15 @@ gradle-use-daemon
 
 Whether to use the `Gradle daemon <https://docs.gradle.org/current/userguide/gradle_daemon.html>`_
 during the build. The daemon is disabled by default.
+
+
+Attributes
+----------
+
+This plugin supports the ``self-contained`` build attribute. Declaring this attribute
+redirects all dependency resolution to a local Maven repository by overriding repository
+settings. All dependencies, including plugins, must then be provided as build packages or
+in an earlier part.
 
 
 Environment variables


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
This PR moves the `gradle-use-daemon` key documentation to the keys section