### PR TITLE
fix(poetry): don't install the export plugin from apt

### DIFF
--- a/craft_parts/plugins/poetry_plugin.py
+++ b/craft_parts/plugins/poetry_plugin.py
@@ -105,11 +105,11 @@ class PoetryPlugin(BasePythonPlugin):
         ):
             build_packages |= {"python3-poetry"}
 
-        # In 25.04+, Poetry 2 is included which deprecated the built-in `export` subcommand
-        # and moved it to an optional plugin.
-        os_release = os_utils.OsRelease()
-        if os_release.name() == "Ubuntu" and os_release.version_id() >= "25.04":
-            build_packages |= {"python3-poetry-plugin-export"}
+            # In 25.04+, Poetry 2 is included which deprecated the built-in `export` subcommand
+            # and moved it to an optional plugin.
+            os_release = os_utils.OsRelease()
+            if os_release.name() == "Ubuntu" and os_release.version_id() >= "25.04":
+                build_packages |= {"python3-poetry-plugin-export"}
 
         return build_packages
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -26,7 +26,7 @@ Changelog
 
 Bug fixes:
 
-- (Poetry plugin) Don't install the poetry export plugin if a ``poetry-deps`` part
+- (Poetry plugin) Don't install the Poetry export plugin if a ``poetry-deps`` part
   is provided.
 
 For a complete list of commits, check out the `2.34.1`_ release on GitHub.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,18 @@ Changelog
 
   For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
 
+.. _release-2.34.1:
+
+2.34.1 (2026-07-09)
+-------------------
+
+Bug fixes:
+
+- (Poetry plugin) Don't install the poetry export plugin if a ``poetry-deps`` part
+  is provided.
+
+For a complete list of commits, check out the `2.34.1`_ release on GitHub.
+
 .. _release-2.34.0:
 
 2.34.0 (2026-06-10)
@@ -1722,6 +1734,7 @@ For a complete list of commits, check out the `2.0.0`_ release on GitHub.
 .. _craft-cli issue #172: https://github.com/canonical/craft-cli/issues/172
 .. _Poetry: https://python-poetry.org
 
+.. _2.34.1: https://github.com/canonical/craft-parts/releases/tag/2.34.1
 .. _2.34.0: https://github.com/canonical/craft-parts/releases/tag/2.34.0
 .. _2.33.0: https://github.com/canonical/craft-parts/releases/tag/2.33.0
 .. _2.32.0: https://github.com/canonical/craft-parts/releases/tag/2.32.0

--- a/tests/unit/plugins/test_poetry_plugin.py
+++ b/tests/unit/plugins/test_poetry_plugin.py
@@ -155,7 +155,25 @@ def test_include_export_plugin(
     mocker.patch(
         "craft_parts.utils.os_utils.OsRelease.version_id", return_value=version
     )
+    mocker.patch.object(plugin, "_system_has_poetry", return_value=False)
 
     build_packages = plugin.get_build_packages()
 
     assert ("python3-poetry-plugin-export" in build_packages) == should_install
+
+
+@pytest.mark.parametrize("version", ["22.04", "24.04", "25.10", "26.04", "26.10"])
+def test_poetry_deps_nullifies_build_packages(
+    plugin: PoetryPlugin, mocker: MockFixture, version: str
+):
+    """Ensure that we don't install any build packages if we have a 'poetry-deps' part."""
+    mocker.patch("craft_parts.utils.os_utils.OsRelease.name", return_value="Ubuntu")
+    mocker.patch(
+        "craft_parts.utils.os_utils.OsRelease.version_id", return_value=version
+    )
+
+    plugin._part_info._part_dependencies = ["poetry-deps"]
+
+    build_packages = plugin.get_build_packages()
+
+    assert "python3-poetry-plugin-export" not in build_packages

--- a/tests/unit/plugins/test_poetry_plugin.py
+++ b/tests/unit/plugins/test_poetry_plugin.py
@@ -172,7 +172,7 @@ def test_poetry_deps_nullifies_build_packages(
         "craft_parts.utils.os_utils.OsRelease.version_id", return_value=version
     )
 
-    plugin._part_info._part_dependencies = {"poetry-deps"}
+    mocker.patch.object(plugin._part_info, "_part_dependencies", {"poetry-deps"})
 
     build_packages = plugin.get_build_packages()
 

--- a/tests/unit/plugins/test_poetry_plugin.py
+++ b/tests/unit/plugins/test_poetry_plugin.py
@@ -166,13 +166,13 @@ def test_include_export_plugin(
 def test_poetry_deps_nullifies_build_packages(
     plugin: PoetryPlugin, mocker: MockFixture, version: str
 ):
-    """Ensure that we don't install any build packages if we have a 'poetry-deps' part."""
+    """Ensure Poetry-related build packages aren't installed when a 'poetry-deps' part is present."""
     mocker.patch("craft_parts.utils.os_utils.OsRelease.name", return_value="Ubuntu")
     mocker.patch(
         "craft_parts.utils.os_utils.OsRelease.version_id", return_value=version
     )
 
-    plugin._part_info._part_dependencies = ["poetry-deps"]
+    plugin._part_info._part_dependencies = {"poetry-deps"}
 
     build_packages = plugin.get_build_packages()
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

...when we're not installing poetry from apt.