### PR TITLE
fix: prevent organizing a directory into itself

### DIFF
--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -28,6 +28,7 @@ import contextlib
 import os
 import shutil
 from glob import iglob
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from craft_parts import errors
@@ -160,7 +161,9 @@ def organize_files(  # noqa: PLR0912
                 else:
                     file_utils.link_or_copy(src, dst)
             else:
-                file_utils.move(src, dst)
+                # Prevent moving a directory into itself or its own subtree
+                if not Path(src).is_dir() or not Path(dst).is_relative_to(src):
+                    file_utils.move(src, dst)
 
 
 def get_src_path(

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -40,7 +40,6 @@ from craft_parts.utils.partition_utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from pathlib import Path
 
 
 def organize_files(  # noqa: PLR0912

--- a/tests/unit/executor/test_organize.py
+++ b/tests/unit/executor/test_organize.py
@@ -163,6 +163,12 @@ from craft_parts.executor.organize import organize_files
             "organize_map": {"**/bardir/*": "bardir/"},
             "expected": [(["bardir", "foodir"], ""), (["foo"], "bardir")],
         },
+        # Organize directory into itself
+        {
+            "setup_files": ["foo.txt", "bar.txt"],
+            "organize_map": {"*": "etc/config/"},
+            "expected": [(["bar.txt", "foo.txt"], "etc/config")],
+        }
     ],
 )
 def test_organize(new_dir, data):


### PR DESCRIPTION
Only move a directory after checking if it's not being organized into
itself (or a subpath of itself).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
