### PR TITLE
fix(organize): nest overlay directory globs

### DIFF
--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -198,10 +198,7 @@ def organize_files(  # noqa: PLR0912, PLR0915
                     dst_path in install_dir_map.values()
                     or dst_partition_pair.partition == OVERLAY_PARTITION
                 ):
-                    if dst_path in install_dir_map.values():
-                        real_dst_path = dst_path / src_path.name
-                    else:
-                        real_dst_path = dst_path
+                    real_dst_path = dst_path / src_path.name
                     if not overwrite:
                         conflicts = file_utils.find_merge_conflicts(
                             src_path,

--- a/tests/unit/features/overlay_partitions/test_executor_organize.py
+++ b/tests/unit/features/overlay_partitions/test_executor_organize.py
@@ -250,10 +250,12 @@ def test_organize(new_dir, data):
                 },
                 "expected": [
                     (["dir"], "../overlay_dir"),
-                    (["child"], "../overlay_dir/dir"),
+                    (["dir1", "dir2"], "../overlay_dir/dir"),
+                    (["child"], "../overlay_dir/dir/dir1"),
+                    (["child"], "../overlay_dir/dir/dir2"),
                 ],
             },
-            id="merge-dir-globs-in-overlay-success",
+            id="nest-dir-globs-in-overlay-success",
         ),
         pytest.param(
             {


### PR DESCRIPTION
## Summary

Make directory glob organize behavior consistent when targeting the overlay pseudo-partition.

Previously, globbed directories organized to `(overlay)/...` were merged directly into the destination, unlike globbed directories organized to partition roots or regular paths. This now nests the source directory name for overlay destinations too.

Fixes #1590.

## Tests

- `python -m pytest -q tests/unit/features/overlay_partitions/test_executor_organize.py -rs`
- `git diff --check`