### PR TITLE
docs: rename plugins '* use' -> '*-use'

### DIFF
--- a/craft_parts/plugins/go_use_plugin.py
+++ b/craft_parts/plugins/go_use_plugin.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The Go Use plugin."""
+"""The Go-use plugin."""
 
 import logging
 from typing import Literal
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class GoUsePluginProperties(PluginProperties, frozen=True):
-    """The part properties used by the Go Use plugin."""
+    """The part properties used by the Go-use plugin."""
 
     plugin: Literal["go-use"] = "go-use"
 

--- a/craft_parts/plugins/maven_use_plugin.py
+++ b/craft_parts/plugins/maven_use_plugin.py
@@ -76,7 +76,7 @@ class MavenUsePluginEnvironmentValidator(validator.PluginEnvironmentValidator):
 
 
 class MavenUsePlugin(JavaPlugin):
-    """The Maven use plugin."""
+    """The Maven-use plugin."""
 
     properties_class = MavenUsePluginProperties
     validator_class = MavenUsePluginEnvironmentValidator

--- a/docs/common/craft-parts/reference/plugins/cargo_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/cargo_use_plugin.rst
@@ -1,9 +1,9 @@
 .. _craft_parts_cargo_use_plugin:
 
-Cargo Use plugin
-=====================
+Cargo-use plugin
+================
 
-The Cargo Use plugin sets up a local `cargo registry`_ for `Rust`_ crates. It's a
+The Cargo-use plugin sets up a local `cargo registry`_ for `Rust`_ crates. It's a
 companion plugin meant to be used with the :ref:`Rust plugin <craft_parts_rust_plugin>`.
 It affects all Rust parts in a project.
 
@@ -19,7 +19,7 @@ This plugin has no unique keys.
 Dependencies
 ------------
 
-The ``cargo-use`` plugin has no dependencies.
+This plugin has no dependencies.
 
 .. _cargo-use-details-end:
 
@@ -39,7 +39,7 @@ Example
 
 The following snippet declares a pair of parts.
 
-The first is named ``librust-cfg-if`` and uses the ``cargo-use`` plugin.
+The first is named ``librust-cfg-if`` and uses the Cargo-use plugin.
 
 The second, the app of the pair, is named ``hello`` and uses the ``rust`` plugin. The
 app's source has ``cfg-if`` as a dependency, which is why the ``librust-cfg-if`` part is

--- a/docs/common/craft-parts/reference/plugins/go_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/go_use_plugin.rst
@@ -1,9 +1,9 @@
 .. _craft_parts_go_use_plugin:
 
-Go Use plugin
+Go-use plugin
 =============
 
-The Go Use plugin allows for setting up a `go workspace`_ for `Go`_ modules. It is a
+The Go-use plugin allows for setting up a `go workspace`_ for `Go`_ modules. It is a
 companion plugin meant to be used with the :ref:`Go plugin <craft_parts_go_plugin>`. Use
 of this plugin sets up ``go.work`` and affects all parts.
 
@@ -49,8 +49,8 @@ During the build step the plugin performs the following actions:
 Example
 -------
 
-The following snippet declares a parts named ``go-flags`` using the ``go-use`` plugin
-and a ``hello`` part that declares this ``go-flags``` in its ``go.mod`` using the ``go``
+The following snippet declares a parts named ``go-flags`` using the Go-use plugin
+and a ``hello`` part that declares this ``go-flags``` in its ``go.mod`` using the Go
 plugin. Correct ordering is achieved with the use of the ``after`` key in the ``hello``
 part.
 

--- a/docs/common/craft-parts/reference/plugins/gradle_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/gradle_use_plugin.rst
@@ -1,9 +1,9 @@
 .. _craft_parts_gradle_use_plugin:
 
-Gradle Use plugin
+Gradle-use plugin
 =================
 
-The Gradle Use plugin builds Java projects using the Gradle build tool and, unlike
+The Gradle-use plugin builds Java projects using the Gradle build tool and, unlike
 the :ref:`craft_parts_gradle_plugin`, publishes the artifacts to a local `Maven
 repository`_.
 

--- a/docs/common/craft-parts/reference/plugins/maven_use_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/maven_use_plugin.rst
@@ -1,12 +1,12 @@
 .. _craft_parts_maven_use_plugin:
 
-Maven Use plugin
+Maven-use plugin
 ================
 
-The Maven Use plugin packages `Maven`_-based projects and, unlike the
+The Maven-use plugin packages `Maven`_-based projects and, unlike the
 :ref:`craft_parts_maven_plugin`, deploys the artifact to an internal `Maven
 repository`_. From this repository, the artifacts can be accessed by any other parts
-using the Maven or Maven Use plugins.
+using the Maven or Maven-use plugins.
 
 
 Keys
@@ -24,10 +24,10 @@ This plugin supports the ``self-contained`` build attribute. Declaring this attr
 prevents access to the default `Maven Central repository`_. All dependencies, including
 plugins, must then be provided as build packages or in an earlier part.
 
-When this attribute is declared, Maven Use may rewrite the version specification of
+When this attribute is declared, Maven-use may rewrite the version specification of
 project dependencies based on what is locally available. This can be avoided by
 provisioning the specified version prior to build time — for example, by building it
-with the Maven Use plugin in an earlier part. For more information on this behavior, see
+with the Maven-use plugin in an earlier part. For more information on this behavior, see
 :ref:`maven_use_version_rewriting`.
 
 .. _maven_use_self-contained_end:
@@ -56,15 +56,15 @@ version of Maven is desired but unavailable as a snap or Ubuntu package.
 Version rewriting
 -----------------
 
-When building a :ref:`self-contained <maven_use_self-contained_start>` part, the Maven
-Use plugin selects dependency versions as follows:
+When building a :ref:`self-contained <maven_use_self-contained_start>` part, the
+Maven-use plugin selects dependency versions as follows:
 
 If the version of the dependency specified in the project's ``pom.xml`` file exists
 locally, that version is selected.
 
-If the requested version doesn't exist locally, Maven Use compares the locally available
+If the requested version doesn't exist locally, Maven-use compares the locally available
 versions that follow `semantic versioning`_ and selects the earliest subsequent release.
-If no such version is found, Maven Use selects the latest release that precedes the
+If no such version is found, Maven-use selects the latest release that precedes the
 requested version.
 
 If no prior conditions were satisfied, no version was requested, or the requested

--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -74,7 +74,7 @@ build tools and which build tools are used to download and verify dependencies.
     - Build tools used
     - Method of provisioning the build tools
 
-  * - :ref:`Cargo Use <craft_parts_cargo_use_plugin>`
+  * - :ref:`Cargo-use <craft_parts_cargo_use_plugin>`
 
       :ref:`Rust <craft_parts_rust_plugin>`
     - `Cargo <https://doc.rust-lang.org/stable/cargo/>`_
@@ -86,7 +86,7 @@ build tools and which build tools are used to download and verify dependencies.
 
   * - :ref:`Go <craft_parts_go_plugin>`
 
-      :ref:`Go Use <craft_parts_go_use_plugin>`
+      :ref:`Go-use <craft_parts_go_use_plugin>`
     - `Go toolchain <https://go.dev/ref/mod>`_
     - not provisioned
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -99,7 +99,7 @@ New features:
   shared local cache for ``self-contained`` builds.
 - Add support for the ``override-overlay`` key, which runs a script
   inside a chroot environment during the overlay step.
-- The ``go-use`` plugin returns an error if a ``go.mod`` file doesn't exist.
+- The Go-use plugin returns an error if a ``go.mod`` file doesn't exist.
   This prevents the error going unnoticed & appearing at build-time (when the
   module doesn't appear in the Go workspace)
 - Add support for copying Apt configuration from the host into the overlay system
@@ -805,7 +805,7 @@ New features:
 
 Bug fixes:
 
-- Correctly handle ``source-subdir`` values on the ``go-use`` plugin.
+- Correctly handle ``source-subdir`` values on the Go-use plugin.
 
 Documentation:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -167,7 +167,7 @@ New features:
 
 Bug fixes:
 
-- The Maven Use plugin now correctly infers a ``groupId`` when there is a parent pom to
+- The Maven-use plugin now correctly infers a ``groupId`` when there is a parent pom to
   infer from.
 - The ``make clean`` command now deletes ``docs/reference/gen``, which fixes
   documentation builds that break because of outdated and leftover files in that
@@ -334,7 +334,7 @@ For a complete list of commits, check out the `2.22.0`_ release on GitHub.
 
 New features:
 
-- Previously, when the Maven Use plugin updated ``pom.xml`` for self-contained projects,
+- Previously, when the Maven-use plugin updated ``pom.xml`` for self-contained projects,
   it wouldn't reliably find the correct dependency versions on the host. It could
   unpredictably declare the wrong package version, or select a vastly different version
   despite a similar one being available.
@@ -868,7 +868,7 @@ New features:
 
 - Add a :ref:`uv plugin<craft_parts_uv_plugin>` for projects that use the `uv
   <https://docs.astral.sh/uv/>`_ build system.
-- Add a :ref:`Go Use plugin<craft_parts_go_use_plugin>` for setting up a
+- Add a :ref:`Go-use plugin<craft_parts_go_use_plugin>` for setting up a
   `workspace <https://go.dev/ref/mod#workspaces>`_ for Go modules.
 - Add new ``poetry-export-extra-args`` and ``poetry-pip-extra-args`` keys
   to the :ref:`poetry plugin<craft_parts_poetry_plugin>`.

--- a/tests/unit/plugins/test_maven_use.py
+++ b/tests/unit/plugins/test_maven_use.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the Maven use plugin."""
+"""Unit tests for the Maven-use plugin."""
 
 import re
 from pathlib import Path


### PR DESCRIPTION
Following an agreement that we should make the spelling of the human names more consistent.

----
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?
