### PR TITLE
Add Patches Directive

### DIFF
--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -540,6 +540,26 @@ class PluginPullError(PartsError):
         super().__init__(brief=brief)
 
 
+class PatchApplyError(PartsError):
+    """A source patch failed to apply during pull.
+
+    :param part_name: The name of the part being processed.
+    :param patch: The patch path as declared in the part definition.
+    :param message: Optional details from patch execution.
+    """
+
+    def __init__(
+        self, *, part_name: str, patch: str, message: str | None = None
+    ) -> None:
+        self.part_name = part_name
+        self.patch = patch
+        self.message = message
+        brief = f"Failed to apply patch {patch!r} for part {part_name!r}."
+        resolution = "Ensure the patch file exists and can be applied cleanly to the pulled source."
+
+        super().__init__(brief=brief, details=message, resolution=resolution)
+
+
 class UserExecutionError(PartsError, abc.ABC):
     """Plugin build script failed at runtime.
 

--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -57,6 +57,7 @@ from . import filesets, migration
 from .environment import generate_step_environment
 from .errors import EnvironmentChangedError
 from .organize import organize_files
+from .source_patches import apply_source_patches
 from .step_handler import (
     StagePartitionContents,
     StepContents,
@@ -803,6 +804,7 @@ class PartHandler:
         state_file = states.get_step_state_path(self._part, step_info.step)
         self._source_handler.check_if_outdated(str(state_file))
         self._source_handler.update()
+        apply_source_patches(self._part, stdout=stdout, stderr=stderr)
 
     def _update_overlay(
         self, step_info: StepInfo, *, stdout: Stream, stderr: Stream

--- a/craft_parts/executor/source_patches.py
+++ b/craft_parts/executor/source_patches.py
@@ -1,0 +1,94 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers to apply source patches declared in part definitions."""
+
+import logging
+from pathlib import Path
+from typing import TextIO
+
+from craft_parts import errors
+from craft_parts.parts import Part
+from craft_parts.utils import process
+
+logger = logging.getLogger(__name__)
+
+Stream = TextIO | int | None
+
+
+def apply_source_patches(part: Part, *, stdout: Stream, stderr: Stream) -> None:
+    """Apply all patches configured for a part to its source tree."""
+    if not part.spec.patches:
+        return
+
+    for patch in part.spec.patches:
+        patch_path = Path(patch).expanduser()
+        if not patch_path.is_absolute():
+            patch_path = part.dirs.project_dir / patch_path
+
+        if not patch_path.is_file():
+            raise errors.PatchApplyError(
+                part_name=part.name,
+                patch=patch,
+                message=f"patch file not found: {patch_path}",
+            )
+
+        command = [
+            "patch",
+            "--strip",
+            "1",
+            "--forward",
+            "--batch",
+            "--input",
+            str(patch_path),
+        ]
+
+        logger.debug("Applying patch %r for part %r", patch_path, part.name)
+        try:
+            process.run(
+                command,
+                cwd=part.part_src_dir,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        except process.ProcessError as process_error:
+            output = process_error.result.combined.decode("utf-8", errors="replace")
+            output_lower = output.lower()
+
+            # `patch --forward` reports already-applied patches as non-zero.
+            if "previously applied" in output_lower:
+                logger.debug(
+                    "Patch %r was already applied for part %r, skipping.",
+                    patch_path,
+                    part.name,
+                )
+                continue
+
+            details = output.strip() or (
+                f"command {command!r} exited with code "
+                f"{process_error.result.returncode}"
+            )
+            raise errors.PatchApplyError(
+                part_name=part.name,
+                patch=patch,
+                message=details,
+            ) from process_error
+        except OSError as err:
+            raise errors.PatchApplyError(
+                part_name=part.name,
+                patch=patch,
+                message=str(err),
+            ) from err

--- a/craft_parts/executor/step_handler.py
+++ b/craft_parts/executor/step_handler.py
@@ -39,6 +39,7 @@ from craft_parts.utils.partition_utils import DEFAULT_PARTITION
 from . import filesets
 from .filesets import Fileset
 from .migration import migrate_files
+from .source_patches import apply_source_patches
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +144,8 @@ class StepHandler:
     def _builtin_pull(self) -> StepContents:
         if self._source_handler:
             self._source_handler.pull()
+
+        apply_source_patches(self._part, stdout=self._stdout, stderr=self._stderr)
 
         pull_commands = self._plugin.get_pull_commands()
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -174,8 +174,7 @@ class PartSpec(BaseModel):
     )
     """A list of patch files to apply to the part's source.
 
-    During the pull step, entries are interpreted as patch files that can be
-    consumed by craft applications that support patch application.
+    During the pull step, entries are applied to the pulled source tree.
     """
 
     source_submodules: list[str] | None = Field(

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -167,6 +167,17 @@ class PartSpec(BaseModel):
     This key does not affect commands specified with ``override-build``.
     """
 
+    patches: list[str] = Field(
+        default=[],
+        description="A list of patch files to apply to the part's source.",
+        examples=[["patches/fix-build.patch", "patches/adjust-paths.patch"]],
+    )
+    """A list of patch files to apply to the part's source.
+
+    During the pull step, entries are interpreted as patch files that can be
+    consumed by craft applications that support patch application.
+    """
+
     source_submodules: list[str] | None = Field(
         default=None,
         description="The registered submodules to fetch from Git sources.",

--- a/craft_parts/state_manager/pull_state.py
+++ b/craft_parts/state_manager/pull_state.py
@@ -68,6 +68,7 @@ class PullState(StepState):
         relevant_properties = [
             "plugin",
             "source",
+            "patches",
             "source-commit",
             "source-depth",
             "source-tag",

--- a/docs/common/craft-parts/reference/part_properties.rst
+++ b/docs/common/craft-parts/reference/part_properties.rst
@@ -51,6 +51,9 @@ from the declared location.
 .. kitbash-field:: PartSpec source_subdir
     :label: reference-part-properties-source-subdir
 
+.. kitbash-field:: PartSpec patches
+    :label: reference-part-properties-patches
+
 .. kitbash-field:: PartSpec override_pull
     :label: reference-part-properties-override-pull
 

--- a/tests/unit/executor/test_part_handler.py
+++ b/tests/unit/executor/test_part_handler.py
@@ -605,6 +605,50 @@ class TestPartUpdateHandler:
         assert out == "hello\n"
         assert err == "+ echo hello\n"
 
+    def test_update_pull_applies_patches(self, mocker, new_dir, partitions):
+        part = Part(
+            "foo",
+            {
+                "plugin": "dump",
+                "source": "subdir",
+                "patches": ["patches/fix.patch"],
+            },
+            partitions=partitions,
+        )
+        project_info = ProjectInfo(
+            application_name="test",
+            cache_dir=new_dir,
+            partitions=partitions,
+            project_dirs=self._dirs,
+        )
+        part_info = PartInfo(project_info, part)
+        ovmgr = OverlayManager(
+            project_info=project_info,
+            part_list=[part],
+            base_layer_dir=None,
+            cache_level=0,
+        )
+        handler = PartHandler(
+            part,
+            part_info=part_info,
+            part_list=[part],
+            overlay_manager=ovmgr,
+        )
+
+        check_if_outdated = mocker.patch.object(
+            handler._source_handler, "check_if_outdated"
+        )
+        update = mocker.patch.object(handler._source_handler, "update")
+        apply_patches = mocker.patch(
+            "craft_parts.executor.part_handler.apply_source_patches"
+        )
+
+        handler._update_pull(StepInfo(part_info, Step.PULL), stdout=None, stderr=None)
+
+        check_if_outdated.assert_called_once()
+        update.assert_called_once_with()
+        apply_patches.assert_called_once_with(part, stdout=None, stderr=None)
+
     _update_build_path = Path("parts/foo/install/foo.txt")
 
     @pytest.mark.slow

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -131,6 +131,77 @@ class TestStepHandlerBuiltins:
         mock_source_pull.assert_called_once_with()
         assert result == StepContents()
 
+    def test_run_builtin_pull_applies_patches(self, new_dir, mocker, partitions):
+        mock_source_pull = mocker.patch(
+            "craft_parts.sources.local_source.LocalSource.pull"
+        )
+        mock_run = mocker.patch("craft_parts.executor.source_patches.process.run")
+
+        patch_path = Path("patches/fix.patch")
+        patch_path.parent.mkdir(parents=True)
+        patch_path.write_text("fake patch")
+
+        part = Part(
+            "p2",
+            {
+                "plugin": "nil",
+                "source": ".",
+                "patches": ["patches/fix.patch"],
+            },
+            partitions=partitions,
+        )
+        part_info = PartInfo(project_info=self._project_info, part=part)
+        sh = _step_handler_for_step(
+            Step.PULL,
+            cache_dir=new_dir,
+            part_info=part_info,
+            part=part,
+            dirs=self._dirs,
+        )
+
+        result = sh.run_builtin()
+
+        mock_source_pull.assert_called_once_with()
+        mock_run.assert_called_once_with(
+            [
+                "patch",
+                "--strip",
+                "1",
+                "--forward",
+                "--batch",
+                "--input",
+                str(new_dir / "patches/fix.patch"),
+            ],
+            cwd=part.part_src_dir,
+            stdout=None,
+            stderr=None,
+        )
+        assert result == StepContents()
+
+    def test_run_builtin_pull_missing_patch_file(self, new_dir, mocker, partitions):
+        mocker.patch("craft_parts.sources.local_source.LocalSource.pull")
+
+        part = Part(
+            "p2",
+            {
+                "plugin": "nil",
+                "source": ".",
+                "patches": ["patches/missing.patch"],
+            },
+            partitions=partitions,
+        )
+        part_info = PartInfo(project_info=self._project_info, part=part)
+        sh = _step_handler_for_step(
+            Step.PULL,
+            cache_dir=new_dir,
+            part_info=part_info,
+            part=part,
+            dirs=self._dirs,
+        )
+
+        with pytest.raises(errors.PatchApplyError):
+            sh.run_builtin()
+
     def test_run_builtin_overlay(self, new_dir, mocker):
         sh = _step_handler_for_step(
             Step.OVERLAY,

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -96,6 +96,7 @@ class TestPullStateChanges:
         relevant_properties = [
             "plugin",
             "source",
+            "patches",
             "source-commit",
             "source-depth",
             "source-tag",
@@ -130,6 +131,7 @@ class TestPullStateChanges:
         relevant_properties = [
             "plugin",
             "source",
+            "patches",
             "source-commit",
             "source-depth",
             "source-tag",

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -43,6 +43,7 @@ class TestPartSpecs:
             "source-commit": "2514f9533ec9b45d07883e10a561b248497a8e3c",
             "source-depth": 3,
             "source-subdir": "src",
+            "patches": ["patches/fix-build.patch", "patches/adjust-paths.patch"],
             "source-submodules": ["submodule_1", "dir/submodule_2"],
             "source-tag": "v2.3",
             "source-type": "tar",
@@ -231,6 +232,17 @@ class TestPartData:
 
         p = Part("foo", {"source": "foobar"}, partitions=partitions)
         assert p.spec.source == "foobar"
+
+    def test_part_patches(self, partitions):
+        p = Part(
+            "foo",
+            {"patches": ["patches/fix-build.patch", "patches/adjust-paths.patch"]},
+            partitions=partitions,
+        )
+        assert p.spec.patches == [
+            "patches/fix-build.patch",
+            "patches/adjust-paths.patch",
+        ]
 
     def test_part_stage_files(self, partitions):
         p = Part("foo", {"stage": ["a", "b", "c"]}, partitions=partitions)


### PR DESCRIPTION
Add a directive called patches which takes a list of filenames that should be applied on top of the source tree during the pull stage, similar to how Debian packaging enables patching through local files in debian/patches/ and a series file that defines the patch order.

Closes: #1587 

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
