### PR TITLE
ci: split QA workflows by runner

### DIFF
--- a/.github/workflows/qa-github-hosted.yaml
+++ b/.github/workflows/qa-github-hosted.yaml
@@ -1,0 +1,103 @@
+name: QA (GitHub-hosted)
+on:
+  push:
+    branches:
+      - "main"
+      - "feature/*"
+      - "hotfix/*"
+      - "release/*"
+      - "renovate/*"
+  pull_request:
+
+# Cancel existing jobs for this branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+  test-common:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: >
+        [
+          "ubuntu-22.04",
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      fast-test-python-versions: '["3.10", "3.12", "3.13"]'
+      slow-test-platforms: >
+        [
+          "ubuntu-22.04",
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-version: ""
+      pytest-markers: not java and not python and not plugin
+      setup-vars: NO_JAVA=1 NO_PYTHON=1 NO_PLUGIN=1
+  test-java-plugins:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: "[]"
+      slow-test-platforms: >
+        [
+          "ubuntu-22.04",
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-version: ""
+      pytest-markers: java
+      setup-vars: NO_PYTHON=1 NO_PLUGIN=1
+  test-python-plugins:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: "[]"
+      slow-test-platforms: >
+        [
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-version: ""
+      pytest-markers: python
+      setup-vars: NO_JAVA=1 NO_PLUGIN=1
+  test-python-plugins-jammy:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: "[]"
+      slow-test-platforms: >
+        [
+          "ubuntu-22.04",
+        ]
+      slow-test-python-versions: '["3.10"]'
+      lowest-python-version: ""
+      pytest-markers: python
+      setup-vars: NO_JAVA=1 NO_PLUGIN=1
+  test-other-plugins:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: "[]"
+      slow-test-platforms: >
+        [
+          "ubuntu-22.04",
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-version: ""
+      pytest-markers: plugin
+      setup-vars: NO_JAVA=1 NO_PYTHON=1
+
+  test-requires-root:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: '["ubuntu-24.04"]'
+      fast-test-python-versions: '["3.12"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-version: ""
+      pytest-markers: requires_root
+      test-command-prefix: sudo env "PATH=$PATH"

--- a/.github/workflows/qa-self-hosted.yaml
+++ b/.github/workflows/qa-self-hosted.yaml
@@ -40,6 +40,7 @@ jobs:
       lowest-python-version: "3.10"
       pytest-markers: not java and not python and not plugin
       setup-vars: NO_JAVA=1 NO_PYTHON=1 NO_PLUGIN=1
+      test-command-prefix: env TMPDIR=$PWD/.tmp
   test-java-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
@@ -55,6 +56,7 @@ jobs:
       lowest-python-version: ""
       pytest-markers: java
       setup-vars: NO_PYTHON=1 NO_PLUGIN=1
+      test-command-prefix: env TMPDIR=$PWD/.tmp
   test-python-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
@@ -69,6 +71,7 @@ jobs:
       lowest-python-version: ""
       pytest-markers: python
       setup-vars: NO_JAVA=1 NO_PLUGIN=1
+      test-command-prefix: env TMPDIR=$PWD/.tmp
   test-python-plugins-jammy:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
@@ -81,6 +84,7 @@ jobs:
       lowest-python-version: ""
       pytest-markers: python
       setup-vars: NO_JAVA=1 NO_PLUGIN=1
+      test-command-prefix: env TMPDIR=$PWD/.tmp
   test-other-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
@@ -97,6 +101,7 @@ jobs:
       lowest-python-version: "3.10"
       pytest-markers: plugin
       setup-vars: NO_JAVA=1 NO_PYTHON=1
+      test-command-prefix: env TMPDIR=$PWD/.tmp
 
   test-requires-root:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
@@ -113,4 +118,4 @@ jobs:
       slow-test-python-versions: '["3.12"]'
       lowest-python-version: ""
       pytest-markers: requires_root
-      test-command-prefix: sudo env "PATH=$PATH"
+      test-command-prefix: sudo env "PATH=$PATH" TMPDIR=$PWD/.tmp

--- a/.github/workflows/qa-self-hosted.yaml
+++ b/.github/workflows/qa-self-hosted.yaml
@@ -1,4 +1,4 @@
-name: QA
+name: QA (self-hosted)
 on:
   push:
     branches:
@@ -15,17 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    uses: canonical/starflow/.github/workflows/lint-python.yaml@main
   test-common:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       fast-test-platforms: >
         [
-          "ubuntu-22.04",
           ["jammy", "arm64", "medium"],
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
           ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
@@ -33,10 +28,7 @@ jobs:
       fast-test-python-versions: '["3.10", "3.12", "3.13"]'
       slow-test-platforms: >
         [
-          "ubuntu-22.04",
           ["jammy", "arm64", "medium"],
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
           ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
@@ -54,10 +46,7 @@ jobs:
       fast-test-platforms: "[]"
       slow-test-platforms: >
         [
-          "ubuntu-22.04",
           ["jammy", "arm64", "medium"],
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
           ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
@@ -72,8 +61,6 @@ jobs:
       fast-test-platforms: "[]"
       slow-test-platforms: >
         [
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
           ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
@@ -88,7 +75,6 @@ jobs:
       fast-test-platforms: "[]"
       slow-test-platforms: >
         [
-          "ubuntu-22.04",
           ["jammy", "arm64", "medium"],
         ]
       slow-test-python-versions: '["3.10"]'
@@ -101,10 +87,7 @@ jobs:
       fast-test-platforms: "[]"
       slow-test-platforms: >
         [
-          "ubuntu-22.04",
           ["jammy", "arm64"],
-          "ubuntu-24.04",
-          "ubuntu-24.04-arm",
           ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
@@ -118,9 +101,15 @@ jobs:
   test-requires-root:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-24.04", ["resolute", "amd64"]]'
+      fast-test-platforms: >
+        [
+          ["resolute", "amd64"],
+        ]
       fast-test-python-versions: '["3.12"]'
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", ["resolute", "amd64"]]'
+      slow-test-platforms: >
+        [
+          ["resolute", "amd64"],
+        ]
       slow-test-python-versions: '["3.12"]'
       lowest-python-version: ""
       pytest-markers: requires_root

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -26,6 +26,7 @@ jobs:
           ["jammy", "arm64", "medium"],
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
         ]
@@ -36,6 +37,7 @@ jobs:
           ["jammy", "arm64", "medium"],
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
         ]
@@ -56,6 +58,7 @@ jobs:
           ["jammy", "arm64", "medium"],
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
         ]
@@ -71,6 +74,7 @@ jobs:
         [
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
         ]
@@ -101,6 +105,7 @@ jobs:
           ["jammy", "arm64"],
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          ["resolute", "amd64"],
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
         ]
@@ -113,9 +118,9 @@ jobs:
   test-requires-root:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-24.04"]'
+      fast-test-platforms: '["ubuntu-24.04", ["resolute", "amd64"]]'
       fast-test-python-versions: '["3.12"]'
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", ["resolute", "amd64"]]'
       slow-test-python-versions: '["3.12"]'
       lowest-python-version: ""
       pytest-markers: requires_root

--- a/Makefile
+++ b/Makefile
@@ -208,12 +208,18 @@ endif
 ifeq ($(wildcard /usr/share/doc/bison/copyright),)
 APT_PACKAGES += bison
 endif
-# We'll check for any dotnet SDK, but install dotnet 8 since that version is common to
-# 22.04 -> 25.10 (and possibly 26.04).
+# We'll check for any dotnet SDK. Use dotnet 8 through Ubuntu 25.04, and
+# dotnet 10 on newer releases where that is the common SDK.
 # On focal, we'll get the snap instead.
+DOTNET_SDK_PACKAGE := dotnet-sdk-8.0
+ifneq ($(VERSION_ID),)
+ifneq ($(shell [ "$(VERSION_ID)" != "25.04" ] && [ "$(VERSION_ID)" = "$$(printf '%s\n%s\n' "25.04" "$(VERSION_ID)" | sort -V | tail -n1)" ] && echo yes),)
+DOTNET_SDK_PACKAGE := dotnet-sdk-10.0
+endif
+endif
 ifeq ($(wildcard /usr/share/doc/dotnet-sdk-*/copyright),)
 ifneq ($(UBUNTU_CODENAME),focal)
-APT_PACKAGES += dotnet-sdk-8.0
+APT_PACKAGES += $(DOTNET_SDK_PACKAGE)
 endif
 endif
 ifeq ($(wildcard /usr/share/doc/gcc/copyright),)

--- a/common.mk
+++ b/common.mk
@@ -220,18 +220,30 @@ endif
 
 .PHONY: test
 test:  ## Run all tests
+ifneq ($(TMPDIR),)
+	mkdir -p $(TMPDIR)
+endif
 	uv run pytest
 
 .PHONY: test-fast
 test-fast:  ##- Run fast tests
+ifneq ($(TMPDIR),)
+	mkdir -p $(TMPDIR)
+endif
 	uv run pytest -m 'not slow'
 
 .PHONY: test-slow
 test-slow:  ##- Run slow tests
+ifneq ($(TMPDIR),)
+	mkdir -p $(TMPDIR)
+endif
 	uv run pytest -m 'slow'
 
 .PHONY: test-coverage
 test-coverage:  ## Generate coverage report
+ifneq ($(TMPDIR),)
+	mkdir -p $(TMPDIR)
+endif
 ifeq ($(COVERAGE_SOURCE),)
 	uv run coverage run --source $(PROJECT),tests -m pytest
 else
@@ -246,6 +258,9 @@ endif
 
 .PHONY: test-find-slow
 test-find-slow:  ##- Identify slow tests. Set cutoff time in seconds with SLOW_CUTOFF_TIME
+ifneq ($(TMPDIR),)
+	mkdir -p $(TMPDIR)
+endif
 	uv run pytest --durations 0 --durations-min $(SLOW_CUTOFF_TIME)
 
 # Alias for `html` target in docs project. We want to use our own `.venv`, so we


### PR DESCRIPTION
## Summary
- split QA into separate GitHub-hosted and self-hosted workflows
- keep GitHub-hosted platforms in `qa-github-hosted.yaml` and self-hosted platforms in `qa-self-hosted.yaml`
- keep the minimum-dependencies lanes on self-hosted runners and retain the added resolute coverage

## Testing
- make lint-prettier