### PR TITLE
fix(sources): retry HTTP(S) downloads on transient failures

### DIFF
--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -52,15 +52,17 @@ _DOWNLOAD_RETRY_BACKOFF_SECONDS = 1.0
 # so it does not need to be divided across retry attempts.
 _DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS = 3600
 # Exceptions that indicate a permanent, non-transient failure (e.g. a
-# malformed URL or an invalid/untrusted TLS certificate), and therefore
-# should never be retried.
+# malformed URL or scheme), and therefore should never be retried.
+# Note that requests.exceptions.SSLError is intentionally not included here:
+# it's raised both for permanent certificate-validation failures and for
+# transient TLS handshake/connection issues, so excluding it entirely would
+# also prevent retrying genuinely transient failures.
 _NON_RETRIABLE_REQUEST_EXCEPTIONS = (
     requests.exceptions.InvalidSchema,
     requests.exceptions.InvalidURL,
     requests.exceptions.MissingSchema,
     requests.exceptions.URLRequired,
     requests.exceptions.TooManyRedirects,
-    requests.exceptions.SSLError,
 )
 
 
@@ -325,30 +327,33 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
-        # url_utils.download_request() appends to an existing destination
-        # file rather than overwriting it, so remember its original size (or
-        # that it didn't exist) to restore it if a download attempt fails,
-        # rather than unconditionally deleting a file we may not have
-        # created.
-        original_size = self._file.stat().st_size if self._file.exists() else None
+        # Download to a temporary file instead of self._file directly.
+        # url_utils.download_request() appends to an existing destination, so
+        # writing straight to self._file would either corrupt a pre-existing
+        # file (by appending the response after it) or require deleting a
+        # file we didn't create when an attempt fails. Downloading to a
+        # dedicated temporary path and only moving it into place once fully
+        # downloaded avoids both problems.
+        temp_file = self._file.with_name(self._file.name + ".part")
+        temp_file.unlink(missing_ok=True)
 
-        for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):
-            error = self._try_download()
-            if error is None:
-                break
+        try:
+            for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):
+                error = self._try_download(temp_file)
+                if error is None:
+                    break
 
-            # Discard any content written by the failed attempt so a
-            # subsequent attempt (or a later download() call) doesn't append
-            # to a truncated, corrupt file.
-            if original_size is None:
-                self._file.unlink(missing_ok=True)
-            elif self._file.exists():
-                with self._file.open("r+b") as partial_file:
-                    partial_file.truncate(original_size)
+                # Discard any content written by the failed attempt so the
+                # next attempt starts from a clean state.
+                temp_file.unlink(missing_ok=True)
 
-            if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
-                raise error from error.__cause__
-            self._retry_download(attempt, error=error)
+                if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
+                    raise error from error.__cause__
+                self._retry_download(attempt, error=error)
+
+            temp_file.replace(self._file)
+        finally:
+            temp_file.unlink(missing_ok=True)
 
         # if source_checksum is defined cache the file for future reuse
         if self.source_checksum:
@@ -356,9 +361,10 @@ class FileSourceHandler(SourceHandler):
             file_cache.cache(filename=str(self._file), key=self.source_checksum)
         return self._file
 
-    def _try_download(self) -> errors.SourceError | None:
+    def _try_download(self, destination: Path) -> errors.SourceError | None:
         """Attempt to download the source file once.
 
+        :param destination: the file to download the source into.
         :returns: ``None`` on success, or a retriable error if the download
             failed due to a transient issue. Non-retriable failures (e.g. a
             404 or a non-transient HTTP error) are raised directly.
@@ -371,7 +377,7 @@ class FileSourceHandler(SourceHandler):
                 timeout=_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS,
             ) as request:
                 request.raise_for_status()
-                url_utils.download_request(request, self._file)
+                url_utils.download_request(request, destination)
         except requests.HTTPError as err:
             if err.response.status_code == requests.codes.not_found:
                 raise errors.SourceNotFound(source=self.source) from err

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -21,8 +21,8 @@ import logging
 import os
 import shutil
 import subprocess
-import tempfile
 import time
+import uuid
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar
@@ -66,17 +66,32 @@ _NON_RETRIABLE_REQUEST_EXCEPTIONS = (
     requests.exceptions.URLRequired,
     requests.exceptions.TooManyRedirects,
 )
+# Number of unique names to try when creating a temporary download file
+# before giving up (a collision is exceedingly unlikely given the name is a
+# random UUID, so this is only a safety net).
+_TEMP_FILE_CREATION_ATTEMPTS = 100
 
 
-def _get_umask() -> int:
-    """Get the process' umask without changing it.
+def _create_download_temp_file(destination_dir: Path, prefix: str) -> Path:
+    """Create a uniquely-named temporary file for a download.
 
-    ``os.umask()`` is the only portable way to read the umask, but it also
-    sets it as a side effect, so the previous value must be restored.
+    Unlike :func:`tempfile.mkstemp`, the file is created with the default
+    permissions the kernel would apply to any new file (i.e. respecting the
+    umask), rather than the restrictive, hardcoded ``0600`` mode
+    ``mkstemp`` uses. This is done with a single atomic ``os.open()`` call
+    (as ``mkstemp`` itself does internally) so there's no window where the
+    process' umask is altered and no risk of a race with other threads
+    creating files concurrently.
     """
-    umask = os.umask(0)
-    os.umask(umask)
-    return umask
+    for _ in range(_TEMP_FILE_CREATION_ATTEMPTS):
+        temp_file = destination_dir / f"{prefix}{uuid.uuid4().hex}.part"
+        try:
+            fd = os.open(temp_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
+        except FileExistsError:
+            continue
+        os.close(fd)
+        return temp_file
+    raise FileExistsError("Could not create a unique temporary download file")
 
 
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
@@ -345,22 +360,13 @@ class FileSourceHandler(SourceHandler):
         # destination, so writing straight to self._file would either
         # corrupt a pre-existing file (by appending the response after it)
         # or require deleting a file we didn't create when an attempt fails.
-        # A dedicated temporary path (created with tempfile so it can't
-        # collide with a legitimate sibling file or a concurrent download)
-        # avoids both problems; it's only moved into place once fully
-        # downloaded.
+        # A dedicated temporary path (that can't collide with a legitimate
+        # sibling file or a concurrent download) avoids both problems; it's
+        # only moved into place once fully downloaded.
         self._file.parent.mkdir(parents=True, exist_ok=True)
-        fd, temp_name = tempfile.mkstemp(
-            dir=self._file.parent, prefix=f".{self._file.name}.", suffix=".part"
+        temp_file = _create_download_temp_file(
+            self._file.parent, prefix=f".{self._file.name}."
         )
-        os.close(fd)
-        temp_file = Path(temp_name)
-        # mkstemp() creates the file with mode 0600 regardless of umask, but
-        # a plain file write would respect the umask (typically 0644). Match
-        # that behavior so the final file's permissions aren't unexpectedly
-        # more restrictive than before this change.
-        default_mode = 0o666 & ~_get_umask()
-        temp_file.chmod(default_mode)
 
         try:
             for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -47,6 +47,11 @@ _MAX_DOWNLOAD_ATTEMPTS = 5
 # Base delay (in seconds) for the exponential backoff between download
 # retries (1, 2, 4, 8 seconds, ...).
 _DOWNLOAD_RETRY_BACKOFF_SECONDS = 1.0
+# Per-attempt timeout (in seconds) for a stalled connection/response. This is
+# divided across all attempts so that adding retries doesn't multiply the
+# worst-case time spent waiting on a hung request beyond the original
+# single-attempt budget of one hour.
+_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS = 3600 // _MAX_DOWNLOAD_ATTEMPTS
 
 
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
@@ -339,7 +344,10 @@ class FileSourceHandler(SourceHandler):
         """
         try:
             request = requests.get(
-                self.source, stream=True, allow_redirects=True, timeout=3600
+                self.source,
+                stream=True,
+                allow_redirects=True,
+                timeout=_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS,
             )
             request.raise_for_status()
             url_utils.download_request(request, self._file)

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -314,6 +314,12 @@ class FileSourceHandler(SourceHandler):
             error = self._try_download()
             if error is None:
                 break
+
+            # Discard any partially downloaded content so a subsequent attempt
+            # (or a later download() call) doesn't append to a truncated,
+            # corrupt file.
+            self._file.unlink(missing_ok=True)
+
             if attempt >= _MAX_DOWNLOAD_ATTEMPTS:
                 raise error from error.__cause__
             self._retry_download(attempt, error=error)
@@ -368,15 +374,11 @@ class FileSourceHandler(SourceHandler):
         return None
 
     def _retry_download(self, attempt: int, *, error: errors.SourceError) -> None:
-        """Wait before retrying a failed download, discarding any partial file.
+        """Wait before retrying a failed download.
 
         :param attempt: The number of the attempt that just failed (1-indexed).
         :param error: The exception raised by the failed attempt.
         """
-        # Discard any partially downloaded content so the next attempt starts
-        # from scratch instead of appending to a truncated file.
-        self._file.unlink(missing_ok=True)
-
         delay = _DOWNLOAD_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
         logger.warning(
             "Retrying download of %r after transient error (attempt %d/%d): %s",

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -314,8 +314,8 @@ class FileSourceHandler(SourceHandler):
             error = self._try_download()
             if error is None:
                 break
-            if attempt == _MAX_DOWNLOAD_ATTEMPTS:
-                raise error
+            if attempt >= _MAX_DOWNLOAD_ATTEMPTS:
+                raise error from error.__cause__
             self._retry_download(attempt, error=error)
 
         # if source_checksum is defined cache the file for future reuse
@@ -358,11 +358,16 @@ class FileSourceHandler(SourceHandler):
                 source=self.source,
             )
             network_error.__cause__ = err
+            if isinstance(
+                err, requests.exceptions.InvalidSchema | requests.exceptions.InvalidURL
+            ):
+                raise network_error from err
+
             return network_error
 
         return None
 
-    def _retry_download(self, attempt: int, *, error: Exception) -> None:
+    def _retry_download(self, attempt: int, *, error: errors.SourceError) -> None:
         """Wait before retrying a failed download, discarding any partial file.
 
         :param attempt: The number of the attempt that just failed (1-indexed).
@@ -378,6 +383,6 @@ class FileSourceHandler(SourceHandler):
             self.source,
             attempt,
             _MAX_DOWNLOAD_ATTEMPTS,
-            error,
+            error.brief,
         )
         time.sleep(delay)

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -398,9 +398,10 @@ class FileSourceHandler(SourceHandler):
                 # during the backoff sleep if the file had been removed.
                 # Truncating preserves the inode (and the safety
                 # guarantees from the os.open(O_EXCL) call that created
-                # it) while still discarding its content.
-                with temp_file.open("wb"):
-                    pass
+                # it) while still discarding its content. O_NOFOLLOW
+                # ensures this truncation itself can't be tricked into
+                # following a symlink planted at the temp path either.
+                os.close(os.open(temp_file, os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW))
 
                 if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
                     raise error from error.__cause__

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -20,6 +20,7 @@ import abc
 import logging
 import shutil
 import subprocess
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar
@@ -36,6 +37,16 @@ from .cache import FileCache
 from .checksum import verify_checksum
 
 logger = logging.getLogger(__name__)
+
+# HTTP status codes that typically indicate a transient server-side or
+# proxy issue, and are therefore worth retrying.
+_RETRIABLE_HTTP_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+# Number of times to attempt an HTTP(S) download before giving up, including
+# the initial attempt.
+_MAX_DOWNLOAD_ATTEMPTS = 5
+# Base delay (in seconds) for the exponential backoff between download
+# retries (1, 2, 4, 8 seconds, ...).
+_DOWNLOAD_RETRY_BACKOFF_SECONDS = 1.0
 
 
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
@@ -299,6 +310,27 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
+        for attempt in range(1, _MAX_DOWNLOAD_ATTEMPTS + 1):
+            error = self._try_download()
+            if error is None:
+                break
+            if attempt == _MAX_DOWNLOAD_ATTEMPTS:
+                raise error
+            self._retry_download(attempt, error=error)
+
+        # if source_checksum is defined cache the file for future reuse
+        if self.source_checksum:
+            verify_checksum(self.source_checksum, self._file)
+            file_cache.cache(filename=str(self._file), key=self.source_checksum)
+        return self._file
+
+    def _try_download(self) -> errors.SourceError | None:
+        """Attempt to download the source file once.
+
+        :returns: ``None`` on success, or a retriable error if the download
+            failed due to a transient issue. Non-retriable failures (e.g. a
+            404 or a non-transient HTTP error) are raised directly.
+        """
         try:
             request = requests.get(
                 self.source, stream=True, allow_redirects=True, timeout=3600
@@ -309,20 +341,43 @@ class FileSourceHandler(SourceHandler):
             if err.response.status_code == requests.codes.not_found:
                 raise errors.SourceNotFound(source=self.source) from err
 
-            raise errors.HttpRequestError(
+            http_error = errors.HttpRequestError(
                 status_code=err.response.status_code,
                 reason=err.response.reason,
                 source=self.source,
-            ) from err
+            )
+            http_error.__cause__ = err
+            if err.response.status_code not in _RETRIABLE_HTTP_STATUS_CODES:
+                raise http_error from err
+
+            return http_error
         except requests.RequestException as err:
-            raise errors.NetworkRequestError(
+            network_error = errors.NetworkRequestError(
                 message=f"network request failed (request={err.request!r}, "
                 f"response={err.response!r})",
                 source=self.source,
-            ) from err
+            )
+            network_error.__cause__ = err
+            return network_error
 
-        # if source_checksum is defined cache the file for future reuse
-        if self.source_checksum:
-            verify_checksum(self.source_checksum, self._file)
-            file_cache.cache(filename=str(self._file), key=self.source_checksum)
-        return self._file
+        return None
+
+    def _retry_download(self, attempt: int, *, error: Exception) -> None:
+        """Wait before retrying a failed download, discarding any partial file.
+
+        :param attempt: The number of the attempt that just failed (1-indexed).
+        :param error: The exception raised by the failed attempt.
+        """
+        # Discard any partially downloaded content so the next attempt starts
+        # from scratch instead of appending to a truncated file.
+        self._file.unlink(missing_ok=True)
+
+        delay = _DOWNLOAD_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
+        logger.warning(
+            "Retrying download of %r after transient error (attempt %d/%d): %s",
+            self.source,
+            attempt,
+            _MAX_DOWNLOAD_ATTEMPTS,
+            error,
+        )
+        time.sleep(delay)

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -397,13 +397,18 @@ class FileSourceHandler(SourceHandler):
                     raise error from error.__cause__
                 self._retry_download(attempt, error=error)
 
+            # Verify the checksum against the temp file before replacing
+            # the destination, so a successful-but-wrong-content download
+            # doesn't destroy a pre-existing destination file.
+            if self.source_checksum:
+                verify_checksum(self.source_checksum, temp_file)
+
             temp_file.replace(self._file)
         finally:
             temp_file.unlink(missing_ok=True)
 
         # if source_checksum is defined cache the file for future reuse
         if self.source_checksum:
-            verify_checksum(self.source_checksum, self._file)
             file_cache.cache(filename=str(self._file), key=self.source_checksum)
         return self._file
 

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -390,8 +390,17 @@ class FileSourceHandler(SourceHandler):
                     break
 
                 # Discard any content written by the failed attempt so the
-                # next attempt starts from a clean state.
-                temp_file.unlink(missing_ok=True)
+                # next attempt starts from a clean state. Truncate rather
+                # than unlink: url_utils.download_request() reopens an
+                # existing destination in append mode with a plain
+                # destination.open("ab"), which doesn't use O_EXCL and
+                # would therefore follow a symlink planted at this path
+                # during the backoff sleep if the file had been removed.
+                # Truncating preserves the inode (and the safety
+                # guarantees from the os.open(O_EXCL) call that created
+                # it) while still discarding its content.
+                with temp_file.open("wb"):
+                    pass
 
                 if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
                     raise error from error.__cause__

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -314,7 +314,7 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
-        for attempt in range(1, _MAX_DOWNLOAD_ATTEMPTS + 1):
+        for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):
             error = self._try_download()
             if error is None:
                 break
@@ -324,7 +324,7 @@ class FileSourceHandler(SourceHandler):
             # corrupt file.
             self._file.unlink(missing_ok=True)
 
-            if attempt >= _MAX_DOWNLOAD_ATTEMPTS:
+            if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
                 raise error from error.__cause__
             self._retry_download(attempt, error=error)
 
@@ -383,14 +383,14 @@ class FileSourceHandler(SourceHandler):
     def _retry_download(self, attempt: int, *, error: errors.SourceError) -> None:
         """Wait before retrying a failed download.
 
-        :param attempt: The number of the attempt that just failed (1-indexed).
+        :param attempt: The number of the attempt that just failed (0-indexed).
         :param error: The exception raised by the failed attempt.
         """
-        delay = _DOWNLOAD_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
+        delay = _DOWNLOAD_RETRY_BACKOFF_SECONDS * (2**attempt)
         logger.warning(
             "Retrying download of %r after transient error (attempt %d/%d): %s",
             self.source,
-            attempt,
+            attempt + 1,
             _MAX_DOWNLOAD_ATTEMPTS,
             error.brief,
         )

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -82,14 +82,29 @@ def _create_download_temp_file(destination_dir: Path, prefix: str) -> Path:
     (as ``mkstemp`` itself does internally) so there's no window where the
     process' umask is altered and no risk of a race with other threads
     creating files concurrently.
+
+    :param prefix: prefix for the temporary filename. Truncated if
+        necessary so the full name stays within typical filesystem limits
+        (e.g. ext4's 255-byte ``NAME_MAX``) even for long source filenames.
     """
+    # 32 hex chars (the uuid4 hex digest) + ".part", leaving the rest of
+    # the budget for the caller-supplied prefix.
+    max_prefix_len = 255 - len(".part") - 32
+    prefix = prefix.encode()[:max_prefix_len].decode(errors="ignore")
     for _ in range(_TEMP_FILE_CREATION_ATTEMPTS):
         temp_file = destination_dir / f"{prefix}{uuid.uuid4().hex}.part"
         try:
             fd = os.open(temp_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
         except FileExistsError:
             continue
-        os.close(fd)
+        try:
+            os.close(fd)
+        except BaseException:
+            # If closing the freshly-created file fails (or this code is
+            # interrupted, e.g. by KeyboardInterrupt) don't leave an
+            # orphaned file behind.
+            temp_file.unlink(missing_ok=True)
+            raise
         return temp_file
     raise FileExistsError("Could not create a unique temporary download file")
 

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -68,6 +68,17 @@ _NON_RETRIABLE_REQUEST_EXCEPTIONS = (
 )
 
 
+def _get_umask() -> int:
+    """Get the process' umask without changing it.
+
+    ``os.umask()`` is the only portable way to read the umask, but it also
+    sets it as a side effect, so the previous value must be restored.
+    """
+    umask = os.umask(0)
+    os.umask(umask)
+    return umask
+
+
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
     """Get extra values for this source type's JSON schema.
 
@@ -344,6 +355,12 @@ class FileSourceHandler(SourceHandler):
         )
         os.close(fd)
         temp_file = Path(temp_name)
+        # mkstemp() creates the file with mode 0600 regardless of umask, but
+        # a plain file write would respect the umask (typically 0644). Match
+        # that behavior so the final file's permissions aren't unexpectedly
+        # more restrictive than before this change.
+        default_mode = 0o666 & ~_get_umask()
+        temp_file.chmod(default_mode)
 
         try:
             for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -47,11 +47,10 @@ _MAX_DOWNLOAD_ATTEMPTS = 5
 # Base delay (in seconds) for the exponential backoff between download
 # retries (1, 2, 4, 8 seconds, ...).
 _DOWNLOAD_RETRY_BACKOFF_SECONDS = 1.0
-# Per-attempt timeout (in seconds) for a stalled connection/response. This is
-# divided across all attempts so that adding retries doesn't multiply the
-# worst-case time spent waiting on a hung request beyond the original
-# single-attempt budget of one hour.
-_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS = 3600 // _MAX_DOWNLOAD_ATTEMPTS
+# Inactivity timeout (in seconds) applied to socket operations for each
+# download attempt. This is *not* a wall-clock limit for the whole request,
+# so it does not need to be divided across retry attempts.
+_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS = 3600
 
 
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
@@ -343,14 +342,14 @@ class FileSourceHandler(SourceHandler):
             404 or a non-transient HTTP error) are raised directly.
         """
         try:
-            request = requests.get(
+            with requests.get(
                 self.source,
                 stream=True,
                 allow_redirects=True,
                 timeout=_DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS,
-            )
-            request.raise_for_status()
-            url_utils.download_request(request, self._file)
+            ) as request:
+                request.raise_for_status()
+                url_utils.download_request(request, self._file)
         except requests.HTTPError as err:
             if err.response.status_code == requests.codes.not_found:
                 raise errors.SourceNotFound(source=self.source) from err

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -18,8 +18,10 @@
 
 import abc
 import logging
+import os
 import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -327,15 +329,21 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
-        # Download to a temporary file instead of self._file directly.
-        # url_utils.download_request() appends to an existing destination, so
-        # writing straight to self._file would either corrupt a pre-existing
-        # file (by appending the response after it) or require deleting a
-        # file we didn't create when an attempt fails. Downloading to a
-        # dedicated temporary path and only moving it into place once fully
-        # downloaded avoids both problems.
-        temp_file = self._file.with_name(self._file.name + ".part")
-        temp_file.unlink(missing_ok=True)
+        # Download to a uniquely-named temporary file instead of self._file
+        # directly. url_utils.download_request() appends to an existing
+        # destination, so writing straight to self._file would either
+        # corrupt a pre-existing file (by appending the response after it)
+        # or require deleting a file we didn't create when an attempt fails.
+        # A dedicated temporary path (created with tempfile so it can't
+        # collide with a legitimate sibling file or a concurrent download)
+        # avoids both problems; it's only moved into place once fully
+        # downloaded.
+        self._file.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_name = tempfile.mkstemp(
+            dir=self._file.parent, prefix=f".{self._file.name}.", suffix=".part"
+        )
+        os.close(fd)
+        temp_file = Path(temp_name)
 
         try:
             for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):

--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -51,6 +51,17 @@ _DOWNLOAD_RETRY_BACKOFF_SECONDS = 1.0
 # download attempt. This is *not* a wall-clock limit for the whole request,
 # so it does not need to be divided across retry attempts.
 _DOWNLOAD_ATTEMPT_TIMEOUT_SECONDS = 3600
+# Exceptions that indicate a permanent, non-transient failure (e.g. a
+# malformed URL or an invalid/untrusted TLS certificate), and therefore
+# should never be retried.
+_NON_RETRIABLE_REQUEST_EXCEPTIONS = (
+    requests.exceptions.InvalidSchema,
+    requests.exceptions.InvalidURL,
+    requests.exceptions.MissingSchema,
+    requests.exceptions.URLRequired,
+    requests.exceptions.TooManyRedirects,
+    requests.exceptions.SSLError,
+)
 
 
 def get_json_extra_schema(type_pattern: str) -> dict[str, dict[str, Any]]:
@@ -314,15 +325,26 @@ class FileSourceHandler(SourceHandler):
         if url_utils.get_url_scheme(self.source) == "ftp":
             raise NotImplementedError("ftp download not implemented")
 
+        # url_utils.download_request() appends to an existing destination
+        # file rather than overwriting it, so remember its original size (or
+        # that it didn't exist) to restore it if a download attempt fails,
+        # rather than unconditionally deleting a file we may not have
+        # created.
+        original_size = self._file.stat().st_size if self._file.exists() else None
+
         for attempt in range(_MAX_DOWNLOAD_ATTEMPTS):
             error = self._try_download()
             if error is None:
                 break
 
-            # Discard any partially downloaded content so a subsequent attempt
-            # (or a later download() call) doesn't append to a truncated,
-            # corrupt file.
-            self._file.unlink(missing_ok=True)
+            # Discard any content written by the failed attempt so a
+            # subsequent attempt (or a later download() call) doesn't append
+            # to a truncated, corrupt file.
+            if original_size is None:
+                self._file.unlink(missing_ok=True)
+            elif self._file.exists():
+                with self._file.open("r+b") as partial_file:
+                    partial_file.truncate(original_size)
 
             if attempt >= _MAX_DOWNLOAD_ATTEMPTS - 1:
                 raise error from error.__cause__
@@ -371,9 +393,7 @@ class FileSourceHandler(SourceHandler):
                 source=self.source,
             )
             network_error.__cause__ = err
-            if isinstance(
-                err, requests.exceptions.InvalidSchema | requests.exceptions.InvalidURL
-            ):
+            if isinstance(err, _NON_RETRIABLE_REQUEST_EXCEPTIONS):
                 raise network_error from err
 
             return network_error

--- a/craft_parts/utils/url_utils.py
+++ b/craft_parts/utils/url_utils.py
@@ -17,6 +17,7 @@
 """URL parsing and downloading helpers."""
 
 import logging
+import os
 import urllib.parse
 from pathlib import Path
 
@@ -67,7 +68,14 @@ def download_request(
 
     mode = "ab" if destination.exists() else "wb"
 
-    with destination.open(mode) as destination_file:
+    # Open by file descriptor with O_NOFOLLOW rather than destination.open(),
+    # so that if something replaced the destination path with a symlink
+    # since it was last checked (e.g. during a caller's retry backoff), this
+    # doesn't silently follow it and write to an unintended location.
+    open_flags = os.O_WRONLY | os.O_NOFOLLOW
+    open_flags |= os.O_APPEND if mode == "ab" else os.O_CREAT | os.O_TRUNC
+    fd = os.open(destination, open_flags, 0o666)
+    with os.fdopen(fd, mode) as destination_file:
         for buf in request.iter_content(1024):
             destination_file.write(buf)
             if not os_utils.is_dumb_terminal():

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -375,7 +375,7 @@ class TestFileSourceHandler:
 
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert not downloaded.exists()
-        assert not downloaded.with_name(downloaded.name + ".part").exists()
+        assert list(downloaded.parent.glob("*.part")) == []
 
     def test_pull_url_preserves_preexisting_file_after_max_retries(
         self, new_dir, mocker
@@ -407,7 +407,7 @@ class TestFileSourceHandler:
 
         assert downloaded.exists()
         assert downloaded.read_bytes() == b"preexisting content"
-        assert not downloaded.with_name(downloaded.name + ".part").exists()
+        assert list(downloaded.parent.glob("*.part")) == []
 
     def test_pull_url_overwrites_preexisting_file_on_success(self, new_dir, mocker):
         """A pre-existing destination file is fully replaced on success, not

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -376,6 +376,37 @@ class TestFileSourceHandler:
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert not downloaded.exists()
 
+    def test_pull_url_preserves_preexisting_file_after_max_retries(
+        self, new_dir, mocker
+    ):
+        """A destination file that existed before pull() is not deleted."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        downloaded.write_bytes(b"preexisting content")
+
+        response = mocker.Mock()
+        response.raise_for_status.return_value = None
+        response.headers = {}
+
+        def iter_content(_chunk_size):
+            # Simulate writing a few bytes before the connection drops,
+            # without ever clearing the file we're appending to.
+            yield b"partial"
+            raise requests.exceptions.ChunkedEncodingError("stream interrupted")
+
+        response.iter_content.side_effect = iter_content
+        response.__enter__ = mocker.Mock(return_value=response)
+        response.__exit__ = mocker.Mock(return_value=False)
+        mocker.patch("craft_parts.sources.base.requests.get", return_value=response)
+
+        with pytest.raises(errors.NetworkRequestError):
+            self.source.pull()
+
+        assert downloaded.exists()
+        assert downloaded.read_bytes() == b"preexisting content"
+
     def test_pull_url_retries_network_error(self, new_dir, mocker):
         """A network-level exception (e.g. connection reset) is retried."""
         mocker.patch("time.sleep")
@@ -404,14 +435,25 @@ class TestFileSourceHandler:
         assert downloaded.read_bytes() == b"content"
         assert mock_get.call_count == 2
 
-    def test_pull_url_invalid_schema_not_retried(self, new_dir, mocker):
-        """A non-transient error like an invalid URL scheme fails immediately."""
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            requests.exceptions.InvalidSchema("No connection adapters"),
+            requests.exceptions.InvalidURL("invalid URL"),
+            requests.exceptions.MissingSchema("Invalid URL, no scheme supplied"),
+            requests.exceptions.URLRequired("a valid URL is required"),
+            requests.exceptions.TooManyRedirects("Exceeded 30 redirects"),
+            requests.exceptions.SSLError("certificate verify failed"),
+        ],
+    )
+    def test_pull_url_permanent_error_not_retried(self, new_dir, mocker, exception):
+        """A non-transient error fails immediately without retrying."""
         mock_sleep = mocker.patch("time.sleep")
         self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
 
         mock_get = mocker.patch(
             "craft_parts.sources.base.requests.get",
-            side_effect=requests.exceptions.InvalidSchema("No connection adapters"),
+            side_effect=exception,
         )
 
         with pytest.raises(errors.NetworkRequestError):

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -375,6 +375,7 @@ class TestFileSourceHandler:
 
         downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
         assert not downloaded.exists()
+        assert not downloaded.with_name(downloaded.name + ".part").exists()
 
     def test_pull_url_preserves_preexisting_file_after_max_retries(
         self, new_dir, mocker
@@ -406,6 +407,28 @@ class TestFileSourceHandler:
 
         assert downloaded.exists()
         assert downloaded.read_bytes() == b"preexisting content"
+        assert not downloaded.with_name(downloaded.name + ".part").exists()
+
+    def test_pull_url_overwrites_preexisting_file_on_success(self, new_dir, mocker):
+        """A pre-existing destination file is fully replaced on success, not
+        appended to."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        downloaded.write_bytes(b"stale content")
+
+        ok_response = mocker.Mock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.headers = {}
+        ok_response.iter_content.return_value = [b"fresh content"]
+        ok_response.__enter__ = mocker.Mock(return_value=ok_response)
+        ok_response.__exit__ = mocker.Mock(return_value=False)
+        mocker.patch("craft_parts.sources.base.requests.get", return_value=ok_response)
+
+        self.source.pull()
+
+        assert downloaded.read_bytes() == b"fresh content"
 
     def test_pull_url_retries_network_error(self, new_dir, mocker):
         """A network-level exception (e.g. connection reset) is retried."""
@@ -443,7 +466,6 @@ class TestFileSourceHandler:
             requests.exceptions.MissingSchema("Invalid URL, no scheme supplied"),
             requests.exceptions.URLRequired("a valid URL is required"),
             requests.exceptions.TooManyRedirects("Exceeded 30 redirects"),
-            requests.exceptions.SSLError("certificate verify failed"),
         ],
     )
     def test_pull_url_permanent_error_not_retried(self, new_dir, mocker, exception):
@@ -461,6 +483,35 @@ class TestFileSourceHandler:
 
         assert mock_get.call_count == 1
         mock_sleep.assert_not_called()
+
+    def test_pull_url_retries_ssl_error(self, new_dir, mocker):
+        """SSLError is retried since it can indicate a transient TLS issue,
+        not just a permanent certificate problem."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+
+        ok_response = mocker.Mock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.headers = {}
+        ok_response.iter_content.return_value = [b"content"]
+        ok_response.__enter__ = mocker.Mock(return_value=ok_response)
+        ok_response.__exit__ = mocker.Mock(return_value=False)
+
+        mock_get = mocker.patch(
+            "craft_parts.sources.base.requests.get",
+            side_effect=[
+                requests.exceptions.SSLError("TLS handshake failed"),
+                ok_response,
+            ],
+        )
+
+        self.source.pull()
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        assert downloaded.is_file()
+        assert downloaded.read_bytes() == b"content"
+        assert mock_get.call_count == 2
 
     def test_file_source_abstract_methods(self):
         class FaultyFileSource(FileSourceHandler):

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -328,7 +328,7 @@ class TestFileSourceHandler:
         assert downloaded.is_file()
         assert downloaded.read_text() == "content"
         assert requests_mock.call_count == 3
-        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_args_list == [mocker.call(1.0), mocker.call(2.0)]
 
     def test_pull_url_gives_up_after_max_retries(self, requests_mock, new_dir, mocker):
         """A transient HTTP error is raised after all retries are exhausted."""
@@ -344,7 +344,9 @@ class TestFileSourceHandler:
             self.source.pull()
 
         assert requests_mock.call_count == base._MAX_DOWNLOAD_ATTEMPTS
-        assert mock_sleep.call_count == base._MAX_DOWNLOAD_ATTEMPTS - 1
+        assert mock_sleep.call_args_list == [
+            mocker.call(2.0**i) for i in range(base._MAX_DOWNLOAD_ATTEMPTS - 1)
+        ]
 
     def test_pull_url_removes_partial_file_after_max_retries(self, new_dir, mocker):
         """A partially downloaded file is removed once retries are exhausted."""

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -20,7 +20,7 @@ from typing import Literal
 import pytest
 import requests
 from craft_parts import ProjectDirs
-from craft_parts.sources import cache, errors
+from craft_parts.sources import base, cache, errors
 from craft_parts.sources.base import (
     BaseFileSourceModel,
     BaseSourceModel,
@@ -260,7 +260,8 @@ class TestFileSourceHandler:
         "error_code",
         [requests.codes.unauthorized, requests.codes.internal_server_error],
     )
-    def test_pull_url_http_error(self, requests_mock, new_dir, error_code):
+    def test_pull_url_http_error(self, requests_mock, new_dir, error_code, mocker):
+        mocker.patch("time.sleep")
         self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
         requests_mock.get(self.source.source, status_code=error_code, reason="Error")
 
@@ -272,6 +273,7 @@ class TestFileSourceHandler:
             self.source.pull()
 
     def test_pull_url_streaming_request_error(self, mocker, new_dir):
+        mocker.patch("time.sleep")
         self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
         Path("parts/foo/src").mkdir(parents=True)
 
@@ -292,6 +294,83 @@ class TestFileSourceHandler:
         )
         with pytest.raises(errors.NetworkRequestError, match=expected):
             self.source.pull()
+
+    @pytest.mark.parametrize(
+        "error_code",
+        [
+            requests.codes.too_many_requests,
+            requests.codes.internal_server_error,
+            requests.codes.bad_gateway,
+            requests.codes.service_unavailable,
+            requests.codes.gateway_timeout,
+        ],
+    )
+    def test_pull_url_retries_transient_http_error(
+        self, requests_mock, new_dir, error_code, mocker
+    ):
+        """Transient HTTP errors are retried before eventually succeeding."""
+        mock_sleep = mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+
+        requests_mock.get(
+            self.source.source,
+            [
+                {"status_code": error_code, "reason": "Error"},
+                {"status_code": error_code, "reason": "Error"},
+                {"text": "content", "status_code": requests.codes.ok},
+            ],
+        )
+
+        self.source.pull()
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        assert downloaded.is_file()
+        assert downloaded.read_text() == "content"
+        assert requests_mock.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_pull_url_gives_up_after_max_retries(self, requests_mock, new_dir, mocker):
+        """A transient HTTP error is raised after all retries are exhausted."""
+        mock_sleep = mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        requests_mock.get(
+            self.source.source,
+            status_code=requests.codes.service_unavailable,
+            reason="Service Unavailable",
+        )
+
+        with pytest.raises(errors.HttpRequestError):
+            self.source.pull()
+
+        assert requests_mock.call_count == base._MAX_DOWNLOAD_ATTEMPTS
+        assert mock_sleep.call_count == base._MAX_DOWNLOAD_ATTEMPTS - 1
+
+    def test_pull_url_retries_network_error(self, new_dir, mocker):
+        """A network-level exception (e.g. connection reset) is retried."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+
+        ok_response = mocker.Mock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.headers = {}
+        ok_response.iter_content.return_value = [b"content"]
+
+        mock_get = mocker.patch(
+            "craft_parts.sources.base.requests.get",
+            side_effect=[
+                requests.exceptions.ConnectionError("connection reset"),
+                ok_response,
+            ],
+        )
+
+        self.source.pull()
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        assert downloaded.is_file()
+        assert downloaded.read_bytes() == b"content"
+        assert mock_get.call_count == 2
 
     def test_file_source_abstract_methods(self):
         class FaultyFileSource(FileSourceHandler):

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -283,6 +283,8 @@ class TestFileSourceHandler:
         response.iter_content.side_effect = requests.exceptions.ChunkedEncodingError(
             "stream interrupted"
         )
+        response.__enter__ = mocker.Mock(return_value=response)
+        response.__exit__ = mocker.Mock(return_value=False)
 
         mocker.patch("craft_parts.sources.base.requests.get", return_value=response)
 
@@ -364,6 +366,8 @@ class TestFileSourceHandler:
             raise requests.exceptions.ChunkedEncodingError("stream interrupted")
 
         response.iter_content.side_effect = iter_content
+        response.__enter__ = mocker.Mock(return_value=response)
+        response.__exit__ = mocker.Mock(return_value=False)
         mocker.patch("craft_parts.sources.base.requests.get", return_value=response)
 
         with pytest.raises(errors.NetworkRequestError):
@@ -382,6 +386,8 @@ class TestFileSourceHandler:
         ok_response.raise_for_status.return_value = None
         ok_response.headers = {}
         ok_response.iter_content.return_value = [b"content"]
+        ok_response.__enter__ = mocker.Mock(return_value=ok_response)
+        ok_response.__exit__ = mocker.Mock(return_value=False)
 
         mock_get = mocker.patch(
             "craft_parts.sources.base.requests.get",

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -372,6 +372,22 @@ class TestFileSourceHandler:
         assert downloaded.read_bytes() == b"content"
         assert mock_get.call_count == 2
 
+    def test_pull_url_invalid_schema_not_retried(self, new_dir, mocker):
+        """A non-transient error like an invalid URL scheme fails immediately."""
+        mock_sleep = mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+
+        mock_get = mocker.patch(
+            "craft_parts.sources.base.requests.get",
+            side_effect=requests.exceptions.InvalidSchema("No connection adapters"),
+        )
+
+        with pytest.raises(errors.NetworkRequestError):
+            self.source.pull()
+
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
     def test_file_source_abstract_methods(self):
         class FaultyFileSource(FileSourceHandler):
             """A file source handler that doesn't implement abstract methods."""

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import stat
 from pathlib import Path
 from re import escape
 from typing import Literal
@@ -429,6 +430,30 @@ class TestFileSourceHandler:
         self.source.pull()
 
         assert downloaded.read_bytes() == b"fresh content"
+
+    def test_pull_url_downloaded_file_has_default_permissions(self, new_dir, mocker):
+        """The downloaded file's permissions follow the umask, not the
+        restrictive mode used internally for the temporary download file."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+
+        ok_response = mocker.Mock()
+        ok_response.raise_for_status.return_value = None
+        ok_response.headers = {}
+        ok_response.iter_content.return_value = [b"content"]
+        ok_response.__enter__ = mocker.Mock(return_value=ok_response)
+        ok_response.__exit__ = mocker.Mock(return_value=False)
+        mocker.patch("craft_parts.sources.base.requests.get", return_value=ok_response)
+
+        self.source.pull()
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        reference_file = downloaded.with_name("reference_file")
+        reference_file.touch()
+        assert stat.S_IMODE(downloaded.stat().st_mode) == stat.S_IMODE(
+            reference_file.stat().st_mode
+        )
 
     def test_pull_url_retries_network_error(self, new_dir, mocker):
         """A network-level exception (e.g. connection reset) is retried."""

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -346,6 +346,30 @@ class TestFileSourceHandler:
         assert requests_mock.call_count == base._MAX_DOWNLOAD_ATTEMPTS
         assert mock_sleep.call_count == base._MAX_DOWNLOAD_ATTEMPTS - 1
 
+    def test_pull_url_removes_partial_file_after_max_retries(self, new_dir, mocker):
+        """A partially downloaded file is removed once retries are exhausted."""
+        mocker.patch("time.sleep")
+        self.set_source(cache_dir=new_dir, source="http://test.com/some_file")
+        Path("parts/foo/src").mkdir(parents=True)
+
+        response = mocker.Mock()
+        response.raise_for_status.return_value = None
+        response.headers = {}
+
+        def iter_content(_chunk_size):
+            # Simulate writing a few bytes before the connection drops.
+            yield b"partial"
+            raise requests.exceptions.ChunkedEncodingError("stream interrupted")
+
+        response.iter_content.side_effect = iter_content
+        mocker.patch("craft_parts.sources.base.requests.get", return_value=response)
+
+        with pytest.raises(errors.NetworkRequestError):
+            self.source.pull()
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        assert not downloaded.exists()
+
     def test_pull_url_retries_network_error(self, new_dir, mocker):
         """A network-level exception (e.g. connection reset) is retried."""
         mocker.patch("time.sleep")

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -181,6 +181,28 @@ class TestFileSourceHandler:
         assert raised.value.expected == "12345"
         assert raised.value.obtained == "9a0364b9e99bb480dd25e1f0284c8555"
 
+    def test_pull_url_checksum_error_preserves_preexisting_file(
+        self, requests_mock, new_dir
+    ):
+        self.set_source(
+            cache_dir=new_dir,
+            source="http://test.com/some_file",
+            source_checksum="md5/12345",
+        )
+        Path("parts/foo/src").mkdir(parents=True)
+        requests_mock.get(self.source.source, text="content")
+
+        downloaded = Path(new_dir, "parts", "foo", "src", "some_file")
+        downloaded.write_text("preexisting content")
+
+        with pytest.raises(errors.ChecksumMismatch):
+            self.source.pull()
+
+        # A successful-but-wrong-content download must not clobber a
+        # pre-existing destination file.
+        assert downloaded.read_text() == "preexisting content"
+        assert list(downloaded.parent.glob("*.part")) == []
+
     def test_pull_url(self, requests_mock, new_dir):
         self.source.source = "http://test.com/some_file"
         requests_mock.get(self.source.source, text="content")


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by an AI agent (GitHub Copilot).

## What

Adds retry-with-backoff to `SourceHandler.download()` (used by HTTP(S)-based sources such as `TarSource`) for transient network failures during the pull step.

Previously a single `requests.get()` call was made with no retry logic. Any transient issue (proxy `502`/`503`/`504`, rate limiting `429`, connection reset, network unreachable, etc.) during a pull step would fail the build immediately, even though a retry a moment later would very likely succeed.

## Changes

- `craft_parts/sources/base.py`: `FileSourceHandler.download()` now retries up to 5 times (with exponential backoff: 1s, 2s, 4s, 8s) when:
  - the HTTP response status is one of `429, 500, 502, 503, 504`, or
  - a `requests.RequestException` occurs (connection errors, timeouts, chunked-encoding errors mid-stream, etc.)
  - Non-retriable failures (`404` → `SourceNotFound`, other HTTP errors) still raise immediately, preserving existing behavior.
  - Any partially-downloaded file is discarded before each retry attempt so retries always start from a clean state.
- `tests/unit/sources/test_base.py`: added tests covering retry-then-success for transient HTTP status codes, giving up after exhausting retries, and retrying on a network-level exception. Updated existing tests that trigger a retriable code path to mock `time.sleep` so they stay fast.

## Scope

This addresses only the HTTP(S) case described in #1666. The subprocess-based sources (e.g. `GitSource`) are a separate follow-up per that issue.

Closes (partially) #1666