### PR TITLE
docs: update craft-providers link

### DIFF
--- a/docs/common/craft-parts/reuse/links.txt
+++ b/docs/common/craft-parts/reuse/links.txt
@@ -1,5 +1,5 @@
 .. _`Charmcraft`: https://juju.is/docs/sdk/charmcraft
-.. _`Craft Providers`: https://canonical-craft-providers.readthedocs-hosted.com/en/latest/
+.. _`Craft Providers`: https://documentation.ubuntu.com/craft-providers/latest/
 .. _`Juju`: https://juju.is/docs/sdk
 .. _`SDL`: https://www.libsdl.org/
 .. _`Snapcraft`: https://documentation.ubuntu.com/snapcraft/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,6 +268,10 @@ if "discourse_prefix" not in html_context and "discourse" in html_context:
 
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
+    "craft-providers": (
+        "https://documentation.ubuntu.com/craft-providers/latest",
+        None,
+    ),
     "starter-pack": (
         "https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest",
         None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,10 +268,6 @@ if "discourse_prefix" not in html_context and "discourse" in html_context:
 
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
-    "craft-providers": (
-        "https://documentation.ubuntu.com/craft-providers/latest",
-        None,
-    ),
     "starter-pack": (
         "https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest",
         None,


### PR DESCRIPTION
Adds `craft-providers` to the Sphinx `intersphinx_mapping` and updates the hardcoded Craft Providers link in the shared `docs/common/craft-parts/reuse/links.txt` to point at the current `documentation.ubuntu.com` host, following the same approach used in [canonical/craft-application#1136](https://github.com/canonical/craft-application/pull/1136).