### PR TITLE
fix: migrate overlay files before running stage or prime

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -546,6 +546,8 @@ class PartHandler:
         """
         self._make_dirs()
 
+        self._migrate_overlay_files_to_stage()
+
         contents = self._run_step(
             step_info=step_info,
             scriptlet_name="override-stage",
@@ -553,8 +555,6 @@ class PartHandler:
             stdout=stdout,
             stderr=stderr,
         )
-
-        self._migrate_overlay_files_to_stage()
 
         # Overlay integrity is checked based by the hash of its last (topmost) layer,
         # so we compute it for all parts. The overlay hash is added to the stage state
@@ -603,6 +603,8 @@ class PartHandler:
         """
         self._make_dirs()
 
+        self._migrate_overlay_files_to_prime()
+
         contents = self._run_step(
             step_info=step_info,
             scriptlet_name="override-prime",
@@ -611,7 +613,6 @@ class PartHandler:
             stderr=stderr,
         )
 
-        self._migrate_overlay_files_to_prime()
         default_partition = self._part_info.default_partition or DEFAULT_PARTITION
 
         primed_stage_packages: set[str]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,24 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+
+.. _release-2.35.0:
+
+2.35.0 (unreleased)
+-------------------
+
+New features:
+
+- The plus sign is allowed in partition names. More restrictive rules must be
+  enforced at application level.
+
+Bug fixes:
+
+- Always migrate overlay files to Stage and Prime first, even if the part being staged
+  or primed also has contents coming from the install directory.
+
+For a complete list of commits, check out the `2.35.0`_ release on GitHub.
+
 .. _release-2.34.0:
 
 2.34.0 (2026-06-10)
@@ -35,8 +53,6 @@ New features:
   <https://docs.python.org/3/library/pathlib.html>`_. All uses of ``str`` for paths are
   replaced with ``pathlib.Path``. In the public APIs, this change only impacts the
   ``files`` and ``directories`` variables of the ``MigrationState`` class.
-- The plus sign is allowed in partition names. More restrictive rules must be
-  enforced at application level.
 - Allow applications to set up build environment variables when creating the
   lifecycle manager.
 
@@ -1724,6 +1740,7 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.35.0: https://github.com/canonical/craft-parts/releases/tag/2.35.0
 .. _2.34.0: https://github.com/canonical/craft-parts/releases/tag/2.34.0
 .. _2.33.0: https://github.com/canonical/craft-parts/releases/tag/2.33.0
 .. _2.32.0: https://github.com/canonical/craft-parts/releases/tag/2.32.0

--- a/tests/unit/features/overlay/test_executor_part_handler.py
+++ b/tests/unit/features/overlay/test_executor_part_handler.py
@@ -741,7 +741,7 @@ class TestOverlayMigration:
         assert Path("prime/.wh.file1").exists() is False
         assert Path("prime/.wh.file2").exists()
 
-    def test_migrate_overlay_with_install(self, mocker, new_dir, partitions):
+    def test_migrate_overlay_with_install(self, new_dir, partitions):
         """Test that overlay contents are correctly migrated when the part has
         relevant contents coming from the install dir."""
         cache_dir = new_dir / "cache"
@@ -791,6 +791,51 @@ class TestOverlayMigration:
         assert prime_state is not None
         assert Path("my-dir") in prime_state.directories
         assert Path("my-dir/my-file.txt") in prime_state.files
+
+    def test_migrate_overlay_filters(self, new_dir, partitions):
+        """Test the interaction between the overlay migration and the 'stage' and 'prime'
+        filters."""
+        cache_dir = new_dir / "cache"
+        base_dir = new_dir / "base"
+        cache_dir.mkdir()
+        base_dir.mkdir()
+
+        # We'll have a file coming from the overlay and one coming from the build.
+        overlay_file = "my-overlay-file.txt"
+        build_file = "my-build-file.txt"
+
+        p1 = Part(
+            "p1",
+            {
+                "plugin": "nil",
+                "overlay-script": "exit 0",
+                "prime": [f"-{overlay_file}", f"-{build_file}"],
+            },
+            partitions=partitions,
+        )
+        info = ProjectInfo(application_name="test", cache_dir=cache_dir)
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1], base_layer_dir=base_dir, cache_level=0
+        )
+        p1_handler = PartHandler(
+            p1,
+            part_info=PartInfo(info, p1),
+            part_list=[p1],
+            overlay_manager=ovmgr,
+        )
+        p1_handler._make_dirs()
+
+        # Add the files to their respective directories.
+        (p1.part_layer_dir / overlay_file).touch()
+        (p1.part_install_dir / build_file).touch()
+
+        _run_step_migration(p1_handler, Step.PRIME)
+        prime_dir = p1.prime_dir
+
+        # The file coming from the BUILD step is filtered out, but the file coming
+        # from OVERLAY is *not*.
+        assert not (prime_dir / build_file).exists()
+        assert (prime_dir / overlay_file).exists()
 
 
 def _run_step_migration(handler: PartHandler, step: Step) -> None:

--- a/tests/unit/features/overlay/test_executor_part_handler.py
+++ b/tests/unit/features/overlay/test_executor_part_handler.py
@@ -741,6 +741,57 @@ class TestOverlayMigration:
         assert Path("prime/.wh.file1").exists() is False
         assert Path("prime/.wh.file2").exists()
 
+    def test_migrate_overlay_with_install(self, mocker, new_dir, partitions):
+        """Test that overlay contents are correctly migrated when the part has
+        relevant contents coming from the install dir."""
+        cache_dir = new_dir / "cache"
+        base_dir = new_dir / "base"
+        cache_dir.mkdir()
+        base_dir.mkdir()
+
+        p1 = Part(
+            "p1", {"plugin": "nil", "overlay-script": "exit 0"}, partitions=partitions
+        )
+        info = ProjectInfo(application_name="test", cache_dir=cache_dir)
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1], base_layer_dir=base_dir, cache_level=0
+        )
+        p1_handler = PartHandler(
+            p1,
+            part_info=PartInfo(info, p1),
+            part_list=[p1],
+            overlay_manager=ovmgr,
+        )
+        p1_handler._make_dirs()
+
+        # Put a "my-dir/my-file.txt" structure in the part's layer dir.
+        (p1.part_layer_dir / "my-dir").mkdir(exist_ok=False)
+        (p1.part_layer_dir / "my-dir/my-file.txt").touch()
+
+        # Put the *same* structure in the part's install dir.
+        (p1.part_install_dir / "my-dir").mkdir(exist_ok=False)
+        (p1.part_install_dir / "my-dir/my-file.txt").touch()
+
+        # Run Stage and check that the file and directory were recorded in the overlay
+        # migration state
+        p1_handler.run_action(Action("", Step.STAGE))
+        stage_state = states.load_overlay_migration_state(
+            p1.overlay_dirs[None], Step.STAGE
+        )
+        assert stage_state is not None
+        assert Path("my-dir") in stage_state.directories
+        assert Path("my-dir/my-file.txt") in stage_state.files
+
+        # Run Prime and check that the file and directory were recorded in the overlay
+        # migration state
+        p1_handler.run_action(Action("", Step.PRIME))
+        prime_state = states.load_overlay_migration_state(
+            p1.overlay_dirs[None], Step.PRIME
+        )
+        assert prime_state is not None
+        assert Path("my-dir") in prime_state.directories
+        assert Path("my-dir/my-file.txt") in prime_state.files
+
 
 def _run_step_migration(handler: PartHandler, step: Step) -> None:
     if step > Step.STAGE:


### PR DESCRIPTION
This commit switches the order of calling _run_step() and _migrate_overlay* so that the overlay migration always happens *before* the default step behavior. This is the desired behavior, but the previous code had a corner-case when a part has content coming from both 'build' and 'overlay', like this:

```yaml
parts:
  p1:
    override-build: |
      mkdir ${CRAFT_PART_INSTALL}/my-dir
    override-overlay: |
      mkdir my-dir
      touch my-dir/my-file
```

... in this situation, the previous code would *first* stage the `my-dir`directory coming from `override-build` and *then* migrate `my-dir` and `my-dir/my-file` from the overlay to stage. Because of the way the migration happens, the `my-dir` dir coming from build would "shadow" the `my-dir` dir coming from stage, which meant the migrate state would *not* record `my-dir` as coming from the overlay. This is a bug in and of itself but it was usually harmless.

A failure happens if another, separate part gets primed *before* `p1`. In that case, we would try to do the migration of overlay contents from stage to prime, which in this case meant migrating the `my-dir/my-file` file but **not** the `my-dir` dir because it did not get recorded. Then, the migration of `my-dir/my-file` would *maybe* work:

- if `my-file` is a regular file, the code would follow a path that recreates the directory structure to hardlink the file (to save storage);
- if `my-file` is a special file like a symlink the code would try to copy it to `${prime}/my-dir/`, which doesn't exist. Then a failure happens with a cryptic message that suggests that `${stage}/my-dir/my-file` doesn't exist, but this is just bad formatting of the error message.

In my view the main cause of this bug is the fact that overlay files are not correctly recorded in the state file - I added a test to check this scenario and I think it's sufficient to validate this particular bugfix.
---
