### PR TITLE
refactor: remove unused parameter list_only

### DIFF
--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -145,10 +145,8 @@ class BaseRepository(abc.ABC):
     ) -> list[str]:
         """Fetch stage packages to stage_packages_path.
 
-        :param application_name: A unique identifier for the application
-            using Craft Parts.
         :param package_names: A list with the names of the packages to fetch.
-        :stage_packages_path: The path stage packages will be fetched to.
+        :param stage_packages_path: The path stage packages will be fetched to.
         :param base: The base this project will run on.
         :param arch: The architecture of the packages to fetch.
 

--- a/craft_parts/packages/base.py
+++ b/craft_parts/packages/base.py
@@ -91,7 +91,6 @@ class BaseRepository(abc.ABC):
         cls,
         package_names: list[str],
         *,
-        list_only: bool = False,
         refresh_package_cache: bool = True,
         include_recommends: bool = False,
     ) -> list[str]:
@@ -109,7 +108,6 @@ class BaseRepository(abc.ABC):
         host failed :class:`BuildPackagesNotInstalled` should be raised.
 
         :param package_names: A list of package names to install.
-        :param list_only: Only list the packages that would be installed.
         :param refresh_package_cache: Refresh the cache before installing.
         :param include_recommends: Whether or not to include recommended packages.
 
@@ -144,7 +142,6 @@ class BaseRepository(abc.ABC):
         stage_packages_path: Path,
         base: str,
         arch: str,
-        list_only: bool = False,
     ) -> list[str]:
         """Fetch stage packages to stage_packages_path.
 
@@ -154,8 +151,6 @@ class BaseRepository(abc.ABC):
         :stage_packages_path: The path stage packages will be fetched to.
         :param base: The base this project will run on.
         :param arch: The architecture of the packages to fetch.
-        :param list_only: Whether to obtain a list of packages to be fetched
-            instead of actually fetching the packages.
 
         :return: The list of all packages to be fetched, including dependencies.
         """
@@ -221,7 +216,6 @@ class DummyRepository(BaseRepository):
         cls,
         package_names: list[str],
         *,
-        list_only: bool = False,
         refresh_package_cache: bool = True,
         include_recommends: bool = False,
     ) -> list[str]:

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -647,9 +647,7 @@ class Ubuntu(BaseRepository):
         if refresh_package_cache and install_required:
             cls.refresh_packages_list()
         if install_required:
-            cls._install_packages(
-                package_names, include_recommends=include_recommends
-            )
+            cls._install_packages(package_names, include_recommends=include_recommends)
         else:
             logger.debug(
                 "Requested build-packages already installed: %s", package_names

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -623,7 +623,6 @@ class Ubuntu(BaseRepository):
         cls,
         package_names: list[str],
         *,
-        list_only: bool = False,
         refresh_package_cache: bool = True,
         include_recommends: bool = False,
     ) -> list[str]:
@@ -645,17 +644,16 @@ class Ubuntu(BaseRepository):
         marked_packages = cls._get_packages_marked_for_installation(package_names)
         marked_package_names = [name for name, _ in sorted(marked_packages)]
 
-        if not list_only:
-            if refresh_package_cache and install_required:
-                cls.refresh_packages_list()
-            if install_required:
-                cls._install_packages(
-                    package_names, include_recommends=include_recommends
-                )
-            else:
-                logger.debug(
-                    "Requested build-packages already installed: %s", package_names
-                )
+        if refresh_package_cache and install_required:
+            cls.refresh_packages_list()
+        if install_required:
+            cls._install_packages(
+                package_names, include_recommends=include_recommends
+            )
+        else:
+            logger.debug(
+                "Requested build-packages already installed: %s", package_names
+            )
 
         # This result is a best effort approach for deps and virtual packages
         # as they are not part of the installation list.
@@ -710,7 +708,6 @@ class Ubuntu(BaseRepository):
         stage_packages_path: pathlib.Path,
         base: str,
         arch: str,
-        list_only: bool = False,
         packages_filters: set[str] | None = None,
     ) -> list[str]:
         """Fetch stage packages to stage_packages_path."""
@@ -729,7 +726,6 @@ class Ubuntu(BaseRepository):
             stage_packages_path=stage_packages_path,
             base=base,
             arch=arch,
-            list_only=list_only,
             packages_filters=packages_filters,
         )
 
@@ -743,7 +739,6 @@ class Ubuntu(BaseRepository):
         stage_packages_path: pathlib.Path,
         base: str,
         arch: str,
-        list_only: bool = False,
         packages_filters: set[str] | None = None,
     ) -> list[str]:
         """Fetch .deb stage packages to stage_packages_path."""
@@ -756,8 +751,7 @@ class Ubuntu(BaseRepository):
         if packages_filters:
             filtered_names.update(packages_filters)
 
-        if not list_only:
-            stage_packages_path.mkdir(exist_ok=True)
+        stage_packages_path.mkdir(exist_ok=True)
 
         stage_cache_dir, deb_cache_dir = get_cache_dirs(cache_dir)
         deb_cache_dir.mkdir(parents=True, exist_ok=True)
@@ -783,18 +777,12 @@ class Ubuntu(BaseRepository):
             apt_cache.mark_packages(set(package_names))
             apt_cache.unmark_packages(filtered_names)
 
-            if list_only:
-                marked_packages = apt_cache.get_packages_marked_for_installation()
-                installed = {
-                    f"{name}={version}" for name, version in sorted(marked_packages)
-                }
-            else:
-                for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
-                    deb_cache_dir
-                ):
-                    logger.info("Extracting stage package: %s", pkg_name)
-                    installed.add(f"{pkg_name}={pkg_version}")
-                    file_utils.link_or_copy(dl_path, stage_packages_path / dl_path.name)
+            for pkg_name, pkg_version, dl_path in apt_cache.fetch_archives(
+                deb_cache_dir
+            ):
+                logger.info("Extracting stage package: %s", pkg_name)
+                installed.add(f"{pkg_name}={pkg_version}")
+                file_utils.link_or_copy(dl_path, stage_packages_path / dl_path.name)
 
         return sorted(installed)
 

--- a/craft_parts/packages/yum.py
+++ b/craft_parts/packages/yum.py
@@ -121,7 +121,6 @@ class YUMRepository(BaseRepository):
         cls,
         package_names: list[str],
         *,
-        list_only: bool = False,
         refresh_package_cache: bool = True,
         include_recommends: bool = False,  # noqa: ARG003
     ) -> list[str]:
@@ -136,13 +135,12 @@ class YUMRepository(BaseRepository):
         if not cls._check_if_all_packages_installed(package_names):
             install_required = True
 
-        if not list_only:
-            if refresh_package_cache and install_required:
-                cls.refresh_packages_list()
-            if install_required:
-                cls._install_packages(package_names)
-            else:
-                logger.debug("Requested packages already installed: %s", package_names)
+        if refresh_package_cache and install_required:
+            cls.refresh_packages_list()
+        if install_required:
+            cls._install_packages(package_names)
+        else:
+            logger.debug("Requested packages already installed: %s", package_names)
 
         return []
 

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -42,7 +42,6 @@ def test_fetch_stage_slices(tmp_path, fake_apt_cache):
         stage_packages_path=stage_dir,
         base="unused",
         arch="unused",
-        list_only=False,
     )
 
     assert fetched_slices == slices


### PR DESCRIPTION
The list_only parameter to package functions is not used and
was removed.

Fixes #1327

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
