### PR TITLE
fix(colcon): add missing build-packages to colcon

### DIFF
--- a/craft_parts/plugins/colcon_plugin.py
+++ b/craft_parts/plugins/colcon_plugin.py
@@ -55,12 +55,14 @@ class ColconPlugin(Plugin):
             "gcc",
             "g++",
             "cmake",
+            "make",
             "colcon",
             "python3-colcon-core",
             "python3-colcon-cmake",
             "python3-colcon-package-selection",
             "python3-colcon-python-setup-py",
             "python3-colcon-parallel-executor",
+            "python3-colcon-recursive-crawl",
         }
 
     @override

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,18 +19,6 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
-.. _release-2.33.1:
-
-2.33.1 (2026-06-17)
--------------------
-
-Bug fixes:
-
-- Always migrate overlay files to Stage and Prime first, even if the part being staged
-  or primed also has contents coming from the install directory.
-
-For a complete list of commits, check out the `2.33.1`_ release on GitHub.
-
 .. _release-2.36.0:
 
 2.36.0 (unreleased)
@@ -43,6 +31,18 @@ Bug fixes:
   *recommended* (not depended on) by ``cmake`` and ``colcon`` respectively, so
   they were absent when packages are installed with ``--no-install-recommends``,
   causing builds to fail.
+
+.. _release-2.33.1:
+
+2.33.1 (2026-06-17)
+-------------------
+
+Bug fixes:
+
+- Always migrate overlay files to Stage and Prime first, even if the part being staged
+  or primed also has contents coming from the install directory.
+
+For a complete list of commits, check out the `2.33.1`_ release on GitHub.
 
 .. _release-2.35.0:
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -31,6 +31,19 @@ Bug fixes:
 
 For a complete list of commits, check out the `2.33.1`_ release on GitHub.
 
+.. _release-2.36.0:
+
+2.36.0 (unreleased)
+-------------------
+
+Bug fixes:
+
+- Fix the ``colcon`` plugin to declare ``make`` and
+  ``python3-colcon-recursive-crawl`` as explicit build packages. Both are only
+  *recommended* (not depended on) by ``cmake`` and ``colcon`` respectively, so
+  they were absent when packages are installed with ``--no-install-recommends``,
+  causing builds to fail.
+
 .. _release-2.35.0:
 
 2.35.0 (2026-06-17)

--- a/tests/unit/plugins/test_colcon_plugin.py
+++ b/tests/unit/plugins/test_colcon_plugin.py
@@ -55,12 +55,14 @@ class TestPluginColconPlugin:
             "gcc",
             "g++",
             "cmake",
+            "make",
             "colcon",
             "python3-colcon-core",
             "python3-colcon-cmake",
             "python3-colcon-package-selection",
             "python3-colcon-python-setup-py",
             "python3-colcon-parallel-executor",
+            "python3-colcon-recursive-crawl",
         }
 
     def test_get_build_environment_default(self, setup_method_fixture, new_dir):


### PR DESCRIPTION
cmake only Recommends make (does not Depend on it), so it is absent when apt installs packages with --no-install-recommends, causing CMake to fail with 'CMAKE_MAKE_PROGRAM is not set' when using the default Unix Makefiles generator.

Similarly, python3-colcon-recursive-crawl is only Recommended by the colcon meta-package, not depended on. It provides the 'recursive' package-discovery extension that the plugin relies on for the `--base-paths` argument to colcon build. Without it colcon rejects its own generated command line.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
