### PR TITLE
docs: correct the 'organize' description

### DIFF
--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -377,11 +377,11 @@ class PartSpec(BaseModel):
     organize_files: dict[str, str] = Field(
         default_factory=dict,
         alias="organize",
-        description="A map of files from the build directory to their destinations in the stage directory.",
+        description="A map of files from the part's install directory to their destinations in the stage directory.",
         examples=["{hello.py: bin/hello}"],
     )
-    """A map of files from the build directory to their destinations in the stage
-    directory.
+    """A map of files from the part's install directory to their destinations in the
+    stage directory.
 
     Each pair of source and destination paths is represented as a nested key of the form
     ``<source-path>: <destination-path>``.


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
~~Have you successfully run `make lint && make test`?~~
~~Have you added an entry to the changelog (`docs/reference/changelog.rst`)?~~

---

We can always improve this description later on. For now, I just want it to be correct.