### PR TITLE
Add `UV_LINK_MODE=copy`

### DIFF
--- a/craft_parts/plugins/uv_plugin.py
+++ b/craft_parts/plugins/uv_plugin.py
@@ -139,4 +139,5 @@ class UvPlugin(BasePythonPlugin):
             "UV_PYTHON_DOWNLOADS": "never",
             "UV_PYTHON": '"${PARTS_PYTHON_INTERPRETER}"',
             "UV_PYTHON_PREFERENCE": "only-system",
+            "UV_LINK_MODE": "copy",
         }


### PR DESCRIPTION
Companion to https://github.com/canonical/craft-providers/pull/900

When the cache dir is mounted from the LXD host, hardlinking from the global cache (uv's default behavior) is not possible

e.g.
```
:: warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
::          If the cache and target directories are on different filesystems, hardlinking may not be supported.
::          If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
```
