### PR TITLE
ci: separate flaky tests into their own job

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -44,7 +44,23 @@ jobs:
       # correctly on said EOL base.
       lowest-python-platform: '["amd64", "focal"]'
       lowest-python-version: "3.10"
-      pytest-markers: not java and not python and not plugin
+      pytest-markers: not java and not python and not plugin and not flaky
+      setup-vars: NO_JAVA=1 NO_PYTHON=1 NO_PLUGIN=1
+  test-flaky:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: "[]"
+      slow-test-platforms: >
+        [
+          "ubuntu-22.04",
+          "ubuntu-22.04-arm",
+          "ubuntu-24.04",
+          "ubuntu-24.04-arm",
+        ]
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-platform: '["amd64", "focal"]'
+      lowest-python-version: "3.10"
+      pytest-markers: flaky
       setup-vars: NO_JAVA=1 NO_PYTHON=1 NO_PLUGIN=1
   test-java-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ markers = [
     "java: tests that require the Java build tools to be installed (includes maven, gradle, etc.)",
     "python: tests that require the Python build tools (poetry, uv, pip)",
     "plugin: tests that require plugin dependencies other than java or python",
+    "flaky: tests that are known to be flaky and may need reruns (e.g. network-dependent)",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/packages/test_chisel.py
+++ b/tests/integration/packages/test_chisel.py
@@ -62,6 +62,11 @@ def test_slice_error_has_details(new_dir: pathlib.Path, partitions, caplog):
     )
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="ChiselError",
+    reason="Fails on network issues or if digests change.",
+)
 def test_install_slice(new_homedir_path: pathlib.Path, partitions, caplog):
     caplog.set_level(logging.DEBUG)
     part_yaml = textwrap.dedent(


### PR DESCRIPTION
Move tests marked with `@pytest.mark.flaky` into a dedicated `test-flaky` CI job so they can be rerun independently and quickly when they fail due to transient issues (e.g. Ubuntu archive syncs).

This avoids needing to re-run the full suite of slow tests if flaky tests fail.

Artifact upload failure is fixed in https://github.com/canonical/starflow/pull/139