### PR TITLE
fix: wait when retrying snap store; fail install loudly

### DIFF
--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -43,14 +43,6 @@ _STORE_ASSERTION = [
 # pylint: enable=line-too-long
 
 _CHANNEL_RISKS = ["stable", "candidate", "beta", "edge"]
-
-# How many times to try querying the store through snapd (/v2/find), and how
-# long to wait between attempts. Queries can fail transiently, e.g. on slow
-# infrastructure, or while snapd is restarting shortly after a build instance
-# is created (see https://warthogs.atlassian.net/browse/SNAPDENG-36387).
-_STORE_RETRY_COUNT: int = 5
-_STORE_RETRY_INTERVAL: float = 2.0
-
 logger = logging.getLogger(__name__)
 
 
@@ -128,38 +120,31 @@ class SnapPackage:
     def get_store_snap_info(self) -> dict[str, Any] | None:
         """Return a store payload for the snap."""
         if self._is_in_store is None:
-            # Store queries fail transiently in some environments: slow
-            # infrastructure (like armv7 test runners) times out often, and
-            # snapd itself may be briefly unable to service requests (e.g.
-            # while restarting on a freshly created build instance). Retry
-            # with a delay to ride out these windows.
-            for attempt in range(1, _STORE_RETRY_COUNT + 1):
+            # Some environments timeout often, like the armv7 testing
+            # infrastructure. Given that constraint, we add some retry
+            # logic.
+            retry_count = 5
+            while retry_count > 0:
                 try:
                     self._store_snap_info = _get_store_snap_info(self.name)
                     break
                 except exceptions.HTTPError as http_error:
                     logger.debug(
                         "The http error when checking the store for %s is %d "
-                        "(attempt %d of %d)",
+                        "(retries left %d)",
                         self.name,
                         http_error.response.status_code,
-                        attempt,
-                        _STORE_RETRY_COUNT,
+                        retry_count,
                     )
                     if http_error.response.status_code == HTTPStatus.NOT_FOUND:
                         raise errors.SnapUnavailable(
                             snap_name=self.name, snap_channel=self.channel
                         ) from http_error
-                except exceptions.ConnectionError:
-                    logger.debug(
-                        "Failed to connect to snapd when checking the store "
-                        "for %s (attempt %d of %d)",
-                        self.name,
-                        attempt,
-                        _STORE_RETRY_COUNT,
-                    )
-                if attempt < _STORE_RETRY_COUNT:
-                    time.sleep(_STORE_RETRY_INTERVAL)
+                    retry_count -= 1
+                    # Wait before retrying: snapd may be briefly unable to
+                    # service requests, e.g. while restarting shortly after
+                    # a build instance is created (SNAPDENG-36387).
+                    time.sleep(2)
 
         return self._store_snap_info
 

--- a/craft_parts/packages/snaps.py
+++ b/craft_parts/packages/snaps.py
@@ -21,6 +21,7 @@ import logging
 import pathlib
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 from http import HTTPStatus
 from typing import (
@@ -42,6 +43,14 @@ _STORE_ASSERTION = [
 # pylint: enable=line-too-long
 
 _CHANNEL_RISKS = ["stable", "candidate", "beta", "edge"]
+
+# How many times to try querying the store through snapd (/v2/find), and how
+# long to wait between attempts. Queries can fail transiently, e.g. on slow
+# infrastructure, or while snapd is restarting shortly after a build instance
+# is created (see https://warthogs.atlassian.net/browse/SNAPDENG-36387).
+_STORE_RETRY_COUNT: int = 5
+_STORE_RETRY_INTERVAL: float = 2.0
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,27 +128,38 @@ class SnapPackage:
     def get_store_snap_info(self) -> dict[str, Any] | None:
         """Return a store payload for the snap."""
         if self._is_in_store is None:
-            # Some environments timeout often, like the armv7 testing
-            # infrastructure. Given that constraint, we add some retry
-            # logic.
-            retry_count = 5
-            while retry_count > 0:
+            # Store queries fail transiently in some environments: slow
+            # infrastructure (like armv7 test runners) times out often, and
+            # snapd itself may be briefly unable to service requests (e.g.
+            # while restarting on a freshly created build instance). Retry
+            # with a delay to ride out these windows.
+            for attempt in range(1, _STORE_RETRY_COUNT + 1):
                 try:
                     self._store_snap_info = _get_store_snap_info(self.name)
                     break
                 except exceptions.HTTPError as http_error:
                     logger.debug(
                         "The http error when checking the store for %s is %d "
-                        "(retries left %d)",
+                        "(attempt %d of %d)",
                         self.name,
                         http_error.response.status_code,
-                        retry_count,
+                        attempt,
+                        _STORE_RETRY_COUNT,
                     )
                     if http_error.response.status_code == HTTPStatus.NOT_FOUND:
                         raise errors.SnapUnavailable(
                             snap_name=self.name, snap_channel=self.channel
                         ) from http_error
-                    retry_count -= 1
+                except exceptions.ConnectionError:
+                    logger.debug(
+                        "Failed to connect to snapd when checking the store "
+                        "for %s (attempt %d of %d)",
+                        self.name,
+                        attempt,
+                        _STORE_RETRY_COUNT,
+                    )
+                if attempt < _STORE_RETRY_COUNT:
+                    time.sleep(_STORE_RETRY_INTERVAL)
 
         return self._store_snap_info
 
@@ -299,8 +319,13 @@ def install_snaps(snaps_list: Sequence[str] | set[str]) -> list[str]:
             if snap_pkg_channel != "stable" and snap_pkg_type == "base":
                 snap_pkg = SnapPackage(f"{snap_pkg.name}/latest/{snap_pkg_channel}")
 
-            if not snap_pkg.installed:
-                snap_pkg.install()
+        # Attempt the install even if the store query failed (store_snap_info
+        # is None): 'snap install' does its own store lookup and fails loudly
+        # if the snap is genuinely unavailable. Skipping the install here
+        # would only surface much later, as a confusing "command not found"
+        # error when the part's build environment is validated.
+        if not snap_pkg.installed:
+            snap_pkg.install()
 
         local_snap_info = snap_pkg.get_local_snap_info()
         if local_snap_info:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -39,6 +39,14 @@ Bug fixes:
   *recommended* (not depended on) by ``cmake`` and ``colcon`` respectively, so
   they were absent when packages are installed with ``--no-install-recommends``,
   causing builds to fail.
+- Fix transient build failures when installing build snaps. A failed store
+  query through snapd (for example while snapd is restarting shortly after a
+  build instance is created) caused the snap installation to be silently
+  skipped, so the build only failed later, with a confusing
+  ``'<command>' not found`` error during plugin environment validation (for
+  example the ``uv`` plugin with ``build-snaps: [astral-uv]``). Store queries
+  are now retried with a delay between attempts, and installation is
+  attempted even if the query still fails.
 
 .. _release-2.33.1:
 

--- a/tests/unit/packages/test_snaps.py
+++ b/tests/unit/packages/test_snaps.py
@@ -17,6 +17,7 @@
 from pathlib import Path
 
 import pytest
+import requests
 from craft_parts.packages import errors, snaps
 
 # pylint: disable=missing-class-docstring
@@ -521,6 +522,80 @@ class TestSnapPackageLifecycle:
 
         installed_snaps = snaps.install_snaps(["fake-base-snap"])
         assert installed_snaps == ["fake-base-snap=test-fake-base-snap-revision"]
+
+
+class TestStoreQueryRetries:
+    """Store queries through snapd are retried and never silently skipped."""
+
+    def test_get_store_snap_info_retries_transient_errors(self, mocker):
+        """Transient connection and HTTP errors are retried with a delay."""
+        fake_sleep = mocker.patch("craft_parts.packages.snaps.time.sleep")
+        response = requests.Response()
+        response.status_code = 500
+        store_info = {"channel": "stable", "type": "app"}
+        mocker.patch(
+            "craft_parts.packages.snaps._get_store_snap_info",
+            side_effect=[
+                requests.exceptions.ConnectionError(),
+                requests.exceptions.HTTPError(response=response),
+                store_info,
+            ],
+        )
+        snap_pkg = snaps.SnapPackage("fake-snap")
+        assert snap_pkg.get_store_snap_info() == store_info
+        assert fake_sleep.call_count == 2
+
+    def test_get_store_snap_info_gives_up_after_retries(self, mocker):
+        """After exhausting all attempts the store info is None."""
+        fake_sleep = mocker.patch("craft_parts.packages.snaps.time.sleep")
+        mocker.patch(
+            "craft_parts.packages.snaps._get_store_snap_info",
+            side_effect=requests.exceptions.ConnectionError(),
+        )
+        snap_pkg = snaps.SnapPackage("fake-snap")
+        assert snap_pkg.get_store_snap_info() is None
+        # No sleep after the final attempt.
+        assert fake_sleep.call_count == snaps._STORE_RETRY_COUNT - 1
+
+    def test_install_snaps_installs_when_store_query_fails(
+        self, mocker, fake_snap_command
+    ):
+        """A failed store query must not silently skip installation."""
+        mocker.patch("craft_parts.packages.snaps.time.sleep")
+        mocker.patch(
+            "craft_parts.packages.snaps._get_store_snap_info",
+            side_effect=requests.exceptions.ConnectionError(),
+        )
+        not_found = requests.Response()
+        not_found.status_code = 404
+        # Not installed before the install, installed with revision 1 after.
+        mocker.patch(
+            "craft_parts.packages.snaps._get_local_snap_info",
+            side_effect=[
+                requests.exceptions.HTTPError(response=not_found),
+                {"name": "fake-snap", "revision": "1"},
+            ],
+        )
+        installed_snaps = snaps.install_snaps(["fake-snap"])
+        assert ["snap", "install", "fake-snap"] in fake_snap_command.calls
+        assert installed_snaps == ["fake-snap=1"]
+
+    def test_install_snaps_skips_installed_snap_when_store_query_fails(
+        self, mocker, fake_snap_command
+    ):
+        """An already-installed snap is not reinstalled if the store query fails."""
+        mocker.patch("craft_parts.packages.snaps.time.sleep")
+        mocker.patch(
+            "craft_parts.packages.snaps._get_store_snap_info",
+            side_effect=requests.exceptions.ConnectionError(),
+        )
+        mocker.patch(
+            "craft_parts.packages.snaps._get_local_snap_info",
+            return_value={"name": "fake-snap", "revision": "1"},
+        )
+        installed_snaps = snaps.install_snaps(["fake-snap"])
+        assert fake_snap_command.calls == []
+        assert installed_snaps == ["fake-snap=1"]
 
 
 class TestInstalledSnaps:

--- a/tests/unit/packages/test_snaps.py
+++ b/tests/unit/packages/test_snaps.py
@@ -527,19 +527,19 @@ class TestSnapPackageLifecycle:
 class TestStoreQueryRetries:
     """Store queries through snapd are retried and never silently skipped."""
 
-    def test_get_store_snap_info_retries_transient_errors(self, mocker):
-        """Transient connection and HTTP errors are retried with a delay."""
-        fake_sleep = mocker.patch("craft_parts.packages.snaps.time.sleep")
+    @staticmethod
+    def _transient_error():
         response = requests.Response()
         response.status_code = 500
+        return requests.exceptions.HTTPError(response=response)
+
+    def test_get_store_snap_info_retries_transient_errors(self, mocker):
+        """Transient HTTP errors are retried with a delay."""
+        fake_sleep = mocker.patch("craft_parts.packages.snaps.time.sleep")
         store_info = {"channel": "stable", "type": "app"}
         mocker.patch(
             "craft_parts.packages.snaps._get_store_snap_info",
-            side_effect=[
-                requests.exceptions.ConnectionError(),
-                requests.exceptions.HTTPError(response=response),
-                store_info,
-            ],
+            side_effect=[self._transient_error(), self._transient_error(), store_info],
         )
         snap_pkg = snaps.SnapPackage("fake-snap")
         assert snap_pkg.get_store_snap_info() == store_info
@@ -547,15 +547,13 @@ class TestStoreQueryRetries:
 
     def test_get_store_snap_info_gives_up_after_retries(self, mocker):
         """After exhausting all attempts the store info is None."""
-        fake_sleep = mocker.patch("craft_parts.packages.snaps.time.sleep")
+        mocker.patch("craft_parts.packages.snaps.time.sleep")
         mocker.patch(
             "craft_parts.packages.snaps._get_store_snap_info",
-            side_effect=requests.exceptions.ConnectionError(),
+            side_effect=self._transient_error(),
         )
         snap_pkg = snaps.SnapPackage("fake-snap")
         assert snap_pkg.get_store_snap_info() is None
-        # No sleep after the final attempt.
-        assert fake_sleep.call_count == snaps._STORE_RETRY_COUNT - 1
 
     def test_install_snaps_installs_when_store_query_fails(
         self, mocker, fake_snap_command
@@ -564,7 +562,7 @@ class TestStoreQueryRetries:
         mocker.patch("craft_parts.packages.snaps.time.sleep")
         mocker.patch(
             "craft_parts.packages.snaps._get_store_snap_info",
-            side_effect=requests.exceptions.ConnectionError(),
+            side_effect=self._transient_error(),
         )
         not_found = requests.Response()
         not_found.status_code = 404
@@ -587,7 +585,7 @@ class TestStoreQueryRetries:
         mocker.patch("craft_parts.packages.snaps.time.sleep")
         mocker.patch(
             "craft_parts.packages.snaps._get_store_snap_info",
-            side_effect=requests.exceptions.ConnectionError(),
+            side_effect=self._transient_error(),
         )
         mocker.patch(
             "craft_parts.packages.snaps._get_local_snap_info",


### PR DESCRIPTION
This PR aims to address some unusual `charmcraft pack` failures we've seen in CI, for example [in the charmlibs monorepo](https://github.com/canonical/charmlibs/actions/runs/28564481582/job/84688902250) and [with the Ubuntu charm](https://github.com/canonical/charm-ubuntu/actions/runs/28907087457/job/85756388863). The relevant output is:
```
+ charmcraft pack
Launching managed ubuntu 24.04 instance...
Creating new instance from remote
Creating new base instance from remote
Creating new instance from base instance
Starting instance
Initializing lifecycle
Installing build-packages
Installing build-snaps
Environment validation failed for part 'charm': 'uv' not found and part 'charm' does not depend on a part named 'uv-deps' that would satisfy the dependency.
Failed to run charmcraft in instance
Full execution log: '...'
```

An AI-powered investigation points to the culprit being in `craft-parts`, where `install_snaps()` gates the `snap install` call behind a successful snapd `/v2/find` store query; when that query fails transiently, `get_store_snap_info()` exhausts 5 zero-delay retries and returns `None` instead of raising, so the build-snap is silently never installed and the failure only surfaces later as a missing command.

This PR makes two changes:
1. Don't gate the `snap install` call on the store query, so if the store is unavailable the install will fail loudly rather than surfacing only cryptically at validation time.
2. Try to make querying the store less likely to fail by adding a sleep between the retries, which would otherwise be performed back-to-back.

We don't gate the `snap install` because:
- Original snap support ([`da71b734`, 2021](https://github.com/canonical/craft-parts/commit/da71b73409330c049357fe2bc99f5c65327c5713)) made the install decision independently of the store query, failing loudly with a type error.
- [`8aeb3ea8` — "packages: address issues raised by pyright 1.1.151"](https://github.com/canonical/craft-parts/commit/8aeb3ea8e32edccf04b47bae95eac2bface135c4) wrapped the whole block (including `snap_pkg.install()`) in `if store_snap_info:` to silence a None-indexing warning (the previous loud failure). This changed the behaviour on store query failure to silently skip installation.

A sleep seems like a reasonable approach, because:
- craft-providers restarts snapd during instance setup and guards the following API calls with a retry loop that waits between attempts, commented with: [`base.py`: "snapd claims it's ready but actually isn't (SNAPDENG-36387). The workaround is to retry."](https://github.com/canonical/craft-providers/blob/3.3.0/craft_providers/base.py#L625-L632)
- craft-parts own snapd query retry loop ([`get_store_snap_info`](https://github.com/canonical/craft-parts/blob/5363f3fda4fb004e038eedaf012938814beee041/craft_parts/packages/snaps.py#L119-L144)) fires all 5 attempts back-to-back with no delay.
- A sleep between retries is used elsewhere in craft-parts for CI-transient failures, e.g. the umount retry in [`utils/os_utils.py`](https://github.com/canonical/craft-parts/blob/5363f3fda4fb004e038eedaf012938814beee041/craft_parts/utils/os_utils.py#L259-L286) ("unmount in Github CI fails randomly and needs a retry", `time.sleep(1)` between attempts).

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?