### PR TITLE
docs: group plugins by language

### DIFF
--- a/docs/how-to/document-plugin.rst
+++ b/docs/how-to/document-plugin.rst
@@ -12,6 +12,9 @@ headings and main text.
 
 Replace the instructions with suitable descriptions.
 
+After writing the page, add it to the appropriate language or technology
+group in the :ref:`plugins` reference index.
+
 
 <Name> plugin
 -------------

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -40,6 +40,11 @@ Bug fixes:
   they were absent when packages are installed with ``--no-install-recommends``,
   causing builds to fail.
 
+Documentation:
+
+- Group the plugins in the reference by the language or technology they
+  support.
+
 .. _release-2.34.1:
 
 2.34.1 (2026-07-09)

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -4,40 +4,130 @@ Plugins
 =======
 
 Plugins are used to provide support for specific technologies during the parts
-lifecycle.
+lifecycle. They are grouped here by the language or technology they support.
+
+
+Built-in
+--------
+
+These plugins cover the basic cases -- copying files verbatim, or bypassing
+the build altogether. They are available in every application built on Craft
+Parts.
 
 .. toctree::
    :maxdepth: 1
 
-   /common/craft-parts/reference/plugins/dotnet_v2_plugin.rst
-   /common/craft-parts/reference/plugins/dotnet_plugin.rst
-   /common/craft-parts/reference/plugins/ant_plugin.rst
+   /common/craft-parts/reference/plugins/dump_plugin.rst
+   /common/craft-parts/reference/plugins/nil_plugin.rst
+
+
+Multi-language
+--------------
+
+These plugins drive general-purpose build systems that aren't tied to a
+single language.
+
+.. toctree::
+   :maxdepth: 1
+
    /common/craft-parts/reference/plugins/autotools_plugin.rst
    /common/craft-parts/reference/plugins/bazel_plugin.rst
    /common/craft-parts/reference/plugins/cmake_plugin.rst
    /common/craft-parts/reference/plugins/colcon_plugin.rst
-   /common/craft-parts/reference/plugins/dump_plugin.rst
+   /common/craft-parts/reference/plugins/make_plugin.rst
+   /common/craft-parts/reference/plugins/meson_plugin.rst
+   /common/craft-parts/reference/plugins/qmake_plugin.rst
+   /common/craft-parts/reference/plugins/scons_plugin.rst
+
+
+.NET
+----
+
+These plugins build projects with the .NET SDK.
+
+.. toctree::
+   :maxdepth: 1
+
+   /common/craft-parts/reference/plugins/dotnet_plugin.rst
+   /common/craft-parts/reference/plugins/dotnet_v2_plugin.rst
+
+
+Go
+--
+
+These plugins build Go projects and set up shared Go workspaces.
+
+.. toctree::
+   :maxdepth: 1
+
    /common/craft-parts/reference/plugins/go_plugin.rst
    /common/craft-parts/reference/plugins/go_use_plugin.rst
+
+
+Java
+----
+
+These plugins build Java projects and assemble minimal Java runtimes.
+
+.. toctree::
+   :maxdepth: 1
+
+   /common/craft-parts/reference/plugins/ant_plugin.rst
    /common/craft-parts/reference/plugins/gradle_plugin.rst
    /common/craft-parts/reference/plugins/gradle_use_plugin.rst
    /common/craft-parts/reference/plugins/jlink_plugin.rst
-   /common/craft-parts/reference/plugins/make_plugin.rst
    /common/craft-parts/reference/plugins/maven_plugin.rst
    /common/craft-parts/reference/plugins/maven_use_plugin.rst
-   /common/craft-parts/reference/plugins/meson_plugin.rst
-   /common/craft-parts/reference/plugins/nil_plugin.rst
+
+
+JavaScript
+----------
+
+These plugins build JavaScript projects with npm.
+
+.. toctree::
+   :maxdepth: 1
+
    /common/craft-parts/reference/plugins/npm_plugin.rst
    /common/craft-parts/reference/plugins/npm_use_plugin.rst
+
+
+Python
+------
+
+These plugins build Python projects with pip, Poetry, or uv.
+
+.. toctree::
+   :maxdepth: 1
+
    /common/craft-parts/reference/plugins/poetry_plugin.rst
-   /common/craft-parts/reference/plugins/python_v2_plugin.rst
    /common/craft-parts/reference/plugins/python_plugin.rst
-   /common/craft-parts/reference/plugins/qmake_plugin.rst
-   /common/craft-parts/reference/plugins/cargo_use_plugin.rst
-   /common/craft-parts/reference/plugins/ruby_plugin.rst
-   /common/craft-parts/reference/plugins/rust_plugin.rst
-   /common/craft-parts/reference/plugins/scons_plugin.rst
+   /common/craft-parts/reference/plugins/python_v2_plugin.rst
    /common/craft-parts/reference/plugins/uv_plugin.rst
+
+
+Ruby
+----
+
+This plugin builds Ruby projects.
+
+.. toctree::
+   :maxdepth: 1
+
+   /common/craft-parts/reference/plugins/ruby_plugin.rst
+
+
+Rust
+----
+
+These plugins build Rust projects with Cargo and set up local crate
+registries.
+
+.. toctree::
+   :maxdepth: 1
+
+   /common/craft-parts/reference/plugins/cargo_use_plugin.rst
+   /common/craft-parts/reference/plugins/rust_plugin.rst
 
 
 When documenting a new plugin, follow the guidelines in :ref:`how_to_document_a_plugin`.


### PR DESCRIPTION
Group plugins by the language or technology they support, in both the documentation and the source tree.

**Documentation** (first commit): the plugins reference index is organized into nine groups — Built-in, Multi-language, .NET, Go, Java, JavaScript, Python, Ruby, and Rust — each with a short description, instead of one flat alphabetical list. Page URLs are unchanged.

**Source** (second commit): plugin modules move into per-language subpackages that mirror the documentation groups (for example `craft_parts/plugins/python/python_plugin.py`). Every previous module path remains importable through a compatibility alias module with explicit re-exports, so applications that do `from craft_parts.plugins import python_plugin` (as Snapcraft and Rockcraft do) are unaffected. A new unit test (`tests/unit/plugins/test_module_aliases.py`) checks for that guarantee. The `python_v2` package is already grouped and stays where it is.

This change was developed with the assistance of an AI tool (Claude Fable 5). I have reviewed and tested all of it before making the commits.

Fixes #1571 
