### PR TITLE
chore(codeowners): remove authors from changelog reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 
 # Documentation owners
 /docs/  @canonical/starcraft-authors
-/docs/reference/release-notes.rst  @canonical/starcraft-reviewers
+/docs/reference/changelog.rst  @canonical/starcraft-reviewers
 
 # Finally, all CODEOWNERS changes need to be approved by The Man, Himself.
 /.github/CODEOWNERS     @steinbro


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

The CODEOWNERS template file assumes that a given repository is using `release-notes.rst`, but the libraries generally use `changelog.rst` instead. This updates the file to behave like it should and not ping the TAs unnecessarily for library changelog updates.