### PR TITLE
Make the `nil` plugin out-of-source

### DIFF
--- a/craft_parts/plugins/nil_plugin.py
+++ b/craft_parts/plugins/nil_plugin.py
@@ -80,3 +80,8 @@ class NilPlugin(Plugin):
     def get_build_commands(self) -> list[str]:
         """Return a list of commands to run during the build step."""
         return []
+
+    @classmethod
+    def get_out_of_source_build(cls) -> bool:
+        """Return whether the plugin performs out-of-source-tree builds."""
+        return True

--- a/tests/unit/plugins/test_nil_plugin.py
+++ b/tests/unit/plugins/test_nil_plugin.py
@@ -46,4 +46,4 @@ class TestPluginNil:
         assert self._plugin.get_build_commands() == []
 
     def test_get_out_of_source_build(self):
-        assert self._plugin.get_out_of_source_build() is False
+        assert self._plugin.get_out_of_source_build() is True


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This PR makes the `nil` plugin out-of-source. Resolves #1609.

This is a **breaking change**, as people using the `nil` plugin are most likely expecting the source files to already be in the **build** directory when executing the **override-build** instructions. 

If this is merged, such existing projects will have to add a copy instruction from **source** to **build**, like this one:

```yaml
parts:
  my-file:
    plugin: nil
    source: data
    override-build: |
      # Copy files from source to build. You can optionally add '--link' to create hard-links instead of copies.
      cp -rf --archive --no-dereference ${CRAFT_PART_SRC}/* ${CRAFT_PART_BUILD} 
      
      # Existing instructions here
```