### PR TITLE
feat: allow copying apt sources from host to overlay

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -15,4 +15,3 @@ jobs:
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
       packages: python-apt-dev
-      uv-export: false # can't use `--all-extras` due to the different versions of python-apt conflicting

--- a/craft_parts/ctl.py
+++ b/craft_parts/ctl.py
@@ -41,7 +41,7 @@ class CraftCtl:
 
         :raises RuntimeError: If the command is not handled.
         """
-        if cmd in ["default", "set", "chroot"]:
+        if cmd in ["default", "set"]:
             _client(cmd, args)
             return None
 

--- a/craft_parts/executor/executor.py
+++ b/craft_parts/executor/executor.py
@@ -53,6 +53,8 @@ class Executor:
     :param extra_build_packages: Additional packages to install on the host system.
     :param extra_build_snaps: Additional snaps to install on the host system.
     :param ignore_patterns: File patterns to ignore when pulling local sources.
+    :param use_host_sources: Whether overlay steps should also include the repository
+      sources defined on the host.
     """
 
     def __init__(  # noqa: PLR0913

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -29,7 +29,6 @@ from typing import TextIO
 
 from craft_parts import errors, packages
 from craft_parts.infos import StepInfo
-from craft_parts.overlays import chroot
 from craft_parts.parts import Part
 from craft_parts.plugins import Plugin
 from craft_parts.sources.local_source import SourceHandler
@@ -487,35 +486,6 @@ class StepHandler:
                     message=f"invalid arguments to command {cmd_name!r}",
                 )
             self._execute_builtin_handler(step)
-        elif cmd_name == "chroot":
-            # TODO: why can we only execute this in the overlay step?
-            if self._step_info.step != step.OVERLAY:
-                raise invalid_control_api_call(
-                    message=f"{cmd_name!r} can only run in overlay step",
-                )
-
-            if len(cmd_args) < 1:
-                raise invalid_control_api_call(
-                    message=(
-                        f"invalid arguments. {cmd_name!r} requires at least one command."
-                    ),
-                )
-
-            target_dir = self._part.dirs.overlay_mount_dir
-
-            def execute_cmd(cmd_args: list[str]) -> None:
-                logger.debug(f"Executing {cmd_args} in root {target_dir}")
-                process.run(
-                    cmd_args,
-                    check=True,
-                    stdout=self._stdout,
-                    stderr=self._stderr,
-                )
-
-            chroot.chroot(
-                target_dir, execute_cmd, args=(cmd_args,), use_host_sources=True
-            )
-
         elif cmd_name == "set":
             if len(cmd_args) != 1:
                 raise invalid_control_api_call(
@@ -525,7 +495,7 @@ class StepHandler:
             if "=" not in cmd_args[0]:
                 raise invalid_control_api_call(
                     message=(
-                        f"invalid arguments. {cmd_name!r} expected format <key>=<value>"
+                        f"invalid arguments to command {cmd_name!r} (want key=value)"
                     ),
                 )
 

--- a/craft_parts/lifecycle_manager.py
+++ b/craft_parts/lifecycle_manager.py
@@ -88,6 +88,8 @@ class LifecycleManager:
     :param filesystem_mounts: A dict of filesystem_mounts to apply when migrating files.
     :param usrmerged_by_default: Whether the parts' install dirs should be filled with
         usrmerge-safe directories and symlinks prior to a part's build.
+    :param use_host_sources: Whether overlay steps should also include the repository
+      sources defined on the host.
     :param custom_args: Any additional arguments that will be passed directly
         to callbacks.
     """

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -21,19 +21,19 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import os
+import shutil
 import sys
 from collections.abc import Callable
 from multiprocessing.connection import Connection
 from pathlib import Path
-from shutil import copytree
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from craft_parts.utils import os_utils
 
 from . import errors
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from multiprocessing.connection import Connection
 
 logger = logging.getLogger(__name__)
@@ -54,6 +54,8 @@ def chroot(
     :param target: The callable to run in the chroot environment.
     :param args: Arguments for target.
     :param kwargs: Keyword arguments for target.
+    :param use_host_sources: Whether overlay steps should also include the repository
+      sources defined on the host.
 
     :returns: The target function return value.
     """
@@ -69,14 +71,14 @@ def chroot(
         target=_runner, args=(Path(path), child_conn, target, args, kwargs)
     )
     logger.debug("[pid=%d] set up chroot", os.getpid())
-    _setup_chroot(path, use_host_sources)
+    _setup_chroot(path, use_host_sources=use_host_sources)
     try:
         child.start()
         res, err = parent_conn.recv()
         child.join()
     finally:
         logger.debug("[pid=%d] clean up chroot", os.getpid())
-        _cleanup_chroot(path, use_host_sources)
+        _cleanup_chroot(path, use_host_sources=use_host_sources)
 
     if isinstance(err, str):
         raise errors.OverlayChrootExecutionError(err)
@@ -126,7 +128,7 @@ def _host_compatible_chroot(path: Path) -> None:
     _compare_os_release(host_os_release, chroot_os_release)
 
 
-def _setup_chroot(path: Path, use_host_sources: bool) -> None:  # noqa: FBT001
+def _setup_chroot(path: Path, *, use_host_sources: bool) -> None:
     """Prepare the chroot environment before executing the target function."""
     logger.debug("setup chroot: %r", path)
     if sys.platform == "linux":
@@ -138,49 +140,7 @@ def _setup_chroot(path: Path, use_host_sources: bool) -> None:  # noqa: FBT001
             _setup_chroot_mounts(path, _ubuntu_apt_mounts)
 
 
-class _Mount(NamedTuple):
-    """Mount entry for chroot setup."""
-
-    fstype: str | None
-    src: str
-    mountpoint: str
-    options: list[str] | None
-
-
-def _setup_chroot_linux(path: Path) -> None:
-    """Linux-specific chroot environment preparation."""
-    # Some images (such as cloudimgs) symlink ``/etc/resolv.conf`` to
-    # ``/run/systemd/resolve/stub-resolv.conf``. We want resolv.conf to be
-    # a regular file to bind-mount the host resolver configuration on.
-    #
-    # There's no need to restore the file to its original condition because
-    # this operation happens on a temporary filesystem layer.
-    resolv_conf = path / "etc/resolv.conf"
-    if resolv_conf.is_symlink():
-        resolv_conf.unlink()
-        resolv_conf.touch()
-    elif not resolv_conf.exists() and resolv_conf.parent.is_dir():
-        resolv_conf.touch()
-
-    pid = os.getpid()
-    for entry in _linux_mounts:
-        args = entry.options or []
-        if entry.fstype:
-            args.append(f"-t{entry.fstype}")
-
-        mountpoint = path / entry.mountpoint.lstrip("/")
-
-        # Only mount if mountpoint exists.
-        if mountpoint.exists():
-            logger.debug("[pid=%d] mount %r on chroot", pid, str(mountpoint))
-            os_utils.mount(entry.src, str(mountpoint), *args)
-        else:
-            logger.debug("[pid=%d] mountpoint %r does not exist", pid, str(mountpoint))
-
-    logger.debug("chroot setup complete")
-
-
-def _cleanup_chroot(path: Path, use_host_sources: bool) -> None:  # noqa: FBT001
+def _cleanup_chroot(path: Path, *, use_host_sources: bool) -> None:
     """Clean the chroot environment after executing the target function."""
     logger.debug("cleanup chroot: %r", path)
     if sys.platform == "linux":
@@ -194,7 +154,6 @@ def _cleanup_chroot(path: Path, use_host_sources: bool) -> None:  # noqa: FBT001
     logger.debug("chroot cleanup complete")
 
 
-# TODO: refactor as to not call _Mount.get_abs_path repeatedly
 class _Mount:
     def __init__(
         self,
@@ -242,7 +201,6 @@ class _Mount:
     def remove_dst(self, chroot: Path) -> None:
         """Remove `self.dst` if present to prepare mountpoint `self.dst`."""
         # This is not required for the base class
-        # TODO: consider using abc
 
     def create_dst(self, chroot: Path) -> None:
         """Create mountpoint `self.dst` later used in mount call."""
@@ -363,7 +321,7 @@ class _TempFSClone(_Mount):
         super()._mount(src, chroot, *args)
 
         abs_dst = self.get_abs_path(chroot, self.dst)
-        copytree(src, abs_dst, dirs_exist_ok=True)
+        shutil.copytree(src, abs_dst, dirs_exist_ok=True)
 
 
 # Essential filesystems to mount in order to have basic utilities and
@@ -375,7 +333,7 @@ class _TempFSClone(_Mount):
 #
 # There's no need to restore the file to its original condition because
 # this operation happens on a temporary filesystem layer.
-_linux_mounts: list[_Mount] = [
+_linux_mounts: Sequence[_Mount] = [
     _BindMount("/etc/resolv.conf", "/etc/resolv.conf"),
     _Mount("proc", "/proc", fstype="proc"),
     _Mount("sysfs", "/sys", fstype="sysfs"),
@@ -384,8 +342,7 @@ _linux_mounts: list[_Mount] = [
 ]
 
 # Mounts required to import host's Ubuntu Pro apt configuration to chroot
-# TODO: parameterize this per linux distribution / package manager
-_ubuntu_apt_mounts = [
+_ubuntu_apt_mounts: Sequence[_Mount] = [
     _TempFSClone("/etc/apt", "/etc/apt", skip_missing=False),
     _BindMount(
         "/usr/share/ca-certificates/",
@@ -400,13 +357,13 @@ _ubuntu_apt_mounts = [
 ]
 
 
-def _setup_chroot_mounts(path: Path, mounts: list[_Mount]) -> None:
+def _setup_chroot_mounts(path: Path, mounts: Sequence[_Mount]) -> None:
     """Linux-specific chroot environment preparation."""
     for entry in mounts:
         entry.mount_to(path)
 
 
-def _cleanup_chroot_mounts(path: Path, mounts: list[_Mount]) -> None:
+def _cleanup_chroot_mounts(path: Path, mounts: Sequence[_Mount]) -> None:
     """Linux-specific chroot environment cleanup."""
     for entry in reversed(mounts):
         entry.unmount_from(path)

--- a/craft_parts/overlays/overlay_manager.py
+++ b/craft_parts/overlays/overlay_manager.py
@@ -67,7 +67,7 @@ class OverlayManager:
     :param cache_level: The number of part layers to be mounted before the
         package cache.
     :param use_host_sources: Configure chroot to use package sources from
-        the the host environment.
+        the host environment.
     """
 
     def __init__(

--- a/tests/integration/lifecycle/test_craftctl.py
+++ b/tests/integration/lifecycle/test_craftctl.py
@@ -556,7 +556,7 @@ def test_craftctl_set_argument_error(new_dir, partitions, capfd, mocker):
             ctx.execute(Action("foo", Step.PULL))
 
     captured = capfd.readouterr()
-    assert "invalid arguments. 'set' expected format <key>=<value>." in captured.err
+    assert "invalid arguments to command 'set' (want key=value)" in captured.err
 
 
 def test_craftctl_set_consume(new_dir, partitions, capfd):

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import multiprocessing
-from pathlib import Path
+from pathlib import Path, PosixPath
 from unittest.mock import ANY, call
 
 import pytest
@@ -188,3 +188,71 @@ class TestChroot:
         assert fake_conn.sent[0] is None
         assert isinstance(fake_conn.sent[1], str)
         assert str(fake_conn.sent[1]) == "bummer"
+
+    def test_chroot_use_host_sources(self, mocker, new_dir, mock_chroot):
+        mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
+        mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
+        mock_copytree = mocker.patch("shutil.copytree")
+
+        spy_process = mocker.spy(multiprocessing, "Process")
+        new_root = Path(new_dir, "dir1")
+
+        # this runs in the child process
+        Path("dir1").mkdir()
+        for subdir in ["etc", "proc", "sys", "dev", "dev/shm"]:
+            Path(new_root, subdir).mkdir()
+
+        chroot.chroot(new_root, target_func, "content", use_host_sources=True)
+
+        assert Path("dir1/foo.txt").read_text() == "content"
+        assert spy_process.mock_calls == [
+            call(
+                target=chroot._runner,
+                args=(new_root, ANY, target_func, ("content",), {}),
+            )
+        ]
+        assert mock_mount.mock_calls == [
+            call("/etc/resolv.conf", f"{new_root}/etc/resolv.conf", "--bind"),
+            call("proc", f"{new_root}/proc", "-tproc"),
+            call("sysfs", f"{new_root}/sys", "-tsysfs"),
+            call("/dev", f"{new_root}/dev", "--rbind", "--make-rprivate"),
+            call("/etc/apt", f"{new_root}/etc/apt", "-ttmpfs"),
+            call(
+                "/usr/share/ca-certificates",
+                f"{new_root}/usr/share/ca-certificates",
+                "--bind",
+            ),
+            call("/etc/ssl/certs", f"{new_root}/etc/ssl/certs", "--bind"),
+            call(
+                "/etc/ca-certificates.conf",
+                f"{new_root}/etc/ca-certificates.conf",
+                "--bind",
+            ),
+            call(f"{new_root}/dev", "--make-rprivate"),
+            call(f"{new_root}/sys", "--make-rprivate"),
+            call(f"{new_root}/proc", "--make-rprivate"),
+            call(f"{new_root}/etc/resolv.conf", "--make-rprivate"),
+            call(f"{new_root}/etc/ca-certificates.conf", "--make-rprivate"),
+            call(f"{new_root}/etc/ssl/certs", "--make-rprivate"),
+            call(f"{new_root}/usr/share/ca-certificates", "--make-rprivate"),
+            call(f"{new_root}/etc/apt", "--make-rprivate"),
+        ]
+        assert mock_umount.mock_calls == [
+            call(f"{new_root}/dev", "--recursive", "--lazy"),
+            call(f"{new_root}/sys", "--recursive"),
+            call(f"{new_root}/proc", "--recursive"),
+            call(f"{new_root}/etc/resolv.conf", "--recursive"),
+            call(f"{new_root}/etc/ca-certificates.conf", "--recursive"),
+            call(f"{new_root}/etc/ssl/certs", "--recursive"),
+            call(f"{new_root}/usr/share/ca-certificates", "--recursive"),
+            call(f"{new_root}/etc/apt", "--recursive"),
+        ]
+
+        # Check that apt sources were copied to the chroot
+        assert mock_copytree.mock_calls == [
+            call(
+                PosixPath("/etc/apt"),
+                PosixPath(f"{new_root}/etc/apt"),
+                dirs_exist_ok=True,
+            )
+        ]


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This PR is the merge of the `feature/pro-sources` branch into mainline. The new feature is the ability to copy Apt configuration (sources, keys, etc) from the running host into the overlay system. This enables the use of pro sources in overlays.

This new feature is disabled by default and controlled by the `use_host_sources` parameter on the LifecycleManager.
