### PR TITLE
docs: fix cmake plugin ref in parts explanation

### DIFF
--- a/docs/common/craft-parts/explanation/parts.rst
+++ b/docs/common/craft-parts/explanation/parts.rst
@@ -112,9 +112,8 @@ This key can also be used to replace or extend the build process provided by a p
 
 When a plugin is used, it exposes additional properties that can be used to define
 behaviour that is specific to the type of project that the plugin supports. For example,
-the :py:mod:`CMake plugin <craft_parts.plugins.cmake_plugin>` provides the
-``cmake-parameters`` and ``cmake-generator`` properties that can be used to configure
-how CMake is used in the build process.
+the CMake plugin provides the ``cmake-parameters`` and ``cmake-generator`` properties
+that can be used to configure how CMake is used in the build process.
 
 .. ifconfig:: project in ("Snapcraft",)
 


### PR DESCRIPTION
Addressing feedback from @CAD97.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?
