### PR TITLE
fix(organize): allow merging directories in overlay with metadata differences

### DIFF
--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -232,8 +232,9 @@ def organize_files(  # noqa: PLR0912, PLR0915
                     file_utils.link_or_copy_tree(
                         src_path,
                         real_dst_path,
-                        overwrite_metadata=dst_partition_pair.partition
-                        != OVERLAY_PARTITION,
+                        overwrite_metadata=(
+                            dst_partition_pair.partition != OVERLAY_PARTITION
+                        ),
                     )
                     shutil.rmtree(src)
                     continue

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -66,9 +66,11 @@ def _check_overlay_equivalence(
     :raises FileOrganizeError: If the paths are not equivalent.
     """
     msg = file_utils.get_path_differences(src_path, dst_path)
-    if not msg:
+    if not msg or (
+        not src_path.is_symlink() and src_path.is_dir() and dst_path.is_dir()
+    ):
         if not src_path.is_symlink() and src_path.is_dir():
-            file_utils.link_or_copy_tree(src_path, dst_path)
+            file_utils.link_or_copy_tree(src_path, dst_path, overwrite_metadata=False)
             shutil.rmtree(src_path)
         else:
             src_path.unlink()
@@ -207,15 +209,32 @@ def organize_files(  # noqa: PLR0912, PLR0915
                             strict=dst_partition_pair.partition != OVERLAY_PARTITION,
                         )
                         if conflicts:
-                            raise errors.FileOrganizeError.from_merge_conflicts(
-                                part_name=part_name,
-                                key=key,
-                                destination=file_map[key],
-                                conflicts=conflicts,
-                            )
+                            if dst_partition_pair.partition == OVERLAY_PARTITION:
+                                conflicts = {
+                                    p: msg
+                                    for p, msg in conflicts.items()
+                                    if not (
+                                        (src_path / p).is_dir()
+                                        and not (src_path / p).is_symlink()
+                                        and (real_dst_path / p).is_dir()
+                                        and not (real_dst_path / p).is_symlink()
+                                    )
+                                }
+                            if conflicts:
+                                raise errors.FileOrganizeError.from_merge_conflicts(
+                                    part_name=part_name,
+                                    key=key,
+                                    destination=file_map[key],
+                                    conflicts=conflicts,
+                                )
                     # Where the key is a glob, we get the contents of the dir to
                     # organize, so we need to add the source's name back in.
-                    file_utils.link_or_copy_tree(src_path, real_dst_path)
+                    file_utils.link_or_copy_tree(
+                        src_path,
+                        real_dst_path,
+                        overwrite_metadata=dst_partition_pair.partition
+                        != OVERLAY_PARTITION,
+                    )
                     shutil.rmtree(src)
                     continue
 

--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -306,14 +306,15 @@ def create_similar_directory(
     :param overwrite_metadata: Whether to overwrite metadata (mode, ownership)
         of existing destination directories.
     """
-    stat = os.stat(source, follow_symlinks=False)  # noqa: PTH116
-    uid = stat.st_uid
-    gid = stat.st_gid
     exists = pathlib.Path(destination).exists()
     os.makedirs(destination, exist_ok=True)  # noqa: PTH103
 
     if exists and not overwrite_metadata:
         return
+
+    stat = os.stat(source, follow_symlinks=False)  # noqa: PTH116
+    uid = stat.st_uid
+    gid = stat.st_gid
 
     # Windows does not have "os.chown" implementation and copystat
     # is unlikely to be useful, so just bail after creating directory.

--- a/craft_parts/utils/file_utils.py
+++ b/craft_parts/utils/file_utils.py
@@ -193,6 +193,8 @@ def link_or_copy_tree(
     destination_tree: str | Path,
     ignore: Callable[[str, list[str]], list[str]] | None = None,
     copy_function: Callable[..., None] = link_or_copy,
+    *,
+    overwrite_metadata: bool = True,
 ) -> None:
     """Copy a source tree into a destination, hard-linking if possible.
 
@@ -202,6 +204,8 @@ def link_or_copy_tree(
     :param ignore: If given, called with two params, source dir and dir contents,
         for every dir copied. Should return list of contents to NOT copy.
     :param copy_function: Callable that actually copies.
+    :param overwrite_metadata: Whether to overwrite metadata (mode, ownership)
+        of existing destination directories.
     """
     if not os.path.isdir(source_tree):  # noqa: PTH112
         raise errors.CopyTreeError(f"{source_tree!r} is not a directory")
@@ -214,7 +218,9 @@ def link_or_copy_tree(
             f"directory {source_tree!r}"
         )
 
-    create_similar_directory(source_tree, destination_tree)
+    create_similar_directory(
+        source_tree, destination_tree, overwrite_metadata=overwrite_metadata
+    )
 
     destination_basename = os.path.basename(destination_tree)  # noqa: PTH119
 
@@ -246,7 +252,9 @@ def link_or_copy_tree(
                 destination_tree, os.path.relpath(source, source_tree)
             )
 
-            create_similar_directory(source, destination)
+            create_similar_directory(
+                source, destination, overwrite_metadata=overwrite_metadata
+            )
 
         for file_name in set(files) - ignored:
             source = os.path.join(root, file_name)  # noqa: PTH118
@@ -283,6 +291,8 @@ def create_similar_directory(
     source: str | Path,
     destination: str | Path,
     permissions: list[Permissions] | None = None,
+    *,
+    overwrite_metadata: bool = True,
 ) -> None:
     """Create a directory with the same permission bits and owner information.
 
@@ -293,11 +303,17 @@ def create_similar_directory(
     :param permissions: The permission definitions to apply to the new directory.
         If omitted, the new directory will have the same permissions and ownership
         of ``source``.
+    :param overwrite_metadata: Whether to overwrite metadata (mode, ownership)
+        of existing destination directories.
     """
     stat = os.stat(source, follow_symlinks=False)  # noqa: PTH116
     uid = stat.st_uid
     gid = stat.st_gid
+    exists = pathlib.Path(destination).exists()
     os.makedirs(destination, exist_ok=True)  # noqa: PTH103
+
+    if exists and not overwrite_metadata:
+        return
 
     # Windows does not have "os.chown" implementation and copystat
     # is unlikely to be useful, so just bail after creating directory.

--- a/tests/integration/features/overlay_partitions/__init__.py
+++ b/tests/integration/features/overlay_partitions/__init__.py
@@ -1,0 +1,26 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from craft_parts import Features
+
+
+def setup_module():
+    Features.reset()
+    Features(enable_overlay=True, enable_partitions=True)
+
+
+def teardown_module():
+    Features.reset()

--- a/tests/integration/features/overlay_partitions/test_executor_organize.py
+++ b/tests/integration/features/overlay_partitions/test_executor_organize.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+import textwrap
+
+import craft_parts
+import pytest
+import yaml
+from craft_parts import Step
+
+
+@pytest.mark.requires_root
+def test_two_parts_organize_to_same_overlay(new_dir: pathlib.Path):
+    parts_yaml = textwrap.dedent(
+        """\
+            parts:
+              a:
+                plugin: nil
+                override-build: |
+                  mkdir -p "${CRAFT_PART_INSTALL}/my-dir/subdir-a"
+                organize:
+                  '*': (overlay)/
+              b:
+                plugin: nil
+                override-build: |
+                  mkdir -p "${CRAFT_PART_INSTALL}/my-dir/subdir-b"
+                  touch "${CRAFT_PART_INSTALL}/my-dir/subdir-b/my-file"
+                organize:
+                  '*': (overlay)/
+              overlayer:
+                plugin: nil
+                overlay-script: |
+                  echo 'Hi from overlay'
+                  test -d "${CRAFT_OVERLAY}/my-dir/subdir-a"
+                  test -d "${CRAFT_OVERLAY}/my-dir/subdir-b"
+                  test -f "${CRAFT_OVERLAY}/my-dir/subdir-b/my-file"
+        """
+    )
+    overlay_base = new_dir / "overlay_base"
+    overlay_base.mkdir()
+
+    parts = yaml.safe_load(parts_yaml)
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test",
+        cache_dir=new_dir,
+        base_layer_dir=overlay_base,
+        base_layer_hash=b"deadbeef",
+        partitions=["default"],
+    )
+    actions = lf.plan(Step.PRIME)
+    with lf.action_executor() as ctx:
+        ctx.execute(actions)
+
+    assert (lf.project_info.prime_dirs["default"] / "my-dir/subdir-b/my-file").is_file()

--- a/tests/unit/features/overlay_partitions/test_executor_organize.py
+++ b/tests/unit/features/overlay_partitions/test_executor_organize.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 from craft_parts import errors
+from craft_parts.executor.organize import organize_files
 
 # Although it's not explicitly used, randomize_iglob is used here as it's an auto-use
 # fixture that checks that the order of an organize doesn't matter.
@@ -313,3 +314,97 @@ def test_organize_no_overwrite_idempotent(tmp_path, data):
             "build": Path(tmp_path / "build"),
         },
     )
+
+
+def test_organize_glob_to_overlay_with_shared_directory_across_parts(tmp_path):
+    overlay_dir = tmp_path / "overlay_dir"
+    part_a_install = tmp_path / "part-a" / "install"
+    part_b_install = tmp_path / "part-b" / "install"
+    part_a_build = tmp_path / "part-a" / "build"
+    part_b_build = tmp_path / "part-b" / "build"
+
+    for path in [
+        overlay_dir,
+        part_a_install,
+        part_b_install,
+        part_a_build,
+        part_b_build,
+    ]:
+        path.mkdir(parents=True, exist_ok=True)
+
+    (part_a_install / "my-dir").mkdir()
+    organize_files(
+        part_name="part-a",
+        file_map={"*": "(overlay)/"},
+        install_dir_map={
+            "default": part_a_install,
+            "overlay": overlay_dir,
+            "build": part_a_build,
+        },
+        overwrite=False,
+        default_partition="default",
+    )
+
+    (part_b_install / "my-other-dir" / "subdir").mkdir(parents=True)
+    (part_b_install / "my-dir" / "subdir").mkdir(parents=True)
+    organize_files(
+        part_name="part-b",
+        file_map={"*": "(overlay)/"},
+        install_dir_map={
+            "default": part_b_install,
+            "overlay": overlay_dir,
+            "build": part_b_build,
+        },
+        overwrite=False,
+        default_partition="default",
+    )
+
+    assert sorted(path.name for path in overlay_dir.iterdir()) == [
+        "my-dir",
+        "my-other-dir",
+    ]
+    assert (overlay_dir / "my-dir" / "subdir").is_dir()
+    assert (overlay_dir / "my-other-dir" / "subdir").is_dir()
+
+
+def test_organize_merge_overlay_directories(new_path):
+    """Verify that multiple parts can contribute to the same directory in the overlay."""
+    install_dir_a = new_path / "install_a"
+    install_dir_b = new_path / "install_b"
+    overlay_dir = new_path / "overlay_dir"
+
+    install_dir_a.mkdir()
+    install_dir_b.mkdir()
+    overlay_dir.mkdir()
+
+    # Part A contributes a directory
+    (install_dir_a / "my-dir").mkdir(mode=0o755)
+    (install_dir_a / "my-dir" / "file-a").touch()
+
+    organize_files(
+        part_name="part-a",
+        file_map={"*": "(overlay)/"},
+        install_dir_map={"default": install_dir_a, "overlay": overlay_dir},
+        overwrite=False,
+        default_partition="default",
+    )
+
+    # Part B contributes to the same directory with different permissions
+    (install_dir_b / "my-dir").mkdir(mode=0o700)
+    (install_dir_b / "my-dir" / "file-b").touch()
+
+    organize_files(
+        part_name="part-b",
+        file_map={"*": "(overlay)/"},
+        install_dir_map={"default": install_dir_b, "overlay": overlay_dir},
+        overwrite=False,
+        default_partition="default",
+    )
+
+    assert (overlay_dir / "my-dir").is_dir()
+    assert (overlay_dir / "my-dir" / "file-a").exists()
+    assert (overlay_dir / "my-dir" / "file-b").exists()
+
+    # Check that metadata of my-dir was PRESERVED (from Part A)
+    # Part A had 0o755, Part B had 0o700
+    assert ((overlay_dir / "my-dir").stat().st_mode & 0o777) == 0o755


### PR DESCRIPTION
Multiple parts should be able to contribute to the same directory in the overlay partition, even if they have different permissions or ownership. Previously, such differences would trigger a FileOrganizeError during the organization phase.

Fixes: #1487