### PR TITLE
ci: test on Python 3.14 and Ubuntu 26.04 (Resolute)

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -28,8 +28,9 @@ jobs:
           "ubuntu-24.04-arm",
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      fast-test-python-versions: '["3.10", "3.12", "3.13"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.13", "3.14"]'
       slow-test-platforms: >
         [
           "ubuntu-22.04",
@@ -38,8 +39,9 @@ jobs:
           "ubuntu-24.04-arm",
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.12"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       # We must always test on at least one EOL base to ensure that chisel behaves
       # correctly on said EOL base.
       lowest-python-platform: '["amd64", "focal"]'
@@ -56,8 +58,9 @@ jobs:
           "ubuntu-22.04-arm",
           "ubuntu-24.04",
           "ubuntu-24.04-arm",
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.12"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       lowest-python-platform: '["amd64", "focal"]'
       lowest-python-version: "3.10"
       pytest-markers: flaky
@@ -74,8 +77,9 @@ jobs:
           "ubuntu-24.04-arm",
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.12"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       lowest-python-version: ""
       pytest-markers: java
       setup-vars: NO_PYTHON=1 NO_PLUGIN=1
@@ -89,8 +93,9 @@ jobs:
           "ubuntu-24.04-arm",
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.12"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       lowest-python-version: ""
       pytest-markers: python
       setup-vars: NO_JAVA=1 NO_PLUGIN=1
@@ -102,8 +107,9 @@ jobs:
         [
           "ubuntu-22.04",
           "ubuntu-22.04-arm",
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.10"]'
+      slow-test-python-versions: '["3.10", "3.14"]'
       lowest-python-version: ""
       pytest-markers: python
       setup-vars: NO_JAVA=1 NO_PLUGIN=1
@@ -119,8 +125,9 @@ jobs:
           "ubuntu-24.04-arm",
           ["noble", "s390x", "edge"],
           ["noble", "ppc64el", "edge"],
+          "self-hosted-linux-amd64-resolute-large",
         ]
-      slow-test-python-versions: '["3.12"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       lowest-python-platform: '["focal"]'
       lowest-python-version: "3.10"
       pytest-markers: plugin
@@ -131,8 +138,8 @@ jobs:
     with:
       fast-test-platforms: '["ubuntu-24.04"]'
       fast-test-python-versions: '["3.12"]'
-      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm"]'
-      slow-test-python-versions: '["3.12"]'
+      slow-test-platforms: '["ubuntu-24.04", "ubuntu-24.04-arm", "self-hosted-linux-amd64-resolute-large"]'
+      slow-test-python-versions: '["3.12", "3.14"]'
       lowest-python-version: ""
       pytest-markers: requires_root
       test-command-prefix: sudo env "PATH=$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "lxml>=5.3.0",


### PR DESCRIPTION
This PR adds testing for Python 3.14 and Ubuntu 26.04 (Resolute) to the QA workflow. Resolute testing uses the 'self-hosted-linux-amd64-resolute-large' runner.

Fixes: #1605