### PR TITLE
feat(overlay): plugins can define overlay commands

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -370,15 +370,17 @@ class PartHandler:
         self._fetch_overlay_packages()
 
         if self._part.has_overlay:
-            # install overlay packages
-            overlay_packages = self._part.spec.overlay_packages
+            # install overlay packages (from spec and plugin)
+            overlay_packages = self._merged_overlay_packages()
             if overlay_packages:
                 with overlays.LayerMount(
                     self._overlay_manager, top_part=self._part
                 ) as ctx:
                     ctx.install_packages(overlay_packages)
 
-            if self._part.spec.override_overlay:
+            if self._part.spec.override_overlay or self._plugin.uses_overlay:
+                # Run in chroot: either override-overlay scriptlet or
+                # plugin builtin (via _builtin_overlay)
                 with overlays.ChrootMount(
                     self._overlay_manager,
                     top_part=self._part,
@@ -392,7 +394,7 @@ class PartHandler:
                         stderr=stderr,
                     )
             else:
-                # execute overlay script
+                # execute overlay script on host
                 with overlays.LayerMount(self._overlay_manager, top_part=self._part):
                     contents = self._run_step(
                         step_info=step_info,
@@ -1295,12 +1297,18 @@ class PartHandler:
 
         return stage_snaps
 
+    def _merged_overlay_packages(self) -> list[str]:
+        """Return overlay packages from both the part spec and the plugin."""
+        spec_packages = list(self._part.spec.overlay_packages)
+        plugin_packages = sorted(self._plugin.get_overlay_packages())
+        return spec_packages + [p for p in plugin_packages if p not in spec_packages]
+
     def _fetch_overlay_packages(self) -> None:
         """Download overlay packages to the local package cache.
 
         :raises OverlayPackageNotFound: If a package is not available for download.
         """
-        overlay_packages = self._part.spec.overlay_packages
+        overlay_packages = self._merged_overlay_packages()
         if not overlay_packages:
             return
 

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -451,10 +451,10 @@ class StepHandler:
             "export -f __craftctl_default\n"
             "\n"
             "craftctl() {\n"
-            '    if [ "${1-}" = "default" ]; then\n'
+            '    if [ "$#" -eq 1 ] && [ "$1" = "default" ]; then\n'
             "        __craftctl_default\n"
             "    else\n"
-            '        echo "Error: craftctl ${1-} cannot be used in override-overlay" >&2\n'
+            f'        echo "Error: craftctl ${{1-}} cannot be used in {scriptlet_name}" >&2\n'
             "        return 1\n"
             "    fi\n"
             "}\n"

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -162,8 +162,9 @@ class StepHandler:
 
         return StepContents()
 
-    @staticmethod
-    def _builtin_overlay() -> StepContents:
+    def _builtin_overlay(self) -> StepContents:
+        """Run the built-in overlay handler (plugin chroot commands)."""
+        self._run_overlay_scriptlet("craftctl default", work_dir=Path("/"))
         return StepContents()
 
     def _builtin_build(self) -> StepContents:
@@ -376,8 +377,16 @@ class StepHandler:
         """Execute a scriptlet.
 
         :param scriptlet: the scriptlet to run.
+        :param scriptlet_name: the name of the scriptlet.
+        :param step: the step this scriptlet belongs to.
         :param work_dir: the directory where the script will be executed.
         """
+        if step == Step.OVERLAY and scriptlet_name != "overlay-script":
+            # override-overlay runs in chroot where craftctl binary is
+            # unavailable; use the bash function injection approach
+            self._run_overlay_scriptlet(scriptlet, work_dir=work_dir)
+            return
+
         with tempfile.TemporaryDirectory() as tempdir:
             ctl_socket_path = os.path.join(tempdir, "craftctl.socket")  # noqa: PTH118
             ctl_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -410,6 +419,68 @@ class StepHandler:
                 ) from process_error
             finally:
                 ctl_socket.close()
+
+    def _run_overlay_scriptlet(
+        self,
+        scriptlet: str,
+        *,
+        work_dir: Path,
+    ) -> None:
+        """Execute an override-overlay scriptlet inside a chroot.
+
+        Since the chroot doesn't have access to the craftctl binary, this
+        injects a bash function that implements ``craftctl default`` by running
+        the plugin's chroot commands inline.
+
+        :param scriptlet: The scriptlet to run.
+        :param work_dir: The directory where the script will be executed.
+        """
+        chroot_commands = self._plugin.get_overlay_chroot_commands()
+        indented_commands = (
+            "\n".join(f"    {cmd}" for cmd in chroot_commands) or "    :"
+        )
+
+        preamble = (
+            "__craftctl_default() {\n"
+            f"{indented_commands}\n"
+            "}\n"
+            "export -f __craftctl_default\n"
+            "\n"
+            "craftctl() {\n"
+            '    if [ "$1" = "default" ]; then\n'
+            "        __craftctl_default\n"
+            "    else\n"
+            '        echo "Error: craftctl $1 cannot be used in override-overlay" >&2\n'
+            "        return 1\n"
+            "    fi\n"
+            "}\n"
+            "export -f craftctl\n"
+        )
+
+        script_content = "#!/bin/bash\nset -euo pipefail\nset -x\n"
+        script_content += preamble + scriptlet + "\n"
+
+        # Save script to host for debugging
+        script_path = self._part.part_run_dir.absolute() / "override_overlay.sh"
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(script_content)
+        script_path.chmod(0o755)
+
+        try:
+            process.run(
+                ["bash", "-c", script_content],
+                cwd=work_dir,
+                stdout=self._stdout,
+                stderr=self._stderr,
+                check=True,
+            )
+        except process.ProcessError as process_error:
+            raise errors.ScriptletRunError(
+                part_name=self._part.name,
+                scriptlet_name="override-overlay",
+                exit_code=process_error.result.returncode,
+                stderr=process_error.result.stderr,
+            ) from process_error
 
     def _ctl_server_selector(
         self, step: Step, scriptlet_name: str, stream: socket.socket

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -164,7 +164,9 @@ class StepHandler:
 
     def _builtin_overlay(self) -> StepContents:
         """Run the built-in overlay handler (plugin chroot commands)."""
-        self._run_overlay_scriptlet("craftctl default", work_dir=Path("/"))
+        self._run_overlay_scriptlet(
+            "craftctl default", work_dir=Path("/"), scriptlet_name="overlay"
+        )
         return StepContents()
 
     def _builtin_build(self) -> StepContents:
@@ -425,6 +427,7 @@ class StepHandler:
         scriptlet: str,
         *,
         work_dir: Path,
+        scriptlet_name: str = "override-overlay",
     ) -> None:
         """Execute an override-overlay scriptlet inside a chroot.
 
@@ -434,6 +437,7 @@ class StepHandler:
 
         :param scriptlet: The scriptlet to run.
         :param work_dir: The directory where the script will be executed.
+        :param scriptlet_name: The name of the scriptlet for error reporting.
         """
         chroot_commands = self._plugin.get_overlay_chroot_commands()
         indented_commands = (
@@ -447,10 +451,10 @@ class StepHandler:
             "export -f __craftctl_default\n"
             "\n"
             "craftctl() {\n"
-            '    if [ "$1" = "default" ]; then\n'
+            '    if [ "${1-}" = "default" ]; then\n'
             "        __craftctl_default\n"
             "    else\n"
-            '        echo "Error: craftctl $1 cannot be used in override-overlay" >&2\n'
+            '        echo "Error: craftctl ${1-} cannot be used in override-overlay" >&2\n'
             "        return 1\n"
             "    fi\n"
             "}\n"
@@ -459,12 +463,6 @@ class StepHandler:
 
         script_content = "#!/bin/bash\nset -euo pipefail\nset -x\n"
         script_content += preamble + scriptlet + "\n"
-
-        # Save script to host for debugging
-        script_path = self._part.part_run_dir.absolute() / "override_overlay.sh"
-        script_path.parent.mkdir(parents=True, exist_ok=True)
-        script_path.write_text(script_content)
-        script_path.chmod(0o755)
 
         try:
             process.run(
@@ -477,7 +475,7 @@ class StepHandler:
         except process.ProcessError as process_error:
             raise errors.ScriptletRunError(
                 part_name=self._part.name,
-                scriptlet_name="override-overlay",
+                scriptlet_name=scriptlet_name,
                 exit_code=process_error.result.returncode,
                 stderr=process_error.result.stderr,
             ) from process_error

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -755,6 +755,21 @@ class Part:
 
         self._check_partition_feature()
         self._check_partition_usage()
+        self._check_overlay_script_plugin_conflict()
+
+    def _check_overlay_script_plugin_conflict(self) -> None:
+        """Check that overlay-script is not used with a plugin that uses overlay."""
+        if not self.plugin_name or not self.spec.overlay_script:
+            return
+        plugin_class = plugins.get_plugin_class(self.plugin_name)
+        if plugin_class.uses_overlay:
+            raise errors.PartSpecificationError(
+                part_name=self.name,
+                message=(
+                    f"overlay-script cannot be used with plugin "
+                    f"{self.plugin_name!r} because it declares overlay commands"
+                ),
+            )
 
     def __repr__(self) -> str:
         return f"Part({self.name!r})"
@@ -925,7 +940,13 @@ class Part:
     @property
     def has_overlay(self) -> bool:
         """Return whether this part declares overlay content."""
-        return self.spec.has_overlay
+        if self.spec.has_overlay:
+            return True
+        if self.plugin_name:
+            plugin_class = plugins.get_plugin_class(self.plugin_name)
+            if plugin_class.uses_overlay:
+                return True
+        return False
 
     @property
     def organizes_to_overlay(self) -> bool:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -767,7 +767,7 @@ class Part:
                 part_name=self.name,
                 message=(
                     f"overlay-script cannot be used with plugin "
-                    f"{self.plugin_name!r} because it declares overlay commands"
+                    f"{self.plugin_name!r} because it participates in the overlay step"
                 ),
             )
 

--- a/craft_parts/plugins/base.py
+++ b/craft_parts/plugins/base.py
@@ -53,6 +53,9 @@ class Plugin(abc.ABC):
     supports_strict_mode = False
     """Plugins that can run in 'strict' mode must set this classvar to True."""
 
+    uses_overlay = False
+    """Plugins that participate in the overlay step must set this to True."""
+
     def __init__(
         self, *, properties: PluginProperties, part_info: infos.PartInfo
     ) -> None:
@@ -100,6 +103,23 @@ class Plugin(abc.ABC):
         override this to declare support for specific attributes.
         """
         return set()
+
+    def get_overlay_packages(self) -> set[str]:
+        """Return a set of packages to install in the overlay.
+
+        Plugins that set ``uses_overlay = True`` can override this method to
+        declare packages that should be installed into the overlay filesystem.
+        """
+        return set()
+
+    def get_overlay_chroot_commands(self) -> list[str]:
+        """Return commands to run inside the overlay chroot.
+
+        Plugins that set ``uses_overlay = True`` can override this method to
+        declare commands that run inside the overlay chroot during the overlay
+        step.
+        """
+        return []
 
 
 class BasePythonPlugin(Plugin):

--- a/tests/integration/features/overlay/lifecycle/data/parts-chroot-only.yaml
+++ b/tests/integration/features/overlay/lifecycle/data/parts-chroot-only.yaml
@@ -1,0 +1,4 @@
+parts:
+  mypart:
+    plugin: chroot-overlay
+    source: .

--- a/tests/integration/features/overlay/lifecycle/data/parts-override-overlay.yaml
+++ b/tests/integration/features/overlay/lifecycle/data/parts-override-overlay.yaml
@@ -1,0 +1,7 @@
+parts:
+  mypart:
+    plugin: chroot-overlay
+    source: .
+    override-overlay: |
+      craftctl default
+      echo "override ran" > /override-proof.txt

--- a/tests/integration/features/overlay/lifecycle/data/parts-package-and-chroot.yaml
+++ b/tests/integration/features/overlay/lifecycle/data/parts-package-and-chroot.yaml
@@ -1,0 +1,4 @@
+parts:
+  mypart:
+    plugin: package-overlay
+    source: .

--- a/tests/integration/features/overlay/lifecycle/data/parts-package-override.yaml
+++ b/tests/integration/features/overlay/lifecycle/data/parts-package-override.yaml
@@ -1,0 +1,9 @@
+parts:
+  mypart:
+    plugin: package-overlay
+    source: .
+    overlay-packages:
+      - sed
+    override-overlay: |
+      craftctl default
+      sed 's/plugin-overlay-works/override-also-works/' /plugin-overlay-proof.txt > /override-proof.txt

--- a/tests/integration/features/overlay/lifecycle/test_plugin_overlay.py
+++ b/tests/integration/features/overlay/lifecycle/test_plugin_overlay.py
@@ -1,0 +1,204 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for plugin overlay commands without partitions (CRAFT-5027)."""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import craft_parts
+import pytest
+import yaml
+from craft_parts import Step, plugins
+from craft_parts.overlays import errors as overlay_errors
+from tests.integration.features.overlay_plugins import (
+    ChrootCommandPlugin,
+    PackageOverlayPlugin,
+)
+
+pytestmark = [
+    pytest.mark.usefixtures("enable_overlay_feature"),
+    pytest.mark.requires_root,
+]
+
+
+@pytest.fixture(scope="session")
+def _chisel_cache(host_arch):
+    """Session-scoped chisel base that downloads packages once."""
+    arch = host_arch
+    cache_dir = Path(tempfile.mkdtemp(prefix="craft-parts-chisel-", dir=Path.home()))
+    subprocess.run(
+        [
+            "chisel",
+            "cut",
+            f"--root={cache_dir}",
+            f"--arch={arch}",
+            "base-files_base",
+            "apt_apt-get",
+            "bash_bins",
+            "coreutils_bins",
+        ],
+        check=True,
+    )
+    (cache_dir / "dev").mkdir(exist_ok=True)
+    (cache_dir / "proc").mkdir(exist_ok=True)
+    (cache_dir / "sys").mkdir(exist_ok=True)
+    yield cache_dir
+    shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def chisel_base(new_homedir_path, _chisel_cache):
+    """Per-test copy of the cached chisel base layer."""
+    base_dir = new_homedir_path / "base"
+    shutil.copytree(_chisel_cache, base_dir, symlinks=True)
+    return base_dir
+
+
+@pytest.fixture(autouse=True)
+def register_plugins():
+    """Register and unregister the test overlay plugins."""
+    plugins.register(
+        {
+            "chroot-overlay": ChrootCommandPlugin,
+            "package-overlay": PackageOverlayPlugin,
+        }
+    )
+    yield
+    plugins.unregister("chroot-overlay", "package-overlay")
+
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+@pytest.mark.parametrize(
+    ("parts_file", "expected"),
+    [
+        pytest.param("parts-chroot-only.yaml", ["chroot-proof.txt"], id="chroot-only"),
+        pytest.param(
+            "parts-package-and-chroot.yaml",
+            ["plugin-overlay-proof.txt"],
+            id="package-and-chroot",
+        ),
+        pytest.param(
+            "parts-override-overlay.yaml",
+            ["chroot-proof.txt", "override-proof.txt"],
+            id="override-overlay",
+        ),
+        pytest.param(
+            "parts-package-override.yaml",
+            ["plugin-overlay-proof.txt", "override-proof.txt"],
+            id="package-override-overlay",
+        ),
+    ],
+)
+def test_plugin_overlay_commands(new_homedir_path, chisel_base, parts_file, expected):
+    """Plugin overlay commands create expected files in the overlay layer."""
+    parts = yaml.safe_load((DATA_DIR / parts_file).read_text())
+
+    work_dir = new_homedir_path / "work"
+    work_dir.mkdir()
+    cache_dir = new_homedir_path / "cache"
+    cache_dir.mkdir()
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test",
+        cache_dir=cache_dir,
+        work_dir=work_dir,
+        base_layer_dir=chisel_base,
+        base_layer_hash=b"chisel-base",
+    )
+
+    actions = lf.plan(Step.PRIME)
+
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    # Check overlay layer
+    work_parts = work_dir / "parts"
+    for expected_file in expected:
+        found = any(
+            (work_parts / part_name / "layer" / expected_file).exists()
+            for part_name in ("mypart",)
+        )
+        assert found, f"{expected_file} not found in any part's overlay layer"
+
+    # Check files reached the prime directory
+    prime_dir = work_dir / "prime"
+    for expected_file in expected:
+        assert (prime_dir / expected_file).exists(), (
+            f"{expected_file} not found in prime directory"
+        )
+
+
+@pytest.mark.parametrize(
+    ("scriptlet", "description"),
+    [
+        pytest.param(
+            "craftctl set version=1.0",
+            "craftctl set",
+            id="craftctl-set",
+        ),
+        pytest.param(
+            "craftctl get version",
+            "craftctl get",
+            id="craftctl-get",
+        ),
+        pytest.param(
+            "craftctl stage",
+            "craftctl stage",
+            id="craftctl-stage",
+        ),
+    ],
+)
+def test_craftctl_invalid_in_override_overlay(
+    new_homedir_path, chisel_base, scriptlet, description
+):
+    """Non-default craftctl commands fail in override-overlay."""
+    parts_data = {
+        "parts": {
+            "mypart": {
+                "plugin": "nil",
+                "source": ".",
+                "override-overlay": scriptlet,
+            }
+        }
+    }
+
+    work_dir = new_homedir_path / "work"
+    work_dir.mkdir()
+    cache_dir = new_homedir_path / "cache"
+    cache_dir.mkdir()
+
+    lf = craft_parts.LifecycleManager(
+        parts_data,
+        application_name="test",
+        cache_dir=cache_dir,
+        work_dir=work_dir,
+        base_layer_dir=chisel_base,
+        base_layer_hash=b"chisel-base",
+    )
+
+    actions = lf.plan(Step.OVERLAY)
+
+    with pytest.raises(
+        overlay_errors.OverlayChrootExecutionError,
+        match="override-overlay",
+    ):
+        with lf.action_executor() as ctx:
+            ctx.execute(actions)

--- a/tests/integration/features/overlay_plugins.py
+++ b/tests/integration/features/overlay_plugins.py
@@ -1,0 +1,69 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Shared test plugins for overlay integration tests (CRAFT-5027)."""
+
+from craft_parts.plugins import Plugin, PluginProperties
+
+
+class OverlayPluginProperties(PluginProperties, frozen=True):
+    """Properties for the test overlay plugins."""
+
+
+class ChrootCommandPlugin(Plugin):
+    """A plugin that runs chroot commands inside the overlay."""
+
+    properties_class = OverlayPluginProperties
+    uses_overlay = True
+
+    def get_overlay_chroot_commands(self):
+        return ["echo ok > /chroot-proof.txt"]
+
+    def get_build_snaps(self):
+        return set()
+
+    def get_build_packages(self):
+        return set()
+
+    def get_build_environment(self):
+        return {}
+
+    def get_build_commands(self):
+        return []
+
+
+class PackageOverlayPlugin(Plugin):
+    """A plugin that installs overlay packages and runs chroot commands."""
+
+    properties_class = OverlayPluginProperties
+    uses_overlay = True
+
+    def get_overlay_packages(self):
+        return {"hello"}
+
+    def get_overlay_chroot_commands(self):
+        return ["hello --greeting 'plugin-overlay-works' > /plugin-overlay-proof.txt"]
+
+    def get_build_snaps(self):
+        return set()
+
+    def get_build_packages(self):
+        return set()
+
+    def get_build_environment(self):
+        return {}
+
+    def get_build_commands(self):
+        return []

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -395,3 +395,146 @@ class TestStepHandlerRunScriptlet:
             )
         assert raised.value.stderr is not None
         assert raised.value.stderr.endswith(b"\nuh-oh\n+ false\n")
+
+
+class OverlayChrootPlugin(plugins.Plugin):
+    """A test plugin with overlay chroot commands."""
+
+    properties_class = plugins.PluginProperties
+    uses_overlay = True
+
+    def get_overlay_chroot_commands(self):
+        return ["echo chroot-ran > /tmp/chroot-proof.txt"]
+
+    def get_build_snaps(self) -> set[str]:
+        return set()
+
+    def get_build_packages(self) -> set[str]:
+        return set()
+
+    def get_build_environment(self) -> dict[str, str]:
+        return {}
+
+    def get_build_commands(self) -> list[str]:
+        return []
+
+
+class TestOverlayScriptlet:
+    """Test the overlay scriptlet injection for override-overlay."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, new_dir):
+        p_info = ProjectInfo(
+            project_dirs=ProjectDirs(work_dir=new_dir),
+            application_name="test",
+            cache_dir=new_dir,
+        )
+        self._dirs = p_info.dirs
+        self._part = Part(
+            "mypart", {"plugin": "nil", "source": "."}, project_dirs=self._dirs
+        )
+        self._part_info = PartInfo(project_info=p_info, part=self._part)
+        self._part.part_run_dir.mkdir(parents=True, exist_ok=True)
+
+    def test_run_overlay_scriptlet_craftctl_default(self, new_dir):
+        """craftctl default runs plugin chroot commands."""
+        sh = _step_handler_for_step(
+            Step.OVERLAY,
+            cache_dir=new_dir,
+            part_info=self._part_info,
+            part=self._part,
+            dirs=self._dirs,
+            plugin_class=OverlayChrootPlugin,
+        )
+        sh._run_overlay_scriptlet(
+            "craftctl default",
+            work_dir=new_dir,
+        )
+        assert (Path("/tmp/chroot-proof.txt")).exists()
+        Path("/tmp/chroot-proof.txt").unlink()
+
+    def test_run_overlay_scriptlet_craftctl_invalid(self, new_dir):
+        """craftctl with non-default command fails."""
+        sh = _step_handler_for_step(
+            Step.OVERLAY,
+            cache_dir=new_dir,
+            part_info=self._part_info,
+            part=self._part,
+            dirs=self._dirs,
+            plugin_class=OverlayChrootPlugin,
+        )
+        with pytest.raises(errors.ScriptletRunError):
+            sh._run_overlay_scriptlet(
+                "craftctl set version=1.0",
+                work_dir=new_dir,
+            )
+
+    def test_run_overlay_scriptlet_with_user_commands(self, new_dir):
+        """User commands in override-overlay run alongside craftctl default."""
+        sh = _step_handler_for_step(
+            Step.OVERLAY,
+            cache_dir=new_dir,
+            part_info=self._part_info,
+            part=self._part,
+            dirs=self._dirs,
+            plugin_class=OverlayChrootPlugin,
+        )
+        sh._run_overlay_scriptlet(
+            "craftctl default\ntouch /tmp/user-proof.txt",
+            work_dir=new_dir,
+        )
+        assert Path("/tmp/chroot-proof.txt").exists()
+        assert Path("/tmp/user-proof.txt").exists()
+        Path("/tmp/chroot-proof.txt").unlink()
+        Path("/tmp/user-proof.txt").unlink()
+
+    def test_run_overlay_scriptlet_no_plugin_overlay(self, new_dir):
+        """override-overlay without overlay plugin: craftctl default is no-op."""
+        sh = _step_handler_for_step(
+            Step.OVERLAY,
+            cache_dir=new_dir,
+            part_info=self._part_info,
+            part=self._part,
+            dirs=self._dirs,
+            plugin_class=FooPlugin,
+        )
+        # Should succeed — craftctl default does nothing (`:` no-op)
+        sh._run_overlay_scriptlet(
+            "craftctl default\ntouch /tmp/no-plugin-proof.txt",
+            work_dir=new_dir,
+        )
+        assert Path("/tmp/no-plugin-proof.txt").exists()
+        Path("/tmp/no-plugin-proof.txt").unlink()
+
+    def test_builtin_overlay_empty_commands(self, new_dir):
+        """Plugin with uses_overlay=True but empty chroot commands: no-op."""
+
+        class EmptyOverlayPlugin(plugins.Plugin):
+            properties_class = plugins.PluginProperties
+            uses_overlay = True
+
+            def get_overlay_chroot_commands(self):
+                return []
+
+            def get_build_snaps(self):
+                return set()
+
+            def get_build_packages(self):
+                return set()
+
+            def get_build_environment(self):
+                return {}
+
+            def get_build_commands(self):
+                return []
+
+        sh = _step_handler_for_step(
+            Step.OVERLAY,
+            cache_dir=new_dir,
+            part_info=self._part_info,
+            part=self._part,
+            dirs=self._dirs,
+            plugin_class=EmptyOverlayPlugin,
+        )
+        # Should succeed without error (no-op function body runs `:`)
+        sh.run_builtin()

--- a/tests/unit/features/overlay/test_executor_part_handler.py
+++ b/tests/unit/features/overlay/test_executor_part_handler.py
@@ -24,6 +24,8 @@ from craft_parts.executor.step_handler import StagePartitionContents, StepConten
 from craft_parts.infos import PartInfo, ProjectInfo, StepInfo
 from craft_parts.overlays import OverlayManager
 from craft_parts.parts import Part
+from craft_parts.plugins.base import Plugin
+from craft_parts.plugins.properties import PluginProperties
 from craft_parts.state_manager import states
 from craft_parts.steps import Step
 
@@ -790,6 +792,94 @@ class TestHelpers(test_part_handler.TestHelpers):
 
         res = part_handler._parts_with_overlay_in_step(step, part_list=[p1, p2, p3, p4])
         assert res == [p2, p3, p4]
+
+
+class TestMergedOverlayPackages:
+    """Test _merged_overlay_packages combines spec and plugin packages."""
+
+    def test_merged_overlay_packages_deduplicates(self, new_dir, partitions):
+        """Plugin packages already in spec are not duplicated."""
+
+        class PkgPlugin(Plugin):
+            properties_class = PluginProperties
+            uses_overlay = True
+
+            def get_overlay_packages(self):
+                return {"pkg4", "pkg5", "pkg6"}
+
+            def get_overlay_chroot_commands(self):
+                return []
+
+            def get_build_snaps(self):
+                return set()
+
+            def get_build_packages(self):
+                return set()
+
+            def get_build_environment(self):
+                return {}
+
+            def get_build_commands(self):
+                return []
+
+        part = Part(
+            "foo",
+            {
+                "plugin": "nil",
+                "source": ".",
+                "overlay-packages": ["pkg4", "pkg1"],
+            },
+            partitions=partitions,
+        )
+        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        ovmgr = OverlayManager(
+            project_info=info,
+            part_list=[part],
+            base_layer_dir=Path("/base"),
+            cache_level=0,
+        )
+        part_info = PartInfo(info, part)
+        handler = PartHandler(
+            part,
+            part_info=part_info,
+            part_list=[part],
+            overlay_manager=ovmgr,
+        )
+        # Inject our plugin
+        handler._plugin = PkgPlugin(properties=PluginProperties(), part_info=part_info)
+
+        merged = handler._merged_overlay_packages()
+        # spec packages come first, then plugin packages not in spec
+        assert merged == ["pkg4", "pkg1", "pkg5", "pkg6"]
+
+    def test_merged_overlay_packages_no_plugin(self, new_dir, partitions):
+        """Without plugin overlay packages, only spec packages returned."""
+        part = Part(
+            "foo",
+            {
+                "plugin": "nil",
+                "source": ".",
+                "overlay-packages": ["pkg1", "pkg2"],
+            },
+            partitions=partitions,
+        )
+        info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        ovmgr = OverlayManager(
+            project_info=info,
+            part_list=[part],
+            base_layer_dir=Path("/base"),
+            cache_level=0,
+        )
+        part_info = PartInfo(info, part)
+        handler = PartHandler(
+            part,
+            part_info=part_info,
+            part_list=[part],
+            overlay_manager=ovmgr,
+        )
+
+        merged = handler._merged_overlay_packages()
+        assert merged == ["pkg1", "pkg2"]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/features/overlay/test_parts.py
+++ b/tests/unit/features/overlay/test_parts.py
@@ -23,6 +23,7 @@ from craft_parts import errors, parts
 from craft_parts.dirs import ProjectDirs
 from craft_parts.packages import platform
 from craft_parts.parts import Part, PartSpec
+from craft_parts.plugins import Plugin, PluginProperties, register, unregister
 from craft_parts.steps import Step
 
 # pylint: disable=too-many-public-methods
@@ -592,3 +593,86 @@ class TestPartValidation:
         error = r"source\s+Field required"
         with pytest.raises(pydantic.ValidationError, match=error):
             parts.validate_part(data)
+
+
+class TestPluginOverlay:
+    """Tests for plugin overlay integration with parts."""
+
+    def test_part_has_overlay_from_plugin(self, new_dir):
+        """A part using a plugin with uses_overlay=True has overlay."""
+
+        class _Props(PluginProperties, frozen=True):
+            pass
+
+        class _OverlayPlugin(Plugin):
+            properties_class = _Props
+            uses_overlay = True
+
+            def get_build_snaps(self):
+                return set()
+
+            def get_build_packages(self):
+                return set()
+
+            def get_build_environment(self):
+                return {}
+
+            def get_build_commands(self):
+                return []
+
+        register({"test-overlay-plugin": _OverlayPlugin})
+        try:
+            p = Part(
+                "mypart",
+                {"plugin": "test-overlay-plugin", "source": "."},
+                project_dirs=ProjectDirs(work_dir=new_dir),
+            )
+            assert p.has_overlay is True
+        finally:
+            unregister("test-overlay-plugin")
+
+    def test_part_has_overlay_false_from_plugin(self, new_dir):
+        """A part using a plugin with uses_overlay=False does not get overlay from plugin."""
+        p = Part(
+            "mypart",
+            {"plugin": "nil", "source": "."},
+            project_dirs=ProjectDirs(work_dir=new_dir),
+        )
+        assert p.has_overlay is False
+
+    def test_overlay_script_with_overlay_plugin_raises(self, new_dir):
+        """overlay-script cannot be used with a plugin that declares overlay commands."""
+
+        class _Props(PluginProperties, frozen=True):
+            pass
+
+        class _OverlayPlugin(Plugin):
+            properties_class = _Props
+            uses_overlay = True
+
+            def get_build_snaps(self):
+                return set()
+
+            def get_build_packages(self):
+                return set()
+
+            def get_build_environment(self):
+                return {}
+
+            def get_build_commands(self):
+                return []
+
+        register({"test-overlay-plugin": _OverlayPlugin})
+        try:
+            with pytest.raises(errors.PartSpecificationError, match="overlay-script"):
+                Part(
+                    "mypart",
+                    {
+                        "plugin": "test-overlay-plugin",
+                        "source": ".",
+                        "overlay-script": "echo hello",
+                    },
+                    project_dirs=ProjectDirs(work_dir=new_dir),
+                )
+        finally:
+            unregister("test-overlay-plugin")

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -69,6 +69,20 @@ def test_plugin(new_dir):
     assert plugin.get_build_commands() == ["hello", "world"]
 
 
+def test_plugin_overlay_defaults(new_dir):
+    """Base Plugin overlay methods return empty defaults."""
+    part = Part("p1", {})
+    project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
+    part_info = PartInfo(project_info=project_info, part=part)
+
+    props = FooPluginProperties.unmarshal({"foo-name": "world"})
+    plugin = FooPlugin(properties=props, part_info=part_info)
+
+    assert plugin.uses_overlay is False
+    assert plugin.get_overlay_packages() == set()
+    assert plugin.get_overlay_chroot_commands() == []
+
+
 def test_abstract_methods(new_dir):
     class FaultyPlugin(Plugin):
         """A plugin that doesn't implement abstract methods."""


### PR DESCRIPTION
Allow plugins to define overlay commands that run inside of the overlay
chroot. If the user adds an `override-overlay`, they can replace those
commands, or they can wrap them and let `craftctl default` signal where
the plugin's original commands would run.

Unlike other steps, only `craftctl default` is accepted in `override-overlay`.
This is not a regression because previously the `craftctl` command couldn't
be used in an override-overlay scriptlet at all.

In addition to `overlay-script` being mutually exclusive with `override-overlay`,
`overlay-script` is now also mutually exclusive with the plugin offering overlay
commands.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
CRAFT-5027