### PR TITLE
docs(changelog): finalize 2.33.0

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,18 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+.. _release-2.33.0:
+
+2.33.0 (2026-04-15)
+-------------------
+
+Bug fixes:
+
+- Reverts the feature from :ref:`2.31.0 <release-2.31.0>` allowing parts to organize
+  files directly from the build directory.
+
+For a complete list of commits, check out the `2.33.0`_ release on GitHub.
+
 .. _release-2.32.0:
 
 2.32.0 (2026-04-10)
@@ -1682,6 +1694,7 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.33.0: https://github.com/canonical/craft-parts/releases/tag/2.33.0
 .. _2.32.0: https://github.com/canonical/craft-parts/releases/tag/2.32.0
 .. _2.31.0: https://github.com/canonical/craft-parts/releases/tag/2.31.0
 .. _2.30.1: https://github.com/canonical/craft-parts/releases/tag/2.30.1


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Cuts a new 2.33.0 release to grab the revert in #1548.


https://canonical-craft-parts--1549.com.readthedocs.build/1549/reference/changelog/#release-2-33-0