### PR TITLE
fix(plugins/colcon): disable test targets by default

### DIFF
--- a/craft_parts/plugins/colcon_plugin.py
+++ b/craft_parts/plugins/colcon_plugin.py
@@ -133,11 +133,12 @@ class ColconPlugin(Plugin):
         # - Release build type (for performance; no debug symbols in a rock/snap)
         # - BUILD_TESTING=OFF (test targets are not useful and pull in heavy deps)
         # Both can be overridden by passing the corresponding flag in
-        # colcon-cmake-args.
+        # colcon-cmake-args. Detection matches any arg that sets the variable,
+        # including the typed CMake form (e.g. "-DBUILD_TESTING:BOOL=ON").
         cmake_args = list(options.colcon_cmake_args)
-        if not any("-DCMAKE_BUILD_TYPE=" in s for s in cmake_args):
+        if not any(s.lstrip().startswith("-DCMAKE_BUILD_TYPE") for s in cmake_args):
             cmake_args.insert(0, "-DCMAKE_BUILD_TYPE=Release")
-        if not any("-DBUILD_TESTING=" in s for s in cmake_args):
+        if not any(s.lstrip().startswith("-DBUILD_TESTING") for s in cmake_args):
             cmake_args.append("-DBUILD_TESTING=OFF")
         build_command.extend(["--cmake-args", *cmake_args])
 

--- a/craft_parts/plugins/colcon_plugin.py
+++ b/craft_parts/plugins/colcon_plugin.py
@@ -129,17 +129,17 @@ class ColconPlugin(Plugin):
         if options.colcon_packages:
             build_command.extend(["--packages-select", *options.colcon_packages])
 
-        # compile in release only if user did not set the build type in cmake-args
-        if not any("-DCMAKE_BUILD_TYPE=" in s for s in options.colcon_cmake_args):
-            build_command.extend(
-                [
-                    "--cmake-args",
-                    "-DCMAKE_BUILD_TYPE=Release",
-                    *options.colcon_cmake_args,
-                ]
-            )
-        elif len(options.colcon_cmake_args) > 0:
-            build_command.extend(["--cmake-args", *options.colcon_cmake_args])
+        # Inject cmake defaults for options the user has not explicitly set:
+        # - Release build type (for performance; no debug symbols in a rock/snap)
+        # - BUILD_TESTING=OFF (test targets are not useful and pull in heavy deps)
+        # Both can be overridden by passing the corresponding flag in
+        # colcon-cmake-args.
+        cmake_args = list(options.colcon_cmake_args)
+        if not any("-DCMAKE_BUILD_TYPE=" in s for s in cmake_args):
+            cmake_args.insert(0, "-DCMAKE_BUILD_TYPE=Release")
+        if not any("-DBUILD_TESTING=" in s for s in cmake_args):
+            cmake_args.append("-DBUILD_TESTING=OFF")
+        build_command.extend(["--cmake-args", *cmake_args])
 
         # Specify the number of workers
         build_command.extend(

--- a/docs/common/craft-parts/reference/plugins/colcon_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/colcon_plugin.rst
@@ -84,8 +84,8 @@ During the build step the plugin performs the following actions:
    with ``--install-base $CRAFT_PART_INSTALL`` to install the built artifacts
 
 The plugin injects ``-DCMAKE_BUILD_TYPE=Release`` and ``-DBUILD_TESTING=OFF``
-into the CMake arguments by default. Both can be overridden by passing the
-corresponding flag in ``colcon-cmake-args``.
+into the CMake arguments by default. Each argument can be overridden with its own entry
+in the ``colcon-cmake-args`` key.
 
 
 Example

--- a/docs/common/craft-parts/reference/plugins/colcon_plugin.rst
+++ b/docs/common/craft-parts/reference/plugins/colcon_plugin.rst
@@ -83,6 +83,10 @@ During the build step the plugin performs the following actions:
 #. Call ``colcon build`` with any colcon-specific keywords set in the part,
    with ``--install-base $CRAFT_PART_INSTALL`` to install the built artifacts
 
+The plugin injects ``-DCMAKE_BUILD_TYPE=Release`` and ``-DBUILD_TESTING=OFF``
+into the CMake arguments by default. Both can be overridden by passing the
+corresponding flag in ``colcon-cmake-args``.
+
 
 Example
 -------

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,20 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+.. _release-2.36.0:
+
+2.36.0 (unreleased)
+-------------------
+
+New features:
+
+- The ``colcon`` plugin now passes ``-DBUILD_TESTING=OFF`` to CMake by default,
+  disabling test targets that are not useful inside a rock or snap and would
+  otherwise pull in large test-only dependencies. Users can opt back in by
+  passing ``-DBUILD_TESTING=ON`` in ``colcon-cmake-args``.
+
+For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
+
 .. _release-2.33.1:
 
 2.33.1 (2026-06-17)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -31,7 +31,7 @@ New features:
   otherwise pull in large test-only dependencies. Users can opt back in by
   passing ``-DBUILD_TESTING=ON`` in ``colcon-cmake-args``.
 
-For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
+For a complete list of commits, check out the `2.36.0 release on GitHub <https://github.com/canonical/craft-parts/releases/tag/2.36.0>`__.
 
 .. _release-2.33.1:
 

--- a/tests/unit/plugins/test_colcon_plugin.py
+++ b/tests/unit/plugins/test_colcon_plugin.py
@@ -255,3 +255,26 @@ class TestPluginColconPlugin:
 
         assert "-DBUILD_TESTING=ON" in build_command
         assert "-DBUILD_TESTING=OFF" not in build_command
+
+    def test_get_build_commands_typed_cmake_overrides(
+        self, setup_method_fixture, new_dir
+    ):
+        # The typed CMake form (e.g. "-DBUILD_TESTING:BOOL=ON") must also be
+        # detected as a user override so the plugin does not append a
+        # conflicting default.
+        plugin = setup_method_fixture(
+            new_dir,
+            properties={
+                "colcon-cmake-args": [
+                    "-DBUILD_TESTING:BOOL=ON",
+                    "-DCMAKE_BUILD_TYPE:STRING=Debug",
+                ]
+            },
+        )
+
+        build_command = plugin.get_build_commands()[-1]
+
+        assert "-DBUILD_TESTING:BOOL=ON" in build_command
+        assert "-DBUILD_TESTING=OFF" not in build_command
+        assert "-DCMAKE_BUILD_TYPE:STRING=Debug" in build_command
+        assert "-DCMAKE_BUILD_TYPE=Release" not in build_command

--- a/tests/unit/plugins/test_colcon_plugin.py
+++ b/tests/unit/plugins/test_colcon_plugin.py
@@ -144,6 +144,7 @@ class TestPluginColconPlugin:
             f"--merge-install --install-base {plugin._part_info.part_install_dir}"
             f"{optional_properties}"
             f"--cmake-args -DCMAKE_BUILD_TYPE=Release "
+            f"-DBUILD_TESTING=OFF "
             f"--parallel-workers {plugin._part_info.parallel_build_count}",
         ]
 
@@ -189,6 +190,7 @@ class TestPluginColconPlugin:
             f'--build-base "{plugin._part_info.part_build_dir}" '
             f"--merge-install --install-base {plugin._part_info.part_install_dir} "
             f"{cmake_args}"
+            f"-DBUILD_TESTING=OFF "
             f"--parallel-workers {plugin._part_info.parallel_build_count}",
         ]
 
@@ -225,5 +227,31 @@ class TestPluginColconPlugin:
             f'--build-base "{plugin._part_info.part_build_dir}" '
             f"--merge-install --install-base {plugin._part_info.part_install_dir} "
             f'--cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Wall -Wextra" '
+            f"-DBUILD_TESTING=OFF "
             f"--parallel-workers {plugin._part_info.parallel_build_count}",
         ]
+
+    def test_get_build_commands_build_testing_off_by_default(
+        self, setup_method_fixture, new_dir
+    ):
+        # -DBUILD_TESTING=OFF must be injected when the user has not set it.
+        plugin = setup_method_fixture(new_dir)
+
+        build_command = plugin.get_build_commands()[-1]
+
+        assert "-DBUILD_TESTING=OFF" in build_command
+
+    def test_get_build_commands_build_testing_user_override(
+        self, setup_method_fixture, new_dir
+    ):
+        # When the user explicitly sets -DBUILD_TESTING=ON, the plugin must
+        # not append -DBUILD_TESTING=OFF (which would be silently shadowed and
+        # confusing).
+        plugin = setup_method_fixture(
+            new_dir, properties={"colcon-cmake-args": ["-DBUILD_TESTING=ON"]}
+        )
+
+        build_command = plugin.get_build_commands()[-1]
+
+        assert "-DBUILD_TESTING=ON" in build_command
+        assert "-DBUILD_TESTING=OFF" not in build_command


### PR DESCRIPTION
Pass `-DBUILD_TESTING=OFF` to CMake by default. Users can still opt back in by passing `-DBUILD_TESTING=ON` in `colcon-cmake-args`.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
