### PR TITLE
feat(plugins): allow subclasses to set autoconf parameters

### DIFF
--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -66,7 +66,7 @@ class AutotoolsPlugin(Plugin):
     """
 
     properties_class = AutotoolsPluginProperties
-    default_configure_parameters = []
+    default_configure_parameters: list[str] = []
 
     @override
     def get_build_snaps(self) -> set[str]:

--- a/craft_parts/plugins/autotools_plugin.py
+++ b/craft_parts/plugins/autotools_plugin.py
@@ -66,6 +66,7 @@ class AutotoolsPlugin(Plugin):
     """
 
     properties_class = AutotoolsPluginProperties
+    default_configure_parameters = []
 
     @override
     def get_build_snaps(self) -> set[str]:
@@ -84,7 +85,11 @@ class AutotoolsPlugin(Plugin):
 
     def _get_configure_command(self) -> str:
         options = cast(AutotoolsPluginProperties, self._options)
-        cmd = ["./configure", *options.autotools_configure_parameters]
+        cmd = [
+            "./configure",
+            *self.default_configure_parameters,
+            *options.autotools_configure_parameters,
+        ]
         return " ".join(cmd)
 
     def _get_bootstrap_command(self) -> str:

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -56,7 +56,7 @@ class MakePlugin(Plugin):
     """
 
     properties_class = MakePluginProperties
-    default_parameters = []
+    default_parameters: list[str] = []
 
     @override
     def get_build_snaps(self) -> set[str]:

--- a/craft_parts/plugins/make_plugin.py
+++ b/craft_parts/plugins/make_plugin.py
@@ -56,7 +56,7 @@ class MakePlugin(Plugin):
     """
 
     properties_class = MakePluginProperties
-    read_environment = False
+    default_parameters = []
 
     @override
     def get_build_snaps(self) -> set[str]:
@@ -74,9 +74,11 @@ class MakePlugin(Plugin):
         return {}
 
     def _get_make_command(self, target: str = "") -> str:
-        cmd = ["make", f'-j"{self._part_info.parallel_build_count}"']
-        if self.read_environment:
-            cmd.append("-e")
+        cmd = [
+            "make",
+            *self.default_parameters,
+            f'-j"{self._part_info.parallel_build_count}"',
+        ]
 
         if target:
             cmd.append(target)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -22,7 +22,7 @@ Changelog
 
 .. _release-2.35.0:
 
-2.35.0 (unreleased)
+2.35.0 (2026-06-17)
 -------------------
 
 New features:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,15 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+
+2.35.0 (2026-XX-YY)
+-------------------
+
+New features:
+
+- Applications can define default parameters for autoconf and make when subclassing
+  the plugins.
+
 .. _release-2.34.0:
 
 2.34.0 (2026-06-10)

--- a/tests/unit/plugins/test_autotools_plugin.py
+++ b/tests/unit/plugins/test_autotools_plugin.py
@@ -163,3 +163,16 @@ class TestPluginAutotools:
 
     def test_get_out_of_source_build(self):
         assert self._plugin.get_out_of_source_build() is False
+
+    def test_subclass_default_parameters(self, new_dir):
+        class LocalAutotoolsPlugin(AutotoolsPlugin):
+            default_configure_parameters = ["--custom=True"]
+
+        properties = LocalAutotoolsPlugin.properties_class.unmarshal({"source": "."})
+        part = Part("foo", {})
+
+        project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        part_info = PartInfo(project_info=project_info, part=part)
+        plugin = LocalAutotoolsPlugin(properties=properties, part_info=part_info)
+
+        assert "./configure --custom=True" in plugin.get_build_commands()

--- a/tests/unit/plugins/test_make_plugin.py
+++ b/tests/unit/plugins/test_make_plugin.py
@@ -94,3 +94,16 @@ class TestPluginMake:
 
     def test_get_out_of_source_build(self):
         assert self._plugin.get_out_of_source_build() is False
+
+    def test_subclass_default_parameters(self, new_dir):
+        class LocalMakePlugin(MakePlugin):
+            default_parameters = ["-e"]
+
+        properties = LocalMakePlugin.properties_class.unmarshal({"source": "."})
+        part = Part("foo", {})
+
+        project_info = ProjectInfo(application_name="test", cache_dir=new_dir)
+        part_info = PartInfo(project_info=project_info, part=part)
+        plugin = LocalMakePlugin(properties=properties, part_info=part_info)
+
+        assert 'make -e -j"1"' in plugin.get_build_commands()


### PR DESCRIPTION
Applications subclassing the autotools plugin can set default configure
parameters to values specific to the applications' use case. Also extend
the pattern to the make plugin.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
