### PR TITLE
docs: fix Ruby plugin docs examples

### DIFF
--- a/docs/common/craft-parts/reference/plugins/ruby_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/ruby_plugin.rst
@@ -157,7 +157,6 @@ are included in the output artifact.
   parts:
     ruby-deps:
       plugin: nil
-      source: .
       stage-packages:
         - ruby-bundler
     my-project:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
The Ruby plugin examples in the docs were broken (thanks @atandrewlee for pointing this out):

1. The `ruby-deps` part was missing the `source` property.
2. The `mruby` interpreter flavor does not support gems

The docs now present separate examples for building a custom Ruby interpreter, and for creating a `ruby-deps` part.
