### PR TITLE
fix: revert organize from build

### DIFF
--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -32,10 +32,7 @@ from typing import TYPE_CHECKING
 
 from craft_parts import errors
 from craft_parts.utils import file_utils, path_utils
-from craft_parts.utils.partition_utils import (
-    BUILD_PARTITION,
-    DEFAULT_PARTITION,
-)
+from craft_parts.utils.partition_utils import DEFAULT_PARTITION
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -69,24 +66,10 @@ def organize_files(  # noqa: PLR0912
         the default partition.
     """
     for key in sorted(file_map, key=lambda x: ["*" in x, x]):
-        src_partition_pair = path_utils.get_partition_and_path(key, default_partition)
-        src = get_src_path(
-            src_partition_pair, part_name, install_dir_map, default_partition
-        )
-
-        # Remove the leading slash so the path actually joins
-        # Also trailing slash is significant, be careful if using pathlib!
-        dst_partition_pair = path_utils.get_partition_and_path(
-            file_map[key].lstrip("/"), default_partition
-        )
+        src = get_src_path(key, part_name, install_dir_map, default_partition)
         dst, dst_string = get_dst_path(
-            dst_partition_pair, part_name, install_dir_map, default_partition
+            key, file_map, install_dir_map, default_partition
         )
-
-        # If the destinations ends with a slash character and it doesn't exist,
-        # create it as a directory.
-        if dst.endswith("/") and not os.path.exists(dst.rstrip("/")):  # noqa: PTH110
-            os.makedirs(dst)  # noqa: PTH103
 
         sources = iglob(src, recursive=True)  # noqa: PTH207
 
@@ -99,8 +82,7 @@ def organize_files(  # noqa: PLR0912
             # Organize a dir to a dir
             if os.path.isdir(src) and "*" not in key:  # noqa: PTH112
                 file_utils.link_or_copy_tree(src, dst)
-                if src_partition_pair.partition != BUILD_PARTITION:
-                    shutil.rmtree(src)
+                shutil.rmtree(src)
                 continue
 
             # Organize a "not dir" (file, character device, etc.) to a "not dir"
@@ -154,28 +136,23 @@ def organize_files(  # noqa: PLR0912
                     )
 
             os.makedirs(os.path.dirname(dst), exist_ok=True)  # noqa: PTH103, PTH120
-            if src_partition_pair.partition == BUILD_PARTITION:
-                if os.path.isdir(src):  # noqa: PTH112
-                    file_utils.link_or_copy_tree(src, dst)
-                else:
-                    file_utils.link_or_copy(src, dst)
-            else:
-                file_utils.move(src, dst)
+            file_utils.move(src, dst)
 
 
 def get_src_path(
-    src_partition_path: path_utils.PartitionPathPair,
+    key: str,
     part_name: str,
     install_dir_map: Mapping[str | None, Path],
     default_partition: str,
 ) -> str:
     """Return the full path for a relative source."""
-    src_partition, src_inner_path = src_partition_path
+    src_partition, src_inner_path = path_utils.get_partition_and_path(
+        key, default_partition
+    )
 
     if src_partition and src_partition not in [
         default_partition,
         DEFAULT_PARTITION,
-        BUILD_PARTITION,
     ]:
         raise errors.FileOrganizeError(
             part_name=part_name,
@@ -193,21 +170,18 @@ def get_src_path(
 
 
 def get_dst_path(
-    dst_partition_path: path_utils.PartitionPathPair,
-    part_name: str,
+    key: str,
+    file_map: dict[str, str],
     install_dir_map: Mapping[str | None, Path],
     default_partition: str,
 ) -> tuple[str, str]:
     """Return the full destination path and log-friendly representation of a destination."""
-    # The build pseudo-partition can only be specified in the left hand
-    # side of the organize item.
-    dst_partition, dst_inner_path = dst_partition_path
-
-    if dst_partition == BUILD_PARTITION:
-        raise errors.FileOrganizeError(
-            part_name=part_name,
-            message="Cannot organize files into the build directory",
-        )
+    # Remove the leading slash so the path actually joins
+    # Also trailing slash is significant, be careful if using pathlib!
+    dst_partition, dst_inner_path = path_utils.get_partition_and_path(
+        file_map[key].lstrip("/"),
+        default_partition,
+    )
 
     # Replace default partition default name with alias name to allow
     # using (default) in paths even with aliased default partition

--- a/craft_parts/infos.py
+++ b/craft_parts/infos.py
@@ -38,7 +38,7 @@ from craft_parts.filesystem_mounts import (
 from craft_parts.utils.partition_utils import DEFAULT_PARTITION, is_default_partition
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence, ValuesView
+    from collections.abc import Sequence, ValuesView
 
     from craft_parts.parts import Part
     from craft_parts.state_manager import states
@@ -845,7 +845,6 @@ class PartInfo:
         self._part_build_subdir = part.part_build_subdir
         self._part_export_dir = part.part_export_dir
         self._part_install_dir = part.part_install_dir
-        self._part_install_dirs = part.part_install_dirs
         self._part_state_dir = part.part_state_dir
         self._part_cache_dir = part.part_cache_dir
         self._part_dependencies = part.dependencies
@@ -899,11 +898,6 @@ class PartInfo:
     def part_install_dir(self) -> Path:
         """Return the subdirectory to install the part's build artifacts."""
         return self._part_install_dir
-
-    @property
-    def part_install_dirs(self) -> Mapping[str | None, Path]:
-        """Return the subdirectory to install build artifacts in partitions."""
-        return self._part_install_dirs
 
     @property
     def part_state_dir(self) -> Path:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -44,7 +44,6 @@ from craft_parts.permissions import Permissions
 from craft_parts.plugins.properties import PluginProperties
 from craft_parts.steps import Step
 from craft_parts.utils.partition_utils import (
-    BUILD_PARTITION,
     DEFAULT_PARTITION,
     OVERLAY_PARTITION,
     get_partition_dir_map,
@@ -820,8 +819,6 @@ class Part:
         )
         if self.organizes_to_overlay:
             dir_map[OVERLAY_PARTITION] = self.dirs.overlay_mount_dir
-        if Features().enable_partitions:
-            dir_map[BUILD_PARTITION] = self.part_build_dir
         return MappingProxyType(dir_map)
 
     @property
@@ -1005,7 +1002,7 @@ class Part:
                 partitions=self._partitions,
             )
 
-    def _check_partitions_in_filepaths(  # noqa: PLR0912
+    def _check_partitions_in_filepaths(
         self, fileset_name: str, fileset: Iterable[str], *, require_inner_path: bool
     ) -> tuple[list[str], list[str]]:
         """Check if partitions are properly used in a fileset.
@@ -1046,16 +1043,7 @@ class Part:
             match = re.match(partition_pattern, filepath)
             if match:
                 partition = match.group("partition")
-                if str(partition) == BUILD_PARTITION:
-                    if fileset_name == "organize":
-                        error_list.append(
-                            "    cannot organize files into the build directory"
-                        )
-                    else:
-                        error_list.append(
-                            f"    ({partition}) cannot be used in {fileset_name!r}"
-                        )
-                elif str(partition) == OVERLAY_PARTITION and Features().enable_overlay:
+                if str(partition) == OVERLAY_PARTITION and Features().enable_overlay:
                     # If overlays are enabled we can organize to (overlay)
                     pass
                 elif str(partition) not in self._partitions:

--- a/craft_parts/utils/partition_utils.py
+++ b/craft_parts/utils/partition_utils.py
@@ -36,7 +36,6 @@ PARTITION_INVALID_MSG = (
 
 DEFAULT_PARTITION = "default"
 OVERLAY_PARTITION = "overlay"  # Pseudo-partition targeting the overlay
-BUILD_PARTITION = "build"  # Pseudo-partition pointing to the part's build directory
 
 
 def validate_partition_names(partitions: Sequence[str] | None) -> None:
@@ -76,11 +75,10 @@ def validate_partition_names(partitions: Sequence[str] | None) -> None:
     if DEFAULT_PARTITION in partitions[1:]:
         raise errors.FeatureError("Only the first partition can be named 'default'.")
 
-    for partition in (OVERLAY_PARTITION, BUILD_PARTITION):
-        if partition in partitions:
-            raise errors.FeatureError(
-                f"Reserved name '{partition}' cannot be used to name a partition."
-            )
+    if OVERLAY_PARTITION in partitions:
+        raise errors.FeatureError(
+            "Reserved name 'overlay' cannot be used to name a partition."
+        )
 
     _validate_partition_naming_convention(partitions)
     _validate_partitions_conflicts(partitions)

--- a/tests/unit/executor/test_organize.py
+++ b/tests/unit/executor/test_organize.py
@@ -61,12 +61,6 @@ from craft_parts.executor.organize import organize_files
             "organize_map": {"foo": "/bar"},
             "expected": [(["bar"], "")],
         },
-        # trailing_slash_in_value
-        {
-            "setup_files": ["foo"],
-            "organize_map": {"foo": "dir/"},
-            "expected": [(["foo"], "dir")],
-        },
         # overwrite_existing_file
         {
             "setup_files": ["foo", "bar"],
@@ -171,12 +165,10 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=False,
         install_dirs={None: Path(new_dir / "install")},
     )
@@ -187,12 +179,10 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=True,
         install_dirs={None: Path(new_dir / "install")},
     )
@@ -268,12 +258,10 @@ def test_organize_no_overwrite(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=False,
         install_dirs={None: Path(new_dir / "install")},
     )
@@ -285,12 +273,10 @@ def organize_and_assert(
     setup_dirs,
     setup_files,
     setup_symlinks: list[tuple[str, str]],
-    build_files,
     organize_map,
     expected: list[Any],
     expected_message,
     expected_overwrite,
-    check_copy,
     overwrite,
     install_dirs,
 ):
@@ -300,22 +286,8 @@ def organize_and_assert(
     for directory in setup_dirs:
         (install_dir / directory).mkdir(exist_ok=True)
 
-    paths_to_check: list[Path] = []
-
     for file_entry in setup_files:
-        path = install_dir / file_entry
-        paths_to_check.append(path)
-        path.touch()
-
-    if build_files:
-        build_dir = Path(tmp_path / "build")
-        build_dir.mkdir(parents=True, exist_ok=True)
-
-        for file_entry in build_files:
-            path = build_dir / file_entry
-            paths_to_check.append(path)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.touch()
+        (install_dir / file_entry).touch()
 
     for symlink_entry, symlink_target in setup_symlinks:
         symlink_path = install_dir / symlink_entry
@@ -351,7 +323,3 @@ def organize_and_assert(
             dir_contents = os.listdir(dir_path)  # noqa: PTH208
             dir_contents.sort()
             assert dir_contents == expect[0]
-
-        if check_copy:
-            for path in paths_to_check:
-                assert path.exists()

--- a/tests/unit/features/overlay_partitions/test_executor_organize.py
+++ b/tests/unit/features/overlay_partitions/test_executor_organize.py
@@ -17,7 +17,6 @@
 from pathlib import Path
 
 import pytest
-from craft_parts import errors
 
 from tests.unit.executor.test_organize import organize_and_assert
 
@@ -44,19 +43,6 @@ from tests.unit.executor.test_organize import organize_and_assert
             "organize_map": {"foo": "(overlay)/bar"},
             "expected": [([], ""), (["bar"], "../overlay_dir")],
         },
-        # organize_from_build_into_overlay
-        {
-            "build_files": ["foo"],
-            "organize_map": {"(build)/foo": "(overlay)/bar"},
-            "expected": [([], ""), (["bar"], "../overlay_dir")],
-            "check_copy": True,
-        },
-        # organize_from_overlay
-        {
-            "organize_map": {"(overlay)/foo": "bar"},
-            "expected": errors.FileOrganizeError,
-            "expected_message": (r".*Cannot organize files from 'overlay' partition."),
-        },
     ],
 )
 def test_organize(new_dir, data):
@@ -65,17 +51,14 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=False,
         install_dirs={
             "default": Path(new_dir / "install"),
             "overlay": Path(new_dir / "overlay_dir"),
-            "build": Path(new_dir / "build"),
         },
     )
 
@@ -85,16 +68,13 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=True,
         install_dirs={
             "default": Path(new_dir / "install"),
             "overlay": Path(new_dir / "overlay_dir"),
-            "build": Path(new_dir / "build"),
         },
     )

--- a/tests/unit/features/overlay_partitions/test_parts.py
+++ b/tests/unit/features/overlay_partitions/test_parts.py
@@ -44,7 +44,6 @@ class TestPartData:
             "default": Path(new_dir / "parts/foo/install"),
             "mypart": Path(new_dir / "partitions/mypart/parts/foo/install"),
             "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
-            "build": Path(new_dir / "parts/foo/build"),
         }
 
     def test_part_install_dirs_organize_to_overlay(self, new_dir, partitions):
@@ -54,7 +53,6 @@ class TestPartData:
             "mypart": Path(new_dir / "partitions/mypart/parts/foo/install"),
             "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
             "overlay": Path(new_dir / "overlay/overlay"),
-            "build": Path(new_dir / "parts/foo/build"),
         }
 
     def test_get_parts_with_overlay(self, partitions):

--- a/tests/unit/features/partitions/executor/test_organize.py
+++ b/tests/unit/features/partitions/executor/test_organize.py
@@ -101,12 +101,6 @@ from tests.unit.executor.test_organize import organize_and_assert
             "organize_map": {"foo": "/bar"},
             "expected": [(["bar"], "")],
         },
-        # trailing_slash_in_value
-        {
-            "setup_files": ["foo"],
-            "organize_map": {"foo": "dir/"},
-            "expected": [(["foo"], "dir")],
-        },
         # overwrite_existing_file
         {
             "setup_files": ["foo", "bar"],
@@ -204,67 +198,11 @@ from tests.unit.executor.test_organize import organize_and_assert
                 (["foo"], os.path.join("nested", "dir")),  # noqa: PTH118
             ],
         },
-        # from_build
-        {
-            "build_files": ["foo", "bar"],
-            "organize_map": {"(build)/foo": "dir/", "(build)/bar": "(mypart)/baz"},
-            "expected": [
-                (["foo"], "dir"),
-                (["baz"], "../partitions/mypart/parts/part-name/install"),
-            ],
-            "check_copy": True,
-        },
-        # from_build_*
-        {
-            "build_files": ["foo", "dir1/bar"],
-            "organize_map": {"(build)/f*": "dir2/", "(build)/": "."},
-            "expected": [
-                (["dir1", "dir2", "foo"], ""),
-                (["bar"], "dir1"),
-                (["foo"], "dir2"),
-            ],
-            "check_copy": True,
-        },
-        # from_build_*_to_partition
-        {
-            "build_files": ["my-dir/subdir/foo", "my-dir/bar"],
-            "organize_map": {"(build)/*": "(mypart)/"},
-            "expected": [
-                (["bar", "subdir"], "../partitions/mypart/parts/part-name/install"),
-                (["foo"], "../partitions/mypart/parts/part-name/install/subdir"),
-            ],
-            "check_copy": True,
-        },
-        # to_build
-        {
-            "setup_files": [
-                "foo",
-            ],
-            "organize_map": {"foo": "(build)/foo"},
-            "expected": errors.FileOrganizeError,
-            "expected_message": (r".*Cannot organize files into the build directory"),
-            "check_copy": True,
-        },
-        # from_*_to_partition
-        {
-            "setup_dirs": ["my-dir", "my-dir/subdir"],
-            "setup_files": ["my-dir/subdir/foo", "my-dir/bar"],
-            "organize_map": {"(default)/*": "(mypart)/"},
-            "expected": [
-                (["my-dir"], "../partitions/mypart/parts/part-name/install"),
-                (
-                    ["bar", "subdir"],
-                    "../partitions/mypart/parts/part-name/install/my-dir",
-                ),
-                (["foo"], "../partitions/mypart/parts/part-name/install/my-dir/subdir"),
-            ],
-        },
     ],
 )
 def test_organize(new_dir, data):
     install_dirs = {
         "default": new_dir / "install",
-        "build": new_dir / "build",
         "mypart": new_dir / "partitions/mypart/parts/part-name/install",
         "yourpart": new_dir / "partitions/yourpart/parts/part-name/install",
         "our/special-part": new_dir
@@ -276,12 +214,10 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=data.get("check_copy", False),
         overwrite=False,
         install_dirs=install_dirs,
     )
@@ -292,12 +228,10 @@ def test_organize(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=data.get("check_copy", False),
         overwrite=True,
         install_dirs=install_dirs,
     )
@@ -338,12 +272,10 @@ def test_organize_no_overwrite(new_dir, data):
         setup_dirs=data.get("setup_dirs", []),
         setup_files=data.get("setup_files", []),
         setup_symlinks=data.get("setup_symlinks", []),
-        build_files=data.get("build_files", []),
         organize_map=data["organize_map"],
         expected=data["expected"],
         expected_message=data.get("expected_message"),
         expected_overwrite=data.get("expected_overwrite"),
-        check_copy=False,
         overwrite=False,
         install_dirs=install_dirs,
     )

--- a/tests/unit/features/partitions/test_parts.py
+++ b/tests/unit/features/partitions/test_parts.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
 from textwrap import dedent, indent
 
 import pytest
@@ -56,12 +57,9 @@ class TestPartData(test_parts.TestPartData):
         pytest_check.equal(p.prime_dir, new_dir / "prime")
         pytest_check.equal(
             p.part_install_dirs,
-            {
-                **get_partition_dir_map(
-                    base_dir=new_dir, partitions=partitions, suffix="parts/foo/install"
-                ),
-                "build": new_dir / "parts/foo/build",
-            },
+            get_partition_dir_map(
+                base_dir=new_dir, partitions=partitions, suffix="parts/foo/install"
+            ),
         )
 
     def test_part_work_dir(self, new_dir, partitions):
@@ -91,22 +89,18 @@ class TestPartData(test_parts.TestPartData):
         pytest_check.equal(p.prime_dir, new_dir / work_dir / "prime")
         pytest_check.equal(
             p.part_install_dirs,
-            {
-                **get_partition_dir_map(
-                    base_dir=new_dir / work_dir,
-                    partitions=partitions,
-                    suffix="parts/foo/install",
-                ),
-                "build": new_dir / work_dir / "parts/foo/build",
-            },
+            get_partition_dir_map(
+                base_dir=new_dir / work_dir,
+                partitions=partitions,
+                suffix="parts/foo/install",
+            ),
         )
 
     def test_part_install_dirs(self, new_dir):
         p = Part("foo", {"organize": {"foo": "bar"}}, partitions=["mypart", "yourpart"])
         assert p.part_install_dirs == {
-            "mypart": new_dir / "parts/foo/install",  # aliased default part
-            "yourpart": new_dir / "partitions/yourpart/parts/foo/install",
-            "build": new_dir / "parts/foo/build",
+            "mypart": Path(new_dir / "parts/foo/install"),  # aliased default part
+            "yourpart": Path(new_dir / "partitions/yourpart/parts/foo/install"),
         }
 
 

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -602,7 +602,6 @@ def test_part_info(new_dir):
     assert x.part_build_dir == new_dir / "parts/foo/build"
     assert x.part_build_subdir == new_dir / "parts/foo/build"
     assert x.part_install_dir == new_dir / "parts/foo/install"
-    assert x.part_install_dirs == {None: Path(new_dir / "parts/foo/install")}
     assert x.part_state_dir == new_dir / "parts/foo/state"
     assert x.stage_dir == new_dir / "stage"
     assert x.prime_dir == new_dir / "prime"

--- a/tests/unit/utils/test_partition_utils.py
+++ b/tests/unit/utils/test_partition_utils.py
@@ -119,14 +119,6 @@ def test_validate_partitions_success_feature_enabled(partitions):
                 "- 'qux-baz', 'qux/baz'"
             ),
         ),
-        (
-            ["default", "build"],
-            ("Reserved name 'build' cannot be used to name a partition."),
-        ),
-        (
-            ["default", "overlay"],
-            ("Reserved name 'overlay' cannot be used to name a partition."),
-        ),
     ],
 )
 def test_validate_partitions_failure_feature_enabled(partitions, message):


### PR DESCRIPTION
This reverts commit 8e4daf5dfb8c81bc6634b9d7f7f1f182cb9a99ab as
it causes a regression reported in Snapcraft. This feature will be
added back when all issues are properly solved.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
