### PR TITLE
feat: deprecate OsRelease in favor of distro

### DIFF
--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -28,6 +28,9 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import distro
+
+from craft_parts import errors as parts_errors
 from craft_parts.utils import os_utils
 
 from . import errors
@@ -108,24 +111,27 @@ def _runner(
     conn.send((res, None))
 
 
-def _compare_os_release(host: os_utils.OsRelease, chroot: os_utils.OsRelease) -> None:
-    """Compare OsRelease objects from host and chroot for compatibility. See _host_compatible_chroot."""
-    if (host_val := host.id()) != (chroot_val := chroot.id()):
+def _compare_os_release(chroot_release: distro.LinuxDistribution) -> None:
+    """Compare host and chroot os-release data for compatibility."""
+    host_val = distro.id()
+    chroot_val = chroot_release.id()
+    if not host_val or not chroot_val:
+        raise parts_errors.OsReleaseIdError
+    if host_val != chroot_val:
         raise errors.IncompatibleChrootError("id", host_val, chroot_val)
 
-    if (host_val := host.version_id()) != (chroot_val := chroot.version_id()):
-        raise errors.IncompatibleChrootError("version_id", host_val, chroot_val)
+    host_val = distro.version()
+    chroot_val = chroot_release.version()
+    if not host_val or not chroot_val:
+        raise parts_errors.OsReleaseVersionIdError
+    if host_val != chroot_val:
+        raise errors.IncompatibleChrootError("version", host_val, chroot_val)
 
 
 def _host_compatible_chroot(path: Path) -> None:
     """Raise exception if host and chroot are not the same distribution and release."""
-    # Note: /etc/os-release is symlinked to /usr/lib/os-release
-    # This could cause an issue if /etc/os-release is removed at any point.
-    host_os_release = os_utils.OsRelease()
-    chroot_os_release = os_utils.OsRelease(
-        os_release_file=str(path / "/etc/os-release")
-    )
-    _compare_os_release(host_os_release, chroot_os_release)
+    chroot_os_release = distro.LinuxDistribution(root_dir=str(path))
+    _compare_os_release(chroot_os_release)
 
 
 def _setup_chroot(path: Path, *, use_host_sources: bool) -> None:

--- a/craft_parts/overlays/errors.py
+++ b/craft_parts/overlays/errors.py
@@ -66,13 +66,13 @@ class OverlayChrootExecutionError(OverlayError):
 class IncompatibleChrootError(OverlayError):
     """Failed to use host package sources because chroot is incompatible.
 
-    :param key: os-release key which was tested.
-    :param host: value from host os-release which was tested.
-    :param chroot: value from chroot os-release which was tested.
+    :param key: Distribution attribute which was tested.
+    :param host: Value from the host distribution which was tested.
+    :param chroot: Value from the chroot distribution which was tested.
     """
 
     def __init__(self, key: str, host: str, chroot: str) -> None:
-        self.message = f"key {key} in os-release expected to be {host} found {chroot}"
+        self.message = f"attribute {key} expected to be {host} found {chroot}"
         brief = f"Unable to use host sources: {self.message}"
 
         super().__init__(brief=brief)

--- a/craft_parts/packages/platform.py
+++ b/craft_parts/packages/platform.py
@@ -17,26 +17,22 @@
 
 """Helpers to determine the repository for the platform."""
 
-from craft_parts import errors
-from craft_parts.utils import os_utils
+import distro
 
 _DEB_BASED_PLATFORM = ["ubuntu", "debian", "elementary OS", "elementary", "neon"]
 _YUM_BASED_PLATFORM = ["centos"]
 _DNF_BASED_PLATFORM = ["almalinux"]
 
 
-def _check(distro: str | None, platform_distros: list[str]) -> bool:
-    """Check if `distro` is included in the specified platform distros.
+def _check(distro_name: str | None, platform_distros: list[str]) -> bool:
+    """Check if `distro_name` is included in the specified platform distros.
 
-    If the indicated `distro` is None it will be retrieved from OsRelease or
-    return "unknown" on error.
+    If the indicated distro is None it will be retrieved from the `distro`
+    module or treated as "unknown" when unavailable.
     """
-    if not distro:
-        try:
-            distro = os_utils.OsRelease().id()
-        except errors.OsReleaseIdError:
-            distro = "unknown"
-    return distro in platform_distros
+    if not distro_name:
+        distro_name = distro.id() or "unknown"
+    return distro_name in platform_distros
 
 
 def is_deb_based(distro: str | None = None) -> bool:

--- a/craft_parts/plugins/poetry_plugin.py
+++ b/craft_parts/plugins/poetry_plugin.py
@@ -21,11 +21,11 @@ import shlex
 import subprocess
 from typing import Literal
 
+import distro
 import pydantic
 from typing_extensions import override
 
 from craft_parts.plugins import validator
-from craft_parts.utils import os_utils
 
 from .base import BasePythonPlugin
 from .properties import PluginProperties
@@ -107,8 +107,7 @@ class PoetryPlugin(BasePythonPlugin):
 
         # In 25.04+, Poetry 2 is included which deprecated the built-in `export` subcommand
         # and moved it to an optional plugin.
-        os_release = os_utils.OsRelease()
-        if os_release.name() == "Ubuntu" and os_release.version_id() >= "25.04":
+        if distro.id() == "ubuntu" and distro.version(best=True) >= "25.04":
             build_packages |= {"python3-poetry-plugin-export"}
 
         return build_packages

--- a/craft_parts/utils/os_utils.py
+++ b/craft_parts/utils/os_utils.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 import sys
 import time
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -275,13 +276,22 @@ def umount(mountpoint: str, *args: str) -> None:
 
 
 class OsRelease:
-    """A class to intelligently determine the OS on which we're running."""
+    """Deprecated wrapper around os-release data.
+
+    Use the `distro` module instead.
+    """
 
     def __init__(self, *, os_release_file: str = "/etc/os-release") -> None:
         """Create a new OsRelease instance.
 
         :param os_release_file: Path to os-release file to be parsed.
         """
+        warnings.warn(
+            DeprecationWarning(
+                "'OsRelease' is deprecated. Use the 'distro' module instead."
+            ),
+            stacklevel=2,
+        )
         self._os_release: dict[str, str] = {}
         with contextlib.suppress(FileNotFoundError):
             with open(os_release_file) as file:  # noqa: PTH123

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "distro>=1.8.0",
     "lxml>=5.3.0",
     "pydantic>=2.0.0",
     "pyxdg",

--- a/tests/integration/lifecycle/test_chisel_lifecycle.py
+++ b/tests/integration/lifecycle/test_chisel_lifecycle.py
@@ -20,11 +20,11 @@ import textwrap
 from pathlib import Path
 
 import craft_parts
+import distro
 import pytest
 import yaml
 from craft_parts import Step
 from craft_parts.packages import deb, errors
-from craft_parts.utils import os_utils
 
 IS_CI: bool = os.getenv("CI") == "true"
 
@@ -36,9 +36,9 @@ SUPPORTED_UBUNTU_VERSIONS = frozenset(
 
 def _current_release_supported() -> bool:
     """Whether Chisel supports the current running OS release."""
-    release = os_utils.OsRelease()
     return (
-        release.id() == "ubuntu" and release.version_id() in SUPPORTED_UBUNTU_VERSIONS
+        distro.id() == "ubuntu"
+        and distro.version(best=True) in SUPPORTED_UBUNTU_VERSIONS
     )
 
 

--- a/tests/integration/plugins/python_v2/test_python.py
+++ b/tests/integration/plugins/python_v2/test_python.py
@@ -17,20 +17,16 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import distro
 import pytest
 import yaml
-from craft_parts import LifecycleManager, Step, errors, plugins
+from craft_parts import LifecycleManager, Step, plugins
 from craft_parts.errors import PluginBuildError
 from craft_parts.plugins.python_v2.python_plugin import PythonPlugin
-from craft_parts.utils import os_utils
 
 
 def is_ubuntu_jammy() -> bool:
-    release = os_utils.OsRelease()
-    try:
-        return release.id() == "ubuntu" and release.version_id() == "22.04"
-    except errors.OsReleaseIdError:
-        return False
+    return distro.id() == "ubuntu" and distro.version(best=True) == "22.04"
 
 
 pytestmark = [

--- a/tests/integration/plugins/test_bazel.py
+++ b/tests/integration/plugins/test_bazel.py
@@ -19,20 +19,14 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import distro
 import pytest
 import yaml
-from craft_parts import LifecycleManager, Step, errors
-from craft_parts.utils import os_utils
+from craft_parts import LifecycleManager, Step
 
 
 def is_ubuntu_jammy_or_focal() -> bool:
-    release = os_utils.OsRelease()
-    try:
-        return release.id() == "ubuntu" and (
-            release.version_id() == "22.04" or release.version_id() == "20.04"
-        )
-    except errors.OsReleaseIdError:
-        return False
+    return distro.id() == "ubuntu" and distro.version(best=True) in {"22.04", "20.04"}
 
 
 pytestmark = [

--- a/tests/integration/plugins/test_colcon.py
+++ b/tests/integration/plugins/test_colcon.py
@@ -18,21 +18,15 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+import distro
 import pytest
 import yaml
-from craft_parts import LifecycleManager, Step, errors, plugins
+from craft_parts import LifecycleManager, Step, plugins
 from craft_parts.plugins.colcon_plugin import ColconPlugin
-from craft_parts.utils import os_utils
 
 
 def is_ubuntu_jammy_or_focal() -> bool:
-    release = os_utils.OsRelease()
-    try:
-        return release.id() == "ubuntu" and (
-            release.version_id() == "22.04" or release.version_id() == "20.04"
-        )
-    except errors.OsReleaseIdError:
-        return False
+    return distro.id() == "ubuntu" and distro.version(best=True) in {"22.04", "20.04"}
 
 
 pytestmark = [

--- a/tests/integration/plugins/test_java.py
+++ b/tests/integration/plugins/test_java.py
@@ -19,10 +19,10 @@ import textwrap
 import warnings
 from pathlib import Path
 
+import distro
 import pytest
 import yaml
 from craft_parts import LifecycleManager, Step
-from craft_parts.utils.os_utils import OsRelease
 
 pytestmark = [pytest.mark.java]
 
@@ -33,7 +33,7 @@ def expected_jdk_version() -> str:
 
     This method should be expanded as tests are supported on more platforms."""
 
-    platform = OsRelease().version_id()
+    platform = distro.version(best=True)
 
     match platform:
         # Even though 22.04's "default-jdk" virtual package resolves to JDK 11,

--- a/tests/integration/sources/test_git_source.py
+++ b/tests/integration/sources/test_git_source.py
@@ -19,10 +19,10 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import distro
 import pytest
 from craft_parts import ProjectDirs
 from craft_parts.sources.git_source import GitSource
-from craft_parts.utils.os_utils import OsRelease
 
 
 def _call(cmd: list[str]) -> None:
@@ -116,7 +116,7 @@ class TestGitSource(GitBaseTestCase):
         assert Path(working_tree / "test.txt").read_text() == "Howdy, Partner!"
 
     @pytest.mark.skipif(
-        OsRelease().id() == "ubuntu" and OsRelease().version_id() <= "20.04",
+        distro.id() == "ubuntu" and distro.version(best=True) <= "20.04",
         reason="Need git >= 2.28.0",
     )
     def test_pull_existing_with_branch_after_update(self, new_dir, monkeypatch):

--- a/tests/unit/overlays/test_chroot.py
+++ b/tests/unit/overlays/test_chroot.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import multiprocessing
+import textwrap
 from pathlib import Path, PosixPath
 from unittest.mock import ANY, call
 
@@ -49,6 +50,17 @@ def fake_conn():
 @pytest.mark.usefixtures("new_dir")
 class TestChroot:
     """Fork process and execute in chroot."""
+
+    def _write_os_release(self, root: Path, distro_id: str, version_id: str) -> None:
+        (root / "etc").mkdir(parents=True, exist_ok=True)
+        (root / "etc/os-release").write_text(
+            textwrap.dedent(
+                f"""\
+                ID={distro_id}
+                VERSION_ID="{version_id}"
+                """
+            )
+        )
 
     def test_chroot(self, mocker, new_dir, mock_chroot):
         mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
@@ -193,6 +205,8 @@ class TestChroot:
         mock_mount = mocker.patch("craft_parts.utils.os_utils.mount")
         mock_umount = mocker.patch("craft_parts.utils.os_utils.umount")
         mock_copytree = mocker.patch("shutil.copytree")
+        mocker.patch("craft_parts.overlays.chroot.distro.id", return_value="ubuntu")
+        mocker.patch("craft_parts.overlays.chroot.distro.version", return_value="24.04")
 
         spy_process = mocker.spy(multiprocessing, "Process")
         new_root = Path(new_dir, "dir1")
@@ -201,6 +215,7 @@ class TestChroot:
         Path("dir1").mkdir()
         for subdir in ["etc", "proc", "sys", "dev", "dev/shm"]:
             Path(new_root, subdir).mkdir()
+        self._write_os_release(new_root, "ubuntu", "24.04")
 
         chroot.chroot(new_root, target_func, "content", use_host_sources=True)
 
@@ -256,3 +271,36 @@ class TestChroot:
                 dirs_exist_ok=True,
             )
         ]
+
+    def test_host_compatible_chroot_reads_chroot_os_release_path(
+        self, mocker, new_dir
+    ) -> None:
+        mocker.patch("craft_parts.overlays.chroot.distro.id", return_value="ubuntu")
+        mocker.patch("craft_parts.overlays.chroot.distro.version", return_value="24.04")
+        chroot_release = mocker.Mock()
+        chroot_release.id.return_value = "ubuntu"
+        chroot_release.version.return_value = "24.04"
+        linux_distribution = mocker.patch(
+            "craft_parts.overlays.chroot.distro.LinuxDistribution",
+            return_value=chroot_release,
+        )
+
+        new_root = Path(new_dir, "dir1")
+
+        chroot._host_compatible_chroot(new_root)
+
+        linux_distribution.assert_called_once_with(
+            root_dir=str(new_root),
+        )
+
+    def test_host_compatible_chroot_rejects_incompatible_version(
+        self, mocker, new_dir
+    ) -> None:
+        mocker.patch("craft_parts.overlays.chroot.distro.id", return_value="ubuntu")
+        mocker.patch("craft_parts.overlays.chroot.distro.version", return_value="24.04")
+
+        new_root = Path(new_dir, "dir1")
+        self._write_os_release(new_root, "ubuntu", "22.04")
+
+        with pytest.raises(chroot.errors.IncompatibleChrootError, match="version"):
+            chroot._host_compatible_chroot(new_root)

--- a/tests/unit/packages/test_platform.py
+++ b/tests/unit/packages/test_platform.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-from craft_parts import errors, packages
+from craft_parts import packages
 from craft_parts.packages import platform
 from craft_parts.packages.base import DummyRepository
 from craft_parts.packages.deb import Ubuntu
@@ -49,14 +49,12 @@ def test_is_deb_based():
 
 def test_is_deb_based_default(mocker):
     for distro in _all_distros:
-        mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+        mocker.patch("craft_parts.packages.platform.distro.id", return_value=distro)
         assert platform.is_deb_based() == (distro in _deb_distros)
 
 
-def test_is_deb_based_error(mocker):
-    mocker.patch(
-        "craft_parts.utils.os_utils.OsRelease.id", side_effect=errors.OsReleaseIdError()
-    )
+def test_is_deb_based_unknown(mocker):
+    mocker.patch("craft_parts.packages.platform.distro.id", return_value="")
     assert platform.is_deb_based() is False
 
 
@@ -71,14 +69,12 @@ def test_is_yum_based():
 
 def test_is_yum_based_default(mocker):
     for distro in _all_distros:
-        mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+        mocker.patch("craft_parts.packages.platform.distro.id", return_value=distro)
         assert platform.is_yum_based() == (distro in _yum_distros)
 
 
-def test_is_yum_based_error(mocker):
-    mocker.patch(
-        "craft_parts.utils.os_utils.OsRelease.id", side_effect=errors.OsReleaseIdError()
-    )
+def test_is_yum_based_unknown(mocker):
+    mocker.patch("craft_parts.packages.platform.distro.id", return_value="")
     assert platform.is_yum_based() is False
 
 
@@ -93,14 +89,12 @@ def test_is_dnf_based():
 
 def test_is_dnf_based_default(mocker):
     for distro in _all_distros:
-        mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+        mocker.patch("craft_parts.packages.platform.distro.id", return_value=distro)
         assert platform.is_dnf_based() == (distro in _dnf_distros)
 
 
-def test_is_dnf_based_error(mocker):
-    mocker.patch(
-        "craft_parts.utils.os_utils.OsRelease.id", side_effect=errors.OsReleaseIdError()
-    )
+def test_is_dnf_based_unknown(mocker):
+    mocker.patch("craft_parts.packages.platform.distro.id", return_value="")
     assert platform.is_dnf_based() is False
 
 
@@ -114,5 +108,5 @@ def test_is_dnf_based_error(mocker):
     ],
 )
 def test_get_repository_for_platform(mocker, distro, repo):
-    mocker.patch("craft_parts.utils.os_utils.OsRelease.id", return_value=distro)
+    mocker.patch("craft_parts.packages.platform.distro.id", return_value=distro)
     assert packages._get_repository_for_platform() == repo

--- a/tests/unit/plugins/test_maven_use.py
+++ b/tests/unit/plugins/test_maven_use.py
@@ -18,11 +18,11 @@ import re
 from pathlib import Path
 from textwrap import dedent
 
+import distro
 import pytest
 from craft_parts import errors
 from craft_parts.infos import PartInfo
 from craft_parts.plugins.maven_use_plugin import MavenUsePlugin
-from craft_parts.utils.os_utils import OsRelease
 
 
 @pytest.fixture
@@ -108,7 +108,7 @@ def test_get_build_commands(
 
 
 @pytest.mark.skipif(
-    OsRelease().id() == "ubuntu" and OsRelease().version_id() <= "20.04",
+    distro.id() == "ubuntu" and distro.version(best=True) <= "20.04",
     reason="Maven on 20.04 and below does not rewrite the project file.",
 )
 def test_get_build_commands_is_reentrant(

--- a/tests/unit/plugins/test_poetry_plugin.py
+++ b/tests/unit/plugins/test_poetry_plugin.py
@@ -151,9 +151,9 @@ def test_include_export_plugin(
     plugin: PoetryPlugin, mocker: MockFixture, version: str, should_install: bool
 ) -> None:
     """Make sure that the export command plugin is included on 25.04+"""
-    mocker.patch("craft_parts.utils.os_utils.OsRelease.name", return_value="Ubuntu")
+    mocker.patch("craft_parts.plugins.poetry_plugin.distro.id", return_value="ubuntu")
     mocker.patch(
-        "craft_parts.utils.os_utils.OsRelease.version_id", return_value=version
+        "craft_parts.plugins.poetry_plugin.distro.version", return_value=version
     )
 
     build_packages = plugin.get_build_packages()

--- a/tests/unit/utils/test_os_utils.py
+++ b/tests/unit/utils/test_os_utils.py
@@ -245,21 +245,25 @@ class TestOsRelease:
             f.write(contents)
         return path
 
+    def _new_release(self, contents: str) -> os_utils.OsRelease:
+        with pytest.deprecated_call(
+            match=r"'OsRelease' is deprecated\. Use the 'distro' module instead\."
+        ):
+            return os_utils.OsRelease(os_release_file=self._write_os_release(contents))
+
     def test_blank_lines(self):
-        release = os_utils.OsRelease(
-            os_release_file=self._write_os_release(
-                textwrap.dedent(
-                    """\
-                NAME="Arch Linux"
+        release = self._new_release(
+            textwrap.dedent(
+                """\
+            NAME="Arch Linux"
 
-                PRETTY_NAME="Arch Linux"
-                ID=arch
-                ID_LIKE=archlinux
-                VERSION_ID="foo"
-                VERSION_CODENAME="bar"
+            PRETTY_NAME="Arch Linux"
+            ID=arch
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
 
-            """
-                )
+        """
             )
         )
 
@@ -268,17 +272,15 @@ class TestOsRelease:
         assert release.version_id() == "foo"
 
     def test_no_id(self):
-        release = os_utils.OsRelease(
-            os_release_file=self._write_os_release(
-                textwrap.dedent(
-                    """\
-                NAME="Arch Linux"
-                PRETTY_NAME="Arch Linux"
-                ID_LIKE=archlinux
-                VERSION_ID="foo"
-                VERSION_CODENAME="bar"
-            """
-                )
+        release = self._new_release(
+            textwrap.dedent(
+                """\
+            NAME="Arch Linux"
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
+        """
             )
         )
 
@@ -286,17 +288,15 @@ class TestOsRelease:
             release.id()
 
     def test_no_name(self):
-        release = os_utils.OsRelease(
-            os_release_file=self._write_os_release(
-                textwrap.dedent(
-                    """\
-                ID=arch
-                PRETTY_NAME="Arch Linux"
-                ID_LIKE=archlinux
-                VERSION_ID="foo"
-                VERSION_CODENAME="bar"
-            """
-                )
+        release = self._new_release(
+            textwrap.dedent(
+                """\
+            ID=arch
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_ID="foo"
+            VERSION_CODENAME="bar"
+        """
             )
         )
 
@@ -304,17 +304,15 @@ class TestOsRelease:
             release.name()
 
     def test_no_version_id(self):
-        release = os_utils.OsRelease(
-            os_release_file=self._write_os_release(
-                textwrap.dedent(
-                    """\
-                NAME="Arch Linux"
-                ID=arch
-                PRETTY_NAME="Arch Linux"
-                ID_LIKE=archlinux
-                VERSION_CODENAME="bar"
-            """
-                )
+        release = self._new_release(
+            textwrap.dedent(
+                """\
+            NAME="Arch Linux"
+            ID=arch
+            PRETTY_NAME="Arch Linux"
+            ID_LIKE=archlinux
+            VERSION_CODENAME="bar"
+        """
             )
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -425,6 +425,7 @@ toml = [
 name = "craft-parts"
 source = { editable = "." }
 dependencies = [
+    { name = "distro" },
     { name = "lxml" },
     { name = "pydantic" },
     { name = "pyxdg" },
@@ -535,6 +536,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
+    { name = "distro", specifier = ">=1.8.0" },
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyxdg" },
@@ -643,6 +645,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We've been using `distro` in several places, we might as well use it in craft-parts too.

This doesn't remove it yet though since that would require a major release.