### PR TITLE
ci: align policy OSV scanner inputs

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -15,4 +15,9 @@ jobs:
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
       packages: python-apt-dev
-      requirements-find-args: "! -path '*/tests/integration/*'"
+      osv-extra-args: "--config=osv-scanner.toml"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,1 @@
+# OSV Scanner configuration


### PR DESCRIPTION
## Summary
- align `.github/workflows/policy.yaml` security scan inputs with starbase PR #573
- add `osv-extra-args: "--config=osv-scanner.toml"`
- add `osv-exclude-paths` for `docs`
- add `uv-export-no-groups` for `docs` and `docs-sphinx-stack`
- remove `requirements-find-args`
- add root `osv-scanner.toml`

## Dependency/lockfile impact
No dependency or lockfile updates were required. This change only adjusts OSV scan workflow inputs and adds scanner configuration.

## Validation
- targeted checks to confirm required workflow keys are present and `requirements-find-args` is absent
- verified `osv-scanner.toml` exists with expected content