### PR TITLE
fix: handle dependencies when organizing to overlay

### DIFF
--- a/craft_parts/sequencer.py
+++ b/craft_parts/sequencer.py
@@ -231,13 +231,16 @@ class Sequencer:
         return self._sm.project_vars(part, step)
 
     def _process_dependencies(self, part: Part, step: Step) -> None:
-        prerequisite_step = steps.dependency_prerequisite_step(step)
-        if not prerequisite_step:
-            return
-
         all_deps = parts.part_dependencies(part, part_list=self._part_list)
-        deps = {p for p in all_deps if self._sm.should_step_run(p, prerequisite_step)}
-        for dep in deps:
+        for dep in all_deps:
+            prerequisite_step = steps.dependency_prerequisite_step(
+                step, part=part, dependency=dep
+            )
+            if not prerequisite_step or not self._sm.should_step_run(
+                dep, prerequisite_step
+            ):
+                continue
+
             self._add_all_actions(
                 target_step=prerequisite_step,
                 part_names=[dep.name],
@@ -265,7 +268,7 @@ class Sequencer:
             self._layer_state.set_layer_hash(part, layer_hash)
 
         elif (step == Step.BUILD and part in self._overlay_viewers) or (
-            step == Step.STAGE and part.has_overlay
+            step == Step.STAGE and (part.has_overlay or part.organizes_to_overlay)
         ):
             # The overlay step for all parts should run before we build a part
             # with overlay visibility or before we stage a part that declares
@@ -476,11 +479,13 @@ class Sequencer:
                 return True
 
         elif step == Step.STAGE:
-            # If a part declares overlay parameters, restage it if overlay changed
+            # If a part contributes overlay content, restage it if overlay changed
             current_overlay_hash = self._layer_state.get_overlay_hash()
             state_overlay_hash = self._sm.get_step_state_overlay_hash(part, step)
 
-            if part.has_overlay and current_overlay_hash != state_overlay_hash:
+            if (
+                part.has_overlay or part.organizes_to_overlay
+            ) and current_overlay_hash != state_overlay_hash:
                 logger.debug("%s:%s has overlay and it changed", part.name, step)
                 self._rerun_step(part, step, reason="overlay changed")
                 return True

--- a/craft_parts/state_manager/state_manager.py
+++ b/craft_parts/state_manager/state_manager.py
@@ -410,6 +410,12 @@ class StateManager:
 
         changed_dependencies: list[Dependency] = []
         for dependency in dependencies:
+            prerequisite_step = steps.dependency_prerequisite_step(
+                step, part=part, dependency=dependency
+            )
+            if not prerequisite_step:
+                continue
+
             prerequisite_stw = self._state_db.get(
                 part_name=dependency.name, step=prerequisite_step
             )

--- a/craft_parts/steps.py
+++ b/craft_parts/steps.py
@@ -17,8 +17,12 @@
 """Definitions and helpers to handle lifecycle steps."""
 
 import enum
+from typing import TYPE_CHECKING
 
 from craft_parts.features import Features
+
+if TYPE_CHECKING:
+    from craft_parts.parts import Part
 
 
 @enum.unique
@@ -82,7 +86,12 @@ class Step(enum.IntEnum):
         return steps
 
 
-def dependency_prerequisite_step(step: Step) -> Step | None:
+def dependency_prerequisite_step(
+    step: Step,
+    *,
+    part: "Part | None" = None,
+    dependency: "Part | None" = None,
+) -> Step | None:
     """Obtain the step a given step may depend on.
 
     :returns: The prerequisite step.
@@ -90,6 +99,14 @@ def dependency_prerequisite_step(step: Step) -> Step | None:
     #  With V2 plugins we don't need to repull if dependency is restaged
     if step <= Step.OVERLAY:
         return None
+
+    # Organize-to-overlay parts run their overlay-producing build step
+    # before other parts. See [ST-158].
+    if step == Step.BUILD and part and dependency and part.organizes_to_overlay:
+        if dependency.organizes_to_overlay:
+            return Step.BUILD
+        if dependency.has_overlay:
+            return Step.OVERLAY
 
     if step <= Step.STAGE:
         return Step.STAGE

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,15 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+Unreleased
+----------
+
+Bug fixes:
+
+- The Overlay and Build steps of parts that organize content to the overlay
+  are executed before these steps in other parts, even when ``after`` is
+  used.
+
 .. _release-2.33.1:
 
 2.33.1 (2026-06-17)

--- a/tests/integration/lifecycle/test_lifecycle_organize_to_overlay.py
+++ b/tests/integration/lifecycle/test_lifecycle_organize_to_overlay.py
@@ -306,6 +306,8 @@ def test_basic_lifecycle_overlay_only(new_dir, mocker):
         Action("foo", Step.PULL, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.OVERLAY, action_type=ActionType.SKIP, reason="already ran"),
         Action("foo", Step.BUILD, action_type=ActionType.SKIP, reason="already ran"),
+        Action("foobar", Step.PULL, reason="required to stage 'foo'"),
+        Action("foobar", Step.OVERLAY, reason="required to stage 'foo'"),
         Action("foo", Step.STAGE, reason="required to build 'bar'"),
         # now we can build bar
         Action("bar", Step.BUILD),
@@ -499,3 +501,59 @@ def test_organize_after_lifecycle_actions(new_dir, mocker):
         Action("p2", Step.PRIME),
         Action("p1", Step.PRIME),
     ]
+
+
+issue_1611_parts_yaml = textwrap.dedent(
+    """\
+    parts:
+      rootfs:
+        plugin: nil
+        organize:
+          '*': (overlay)/
+
+      apt-config:
+        plugin: nil
+        after: [rootfs]
+        organize:
+          ubuntu.sources: (overlay)/etc/apt/sources.list.d/ubuntu.sources
+
+      fstab:
+        plugin: nil
+        after: [rootfs]
+        overlay-script: |
+          true
+    """
+)
+
+
+def test_issue_1611_organize_builds_before_first_stage(new_dir, mocker):
+    mocker.patch("os.geteuid", return_value=0)
+
+    parts = yaml.safe_load(issue_1611_parts_yaml)
+    Path("base").mkdir()
+
+    lf = craft_parts.LifecycleManager(
+        parts,
+        application_name="test_demo",
+        cache_dir=new_dir,
+        partitions=["default"],
+        base_layer_dir=Path("base"),
+        base_layer_hash=b"hash",
+    )
+
+    actions = lf.plan(Step.PRIME)
+
+    first_rootfs_stage = actions.index(
+        next(a for a in actions if a.part_name == "rootfs" and a.step == Step.STAGE)
+    )
+    apt_config_build = actions.index(
+        Action("apt-config", Step.BUILD, reason="organize contents to overlay")
+    )
+    fstab_overlay = actions.index(Action("fstab", Step.OVERLAY))
+    apt_config_build_count = actions.count(
+        Action("apt-config", Step.BUILD, reason="organize contents to overlay")
+    )
+
+    assert apt_config_build < first_rootfs_stage
+    assert fstab_overlay < first_rootfs_stage
+    assert apt_config_build_count == 1

--- a/tests/unit/features/overlay_partitions/test_steps.py
+++ b/tests/unit/features/overlay_partitions/test_steps.py
@@ -1,0 +1,60 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+from craft_parts import steps
+from craft_parts.parts import Part
+from craft_parts.steps import Step
+
+
+@pytest.mark.parametrize(
+    ("tc_step", "tc_result"),
+    [
+        (Step.PULL, None),
+        (Step.OVERLAY, None),
+        (Step.BUILD, Step.STAGE),
+        (Step.STAGE, Step.STAGE),
+        (Step.PRIME, Step.PRIME),
+    ],
+)
+def test_prerequisite_step(tc_step, tc_result):
+    assert steps.dependency_prerequisite_step(tc_step) == tc_result
+
+
+def test_prerequisite_step_organize_to_overlay_build_dependency(partitions):
+    part = Part("part", {"organize": {"*": "(overlay)/"}}, partitions=partitions)
+    organize_dep = Part(
+        "organize-dep", {"organize": {"*": "(overlay)/"}}, partitions=partitions
+    )
+    overlay_dep = Part("overlay-dep", {"overlay-script": "true"}, partitions=partitions)
+    normal_dep = Part("normal-dep", {}, partitions=partitions)
+
+    assert (
+        steps.dependency_prerequisite_step(
+            Step.BUILD, part=part, dependency=organize_dep
+        )
+        == Step.BUILD
+    )
+    assert (
+        steps.dependency_prerequisite_step(
+            Step.BUILD, part=part, dependency=overlay_dep
+        )
+        == Step.OVERLAY
+    )
+    assert (
+        steps.dependency_prerequisite_step(Step.BUILD, part=part, dependency=normal_dep)
+        == Step.STAGE
+    )


### PR DESCRIPTION
Per ST-158, "the OVERLAY and BUILD steps of parts organizing to the
overlay are executed before these steps of other parts." This has
precedence over regular dependencies, meaning that the BUILD step
(and therefore organize) of a part depending on another part should
execute before the STAGE step of the dependency.

Fixes #1611

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
CRAFT-5215