### PR TITLE
fix: migrate overlay files before running stage or prime (#1617)

### DIFF
--- a/craft_parts/executor/part_handler.py
+++ b/craft_parts/executor/part_handler.py
@@ -540,6 +540,8 @@ class PartHandler:
         """
         self._make_dirs()
 
+        self._migrate_overlay_files_to_stage()
+
         contents = self._run_step(
             step_info=step_info,
             scriptlet_name="override-stage",
@@ -547,8 +549,6 @@ class PartHandler:
             stdout=stdout,
             stderr=stderr,
         )
-
-        self._migrate_overlay_files_to_stage()
 
         # Overlay integrity is checked based by the hash of its last (topmost) layer,
         # so we compute it for all parts. The overlay hash is added to the stage state
@@ -597,6 +597,8 @@ class PartHandler:
         """
         self._make_dirs()
 
+        self._migrate_overlay_files_to_prime()
+
         contents = self._run_step(
             step_info=step_info,
             scriptlet_name="override-prime",
@@ -605,7 +607,6 @@ class PartHandler:
             stderr=stderr,
         )
 
-        self._migrate_overlay_files_to_prime()
         default_partition = self._part_info.default_partition or DEFAULT_PARTITION
 
         primed_stage_packages: set[str]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,18 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+.. _release-2.33.1:
+
+2.33.1 (2026-06-17)
+-------------------
+
+Bug fixes:
+
+- Always migrate overlay files to Stage and Prime first, even if the part being staged
+  or primed also has contents coming from the install directory.
+
+For a complete list of commits, check out the `2.33.1`_ release on GitHub.
+
 .. _release-2.33.0:
 
 2.33.0 (2026-04-15)
@@ -1694,6 +1706,7 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.33.1: https://github.com/canonical/craft-parts/releases/tag/2.33.1
 .. _2.33.0: https://github.com/canonical/craft-parts/releases/tag/2.33.0
 .. _2.32.0: https://github.com/canonical/craft-parts/releases/tag/2.32.0
 .. _2.31.0: https://github.com/canonical/craft-parts/releases/tag/2.31.0

--- a/tests/unit/features/overlay/test_executor_part_handler.py
+++ b/tests/unit/features/overlay/test_executor_part_handler.py
@@ -738,6 +738,102 @@ class TestOverlayMigration:
         assert Path("prime/.wh.file1").exists() is False
         assert Path("prime/.wh.file2").exists()
 
+    def test_migrate_overlay_with_install(self, new_dir, partitions):
+        """Test that overlay contents are correctly migrated when the part has
+        relevant contents coming from the install dir."""
+        cache_dir = new_dir / "cache"
+        base_dir = new_dir / "base"
+        cache_dir.mkdir()
+        base_dir.mkdir()
+
+        p1 = Part(
+            "p1", {"plugin": "nil", "overlay-script": "exit 0"}, partitions=partitions
+        )
+        info = ProjectInfo(application_name="test", cache_dir=cache_dir)
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1], base_layer_dir=base_dir, cache_level=0
+        )
+        p1_handler = PartHandler(
+            p1,
+            part_info=PartInfo(info, p1),
+            part_list=[p1],
+            overlay_manager=ovmgr,
+        )
+        p1_handler._make_dirs()
+
+        # Put a "my-dir/my-file.txt" structure in the part's layer dir.
+        (p1.part_layer_dir / "my-dir").mkdir(exist_ok=False)
+        (p1.part_layer_dir / "my-dir/my-file.txt").touch()
+
+        # Put the *same* structure in the part's install dir.
+        (p1.part_install_dir / "my-dir").mkdir(exist_ok=False)
+        (p1.part_install_dir / "my-dir/my-file.txt").touch()
+
+        # Run Stage and check that the file and directory were recorded in the overlay
+        # migration state
+        p1_handler.run_action(Action("", Step.STAGE))
+        stage_state = states.load_overlay_migration_state(
+            p1.overlay_dirs[None], Step.STAGE
+        )
+        assert stage_state is not None
+        assert "my-dir" in stage_state.directories
+        assert "my-dir/my-file.txt" in stage_state.files
+
+        # Run Prime and check that the file and directory were recorded in the overlay
+        # migration state
+        p1_handler.run_action(Action("", Step.PRIME))
+        prime_state = states.load_overlay_migration_state(
+            p1.overlay_dirs[None], Step.PRIME
+        )
+        assert prime_state is not None
+        assert "my-dir" in prime_state.directories
+        assert "my-dir/my-file.txt" in prime_state.files
+
+    def test_migrate_overlay_filters(self, new_dir, partitions):
+        """Test the interaction between the overlay migration and the 'stage' and 'prime'
+        filters."""
+        cache_dir = new_dir / "cache"
+        base_dir = new_dir / "base"
+        cache_dir.mkdir()
+        base_dir.mkdir()
+
+        # We'll have a file coming from the overlay and one coming from the build.
+        overlay_file = "my-overlay-file.txt"
+        build_file = "my-build-file.txt"
+
+        p1 = Part(
+            "p1",
+            {
+                "plugin": "nil",
+                "overlay-script": "exit 0",
+                "prime": [f"-{overlay_file}", f"-{build_file}"],
+            },
+            partitions=partitions,
+        )
+        info = ProjectInfo(application_name="test", cache_dir=cache_dir)
+        ovmgr = OverlayManager(
+            project_info=info, part_list=[p1], base_layer_dir=base_dir, cache_level=0
+        )
+        p1_handler = PartHandler(
+            p1,
+            part_info=PartInfo(info, p1),
+            part_list=[p1],
+            overlay_manager=ovmgr,
+        )
+        p1_handler._make_dirs()
+
+        # Add the files to their respective directories.
+        (p1.part_layer_dir / overlay_file).touch()
+        (p1.part_install_dir / build_file).touch()
+
+        _run_step_migration(p1_handler, Step.PRIME)
+        prime_dir = p1.prime_dir
+
+        # The file coming from the BUILD step is filtered out, but the file coming
+        # from OVERLAY is *not*.
+        assert not (prime_dir / build_file).exists()
+        assert (prime_dir / overlay_file).exists()
+
 
 def _run_step_migration(handler: PartHandler, step: Step) -> None:
     if step > Step.STAGE:


### PR DESCRIPTION
This is a cherry pick of https://github.com/canonical/craft-parts/pull/1617; the only changes were to fix conflicts in the changelog.