### PR TITLE
fix(npm): escape backslash line continuation in tar command

### DIFF
--- a/craft_parts/plugins/npm_plugin.py
+++ b/craft_parts/plugins/npm_plugin.py
@@ -334,7 +334,7 @@ class NpmPlugin(Plugin):
             cmd += [
                 dedent(
                     f"""\
-                tar -xzf "{self._node_binary_path}" -C "${{CRAFT_PART_INSTALL}}/" \
+                tar -xzf "{self._node_binary_path}" -C "${{CRAFT_PART_INSTALL}}/" \\
                     --no-same-owner --strip-components=1
                 """
                 ),

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -316,8 +316,8 @@ class TestPluginNpmPlugin:
             ),
             (
                 f'tar -xzf "{part_info.part_cache_dir}/node-v20.13.1-linux-x64.tar.gz"'
-                ' -C "${CRAFT_PART_INSTALL}/"                     --no-same-owner '
-                "--strip-components=1\n"
+                ' -C "${CRAFT_PART_INSTALL}/" \\\n'
+                "    --no-same-owner --strip-components=1\n"
             ),
             (
                 'NPM_VERSION="$(npm --version)"\n'


### PR DESCRIPTION
Stacked on #1662.

Addresses review comment: https://github.com/canonical/craft-parts/pull/1662#discussion_r3766208965

The f-string generating the `tar` shell command in `npm_plugin.py` had an unescaped `\` at end-of-line. Since it's not a raw string, Python treated `\<newline>` as a string-continuation escape, silently swallowing the newline and merging the `tar ...` and `--no-same-owner ...` lines with leftover indentation whitespace baked in as literal spaces, instead of emitting a real shell line-continuation.

Escaped it as `\\` so the generated script contains an actual `\` followed by a newline (valid bash line continuation), and updated the corresponding test assertion.

Verified with `ruff check` and `pytest tests/unit/plugins/test_npm_plugin.py` (34 passed).