### PR TITLE
test(gradle): retry gradle plugin integration test on network failures

### DIFF
--- a/tests/integration/plugins/test_gradle.py
+++ b/tests/integration/plugins/test_gradle.py
@@ -39,6 +39,11 @@ def copy_tree(new_dir, copy_dir):
     shutil.copytree(source_location, new_dir, dirs_exist_ok=True)
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun=["PluginBuildError"],
+    reason="Fails when the Gradle wrapper can't download its distribution due to network issues.",
+)
 @pytest.mark.parametrize("use_gradlew", [True, False], indirect=True)
 def test_gradle_plugin(new_dir, partitions, use_gradlew):
     copy_tree(new_dir, "simple")


### PR DESCRIPTION
Fixes flaky gradle integration test failures such as seen in https://github.com/canonical/craft-parts/actions/runs/31634098513/job/94239938405.

## Root cause
`test_gradle_plugin` (when `use_gradlew=True`) runs the Gradle wrapper, which downloads the Gradle distribution zip from `services.gradle.org`. This occasionally fails with a transient `503` HTTP error, causing a `PluginBuildError` and failing the test even though there's no actual bug in craft-parts.

## Fix
Marked `test_gradle_plugin` with `@pytest.mark.flaky(reruns=3, only_rerun=["PluginBuildError"])`, following the same established pattern used for other network-dependent integration tests in this repo (`test_chisel.py`, `test_chisel_lifecycle.py`, `test_process.py`).

Verified: file collects successfully with `pytest --collect-only`, syntax and `ruff check` pass.