### PR TITLE
docs: add example to dump plugin

### DIFF
--- a/docs/common/craft-parts/reference/plugins/dump_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/dump_plugin.rst
@@ -39,3 +39,22 @@ During the build step, the plugin performs the following actions:
 #. Unpack the file if it is an archive specified by the ``source-type`` key.
 #. Copy all contents and preserve the directory structure to the part's install
    directory.
+
+Example
+-------
+
+The following snippet declares a part using the Dump plugin with the local directory
+as the source. It also declares an ``after`` dependency on ``nginx`` and uses
+``organize`` to introduce ``nginx.conf`` and ``default.conf``:
+
+.. code-block:: yaml
+
+   parts:
+      config:
+          plugin: dump
+          after:
+            - nginx
+          source: .
+          organize:
+            nginx.conf: etc/nginx/nginx.conf
+            default.conf: etc/nginx/conf.d/default.conf

--- a/docs/common/craft-parts/reference/plugins/dump_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/dump_plugin.rst
@@ -44,8 +44,8 @@ Example
 -------
 
 The following snippet declares a part using the Dump plugin with the local directory
-as the source. It also declares an ``after`` dependency on ``nginx`` and uses
-``organize`` to introduce ``nginx.conf`` and ``default.conf``:
+as the source. It also declares an ``after`` dependency on the ``nginx`` part and uses
+``organize`` to introduce the ``nginx.conf`` and ``default.conf`` files:
 
 .. code-block:: yaml
 

--- a/docs/common/craft-parts/reference/plugins/dump_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/dump_plugin.rst
@@ -49,12 +49,12 @@ as the source. It also declares an ``after`` dependency on the ``nginx`` part an
 
 .. code-block:: yaml
 
-   parts:
-      config:
-          plugin: dump
-          after:
-            - nginx
-          source: .
-          organize:
-            nginx.conf: etc/nginx/nginx.conf
-            default.conf: etc/nginx/conf.d/default.conf
+  parts:
+    config:
+      plugin: dump
+      after:
+        - nginx
+      source: .
+      organize:
+        nginx.conf: etc/nginx/nginx.conf
+        default.conf: etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Recent UR feedback requested documentation updates to provide a practical example for the Dump plugin to illustrate its usage. This PR adds an example from the [nginx rock](https://github.com/canonical/nginx-rock/blob/83d6198ea16986ecdaa204563c2ac5a77828020a/1.27.5/rockcraft.yaml#L14).