### PR TITLE
fix(organize): make organize to overlay behavior consistent

### DIFF
--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -188,7 +188,7 @@ def organize_files(  # noqa: PLR0912, PLR0915
             # Organize a dir to a dir
             if not src_path.is_symlink() and src_path.is_dir():
                 # When an explicit key is used the source directory is moved
-                # directly to the destination path, replacing it. Multiple
+                # directly to the destination path, replace it. Multiple
                 # explicit keys mapping to the same destination merge their contents.
                 # If a glob key is used, each matching directory is nested inside
                 # the destination preserving its name.

--- a/craft_parts/executor/organize.py
+++ b/craft_parts/executor/organize.py
@@ -187,6 +187,11 @@ def organize_files(  # noqa: PLR0912, PLR0915
 
             # Organize a dir to a dir
             if not src_path.is_symlink() and src_path.is_dir():
+                # When an explicit key is used the source directory is moved
+                # directly to the destination path, replacing it. Multiple
+                # explicit keys mapping to the same destination merge their contents.
+                # If a glob key is used, each matching directory is nested inside
+                # the destination preserving its name.
                 if "*" not in key:  # Key is explicit
                     if dst_path.is_symlink():
                         real_dst_path = dst_path.resolve()
@@ -195,16 +200,13 @@ def organize_files(  # noqa: PLR0912, PLR0915
                     file_utils.link_or_copy_tree(src, real_dst_path)
                     shutil.rmtree(src)
                     continue
+
                 # Key is a glob
                 # Organizing to the root of a partition in overwrite mode.
-                if (
-                    dst_path in install_dir_map.values()
-                    or dst_partition_pair.partition == OVERLAY_PARTITION
-                ):
-                    if dst_path in install_dir_map.values():
-                        real_dst_path = dst_path / src_path.name
-                    else:
-                        real_dst_path = dst_path
+                organize_to_overlay = dst_partition_pair.partition == OVERLAY_PARTITION
+
+                if dst_path in install_dir_map.values() or organize_to_overlay:
+                    real_dst_path = dst_path / src_path.name
                     if not overwrite:
                         conflicts = file_utils.find_merge_conflicts(
                             src_path,

--- a/tests/unit/features/overlay_partitions/test_executor_organize.py
+++ b/tests/unit/features/overlay_partitions/test_executor_organize.py
@@ -250,10 +250,12 @@ def test_organize(new_dir, data):
                 },
                 "expected": [
                     (["dir"], "../overlay_dir"),
-                    (["child"], "../overlay_dir/dir"),
+                    (["dir1", "dir2"], "../overlay_dir/dir"),
+                    (["child"], "../overlay_dir/dir/dir1"),
+                    (["child"], "../overlay_dir/dir/dir2"),
                 ],
             },
-            id="merge-dir-globs-in-overlay-success",
+            id="nest-dir-globs-in-overlay-success",
         ),
         pytest.param(
             {


### PR DESCRIPTION
An inconsistency was introduced in commit a1178308 (PR #1541) that caused
glob-key organizing to the overlay merge directory contents instead of
nesting. The expected behavior is to merge when explicit keys are used
and nest when globs are used. Fixed the organize logic to make glob-key
organizing to overlay nest instead of merge to remain consistent with
the results of organizing to other targets.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
