### PR TITLE
test: delete integration test temp dirs on success in CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -62,7 +62,7 @@ jobs:
       lowest-python-platform: '["amd64", "focal"]'
       lowest-python-version: "3.10"
       pytest-markers: flaky
-      setup-vars: NO_JAVA=1 NO_PYTHON=1 NO_PLUGIN=1
+      setup-vars: NO_JAVA=1 NO_PYTHON=1
       use-lxd: false
   test-java-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main

--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,21 @@ endif
 endif
 
 # Tools needed for plugin integration tests that aren't java or python
-ifneq ($(NO_PLUGIN),1)
+# Used in flaky tests, so we need to install them regardless.
 ifeq ($(wildcard /usr/share/doc/automake/copyright),)
 APT_PACKAGES += automake
 endif
 ifeq ($(wildcard /usr/share/doc/autopoint/copyright),)
 APT_PACKAGES += autopoint
 endif
+ifeq ($(wildcard /usr/share/doc/gcc/copyright),)
+APT_PACKAGES += gcc
+endif
+ifeq ($(wildcard /usr/share/doc/texinfo/copyright),)
+APT_PACKAGES += texinfo
+endif
+# Not used in flaky tests
+ifneq ($(NO_PLUGIN),1)
 ifeq ($(wildcard /usr/share/doc/cargo/copyright),)
 # Cargo may be installed by other means, like the rustup snap.
 ifeq ($(shell which cargo),)
@@ -216,9 +224,6 @@ ifneq ($(UBUNTU_CODENAME),focal)
 APT_PACKAGES += dotnet-sdk-8.0
 endif
 endif
-ifeq ($(wildcard /usr/share/doc/gcc/copyright),)
-APT_PACKAGES += gcc
-endif
 ifeq ($(wildcard /usr/share/doc/meson/copyright),)
 APT_PACKAGES += meson
 endif
@@ -237,9 +242,6 @@ APT_PACKAGES += gperf
 endif
 ifeq ($(wildcard /usr/share/doc/help2man/copyright),)
 APT_PACKAGES += help2man
-endif
-ifeq ($(wildcard /usr/share/doc/texinfo/copyright),)
-APT_PACKAGES += texinfo
 endif
 # Used by the autotools plugin itself.
 ifeq ($(wildcard /usr/share/doc/libtool/copyright),)

--- a/Makefile
+++ b/Makefile
@@ -170,21 +170,13 @@ endif
 endif
 
 # Tools needed for plugin integration tests that aren't java or python
-# Used in flaky tests, so we need to install them regardless.
+ifneq ($(NO_PLUGIN),1)
 ifeq ($(wildcard /usr/share/doc/automake/copyright),)
 APT_PACKAGES += automake
 endif
 ifeq ($(wildcard /usr/share/doc/autopoint/copyright),)
 APT_PACKAGES += autopoint
 endif
-ifeq ($(wildcard /usr/share/doc/gcc/copyright),)
-APT_PACKAGES += gcc
-endif
-ifeq ($(wildcard /usr/share/doc/texinfo/copyright),)
-APT_PACKAGES += texinfo
-endif
-# Not used in flaky tests
-ifneq ($(NO_PLUGIN),1)
 ifeq ($(wildcard /usr/share/doc/cargo/copyright),)
 # Cargo may be installed by other means, like the rustup snap.
 ifeq ($(shell which cargo),)
@@ -224,6 +216,9 @@ ifneq ($(UBUNTU_CODENAME),focal)
 APT_PACKAGES += dotnet-sdk-8.0
 endif
 endif
+ifeq ($(wildcard /usr/share/doc/gcc/copyright),)
+APT_PACKAGES += gcc
+endif
 ifeq ($(wildcard /usr/share/doc/meson/copyright),)
 APT_PACKAGES += meson
 endif
@@ -242,6 +237,9 @@ APT_PACKAGES += gperf
 endif
 ifeq ($(wildcard /usr/share/doc/help2man/copyright),)
 APT_PACKAGES += help2man
+endif
+ifeq ($(wildcard /usr/share/doc/texinfo/copyright),)
+APT_PACKAGES += texinfo
 endif
 # Used by the autotools plugin itself.
 ifeq ($(wildcard /usr/share/doc/libtool/copyright),)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,8 +32,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
     setattr(item, f"rep_{rep.when}", rep)
 
 
-@pytest.fixture(autouse=True)
-def _cleanup_integration_temp_dir(
+def _cleanup_integration_temp_dir_impl(
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:
     """Clean up temporary directory after successful integration tests in CI."""
@@ -64,3 +63,11 @@ def _cleanup_integration_temp_dir(
 
     for path in dirs_to_delete:
         shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_integration_temp_dir(
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
+    """Clean up temporary directory after successful integration tests in CI."""
+    return _cleanup_integration_temp_dir_impl(request)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,63 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Configuration for integration tests."""
+
+import contextlib
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
+    """Store test result report on item for fixture teardown inspection."""
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_integration_temp_dir(request: pytest.FixtureRequest) -> None:
+    """Clean up temporary directory after successful integration tests in CI."""
+    yield
+
+    if not os.getenv("CI"):
+        return
+
+    rep_call = getattr(request.node, "rep_call", None)
+    if not rep_call or not rep_call.passed:
+        return
+
+    dirs_to_delete = set()
+    for fixture_name in (
+        "new_dir",
+        "new_path",
+        "tmp_path",
+        "tmpdir",
+        "tmp_homedir_path",
+        "new_homedir_path",
+    ):
+        if fixture_name in request.fixturenames:
+            with contextlib.suppress(Exception):
+                val = request.getfixturevalue(fixture_name)
+                path = Path(val).resolve()
+                if path.exists() and path.is_dir():
+                    dirs_to_delete.add(path)
+
+    for path in dirs_to_delete:
+        shutil.rmtree(path, ignore_errors=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,7 @@
 import contextlib
 import os
 import shutil
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -32,7 +33,9 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_integration_temp_dir(request: pytest.FixtureRequest) -> None:
+def _cleanup_integration_temp_dir(
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
     """Clean up temporary directory after successful integration tests in CI."""
     yield
 

--- a/tests/integration/plugins/test_autotools.py
+++ b/tests/integration/plugins/test_autotools.py
@@ -26,6 +26,12 @@ from craft_parts import LifecycleManager, Step
 pytestmark = [pytest.mark.plugin]
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    only_rerun="HttpError",
+    reason="Occasional 502s from Launchpad.",
+    reruns_delay=60,  # Give it a minute before retrying.
+)
 def test_autotools_plugin(new_dir, partitions):
     parts_yaml = textwrap.dedent(
         """

--- a/tests/unit/test_integration_cleanup.py
+++ b/tests/unit/test_integration_cleanup.py
@@ -17,7 +17,7 @@
 import contextlib
 from unittest.mock import MagicMock
 
-from tests.integration.conftest import _cleanup_integration_temp_dir
+from tests.integration.conftest import _cleanup_integration_temp_dir_impl
 
 pytest_plugins = ["pytester"]
 
@@ -36,7 +36,7 @@ def test_integration_cleanup_success_in_ci(monkeypatch, tmp_path):
         target_dir if name == "new_dir" else None
     )
 
-    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    gen = _cleanup_integration_temp_dir_impl(request)
     next(gen)  # Yield
     with contextlib.suppress(StopIteration):
         next(gen)
@@ -58,7 +58,7 @@ def test_integration_cleanup_failure_in_ci(monkeypatch, tmp_path):
         target_dir if name == "new_dir" else None
     )
 
-    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    gen = _cleanup_integration_temp_dir_impl(request)
     next(gen)
     with contextlib.suppress(StopIteration):
         next(gen)
@@ -80,7 +80,7 @@ def test_integration_cleanup_success_not_in_ci(monkeypatch, tmp_path):
         target_dir if name == "new_dir" else None
     )
 
-    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    gen = _cleanup_integration_temp_dir_impl(request)
     next(gen)
     with contextlib.suppress(StopIteration):
         next(gen)

--- a/tests/unit/test_integration_cleanup.py
+++ b/tests/unit/test_integration_cleanup.py
@@ -1,0 +1,116 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+from unittest.mock import MagicMock
+
+from tests.integration.conftest import _cleanup_integration_temp_dir
+
+pytest_plugins = ["pytester"]
+
+
+def test_integration_cleanup_success_in_ci(monkeypatch, tmp_path):
+    monkeypatch.setenv("CI", "true")
+    target_dir = tmp_path / "integration_test_dir"
+    target_dir.mkdir()
+
+    request = MagicMock()
+    rep_call = MagicMock()
+    rep_call.passed = True
+    request.node.rep_call = rep_call
+    request.fixturenames = ["new_dir"]
+    request.getfixturevalue.side_effect = lambda name: (
+        target_dir if name == "new_dir" else None
+    )
+
+    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    next(gen)  # Yield
+    with contextlib.suppress(StopIteration):
+        next(gen)
+
+    assert not target_dir.exists()
+
+
+def test_integration_cleanup_failure_in_ci(monkeypatch, tmp_path):
+    monkeypatch.setenv("CI", "true")
+    target_dir = tmp_path / "integration_test_dir"
+    target_dir.mkdir()
+
+    request = MagicMock()
+    rep_call = MagicMock()
+    rep_call.passed = False
+    request.node.rep_call = rep_call
+    request.fixturenames = ["new_dir"]
+    request.getfixturevalue.side_effect = lambda name: (
+        target_dir if name == "new_dir" else None
+    )
+
+    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    next(gen)
+    with contextlib.suppress(StopIteration):
+        next(gen)
+
+    assert target_dir.exists()
+
+
+def test_integration_cleanup_success_not_in_ci(monkeypatch, tmp_path):
+    monkeypatch.delenv("CI", raising=False)
+    target_dir = tmp_path / "integration_test_dir"
+    target_dir.mkdir()
+
+    request = MagicMock()
+    rep_call = MagicMock()
+    rep_call.passed = True
+    request.node.rep_call = rep_call
+    request.fixturenames = ["new_dir"]
+    request.getfixturevalue.side_effect = lambda name: (
+        target_dir if name == "new_dir" else None
+    )
+
+    gen = _cleanup_integration_temp_dir.__wrapped__(request)
+    next(gen)
+    with contextlib.suppress(StopIteration):
+        next(gen)
+
+    assert target_dir.exists()
+
+
+def test_pytester_integration_cleanup_in_ci(pytester, monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    pytester.plugins.append("tests.integration.conftest")
+    pytester.makepyfile(
+        """
+        def test_dummy_integration(tmp_path):
+            (tmp_path / "file.txt").write_text("hello")
+            assert (tmp_path / "file.txt").exists()
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_pytester_integration_cleanup_on_failure_in_ci(pytester, monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    pytester.plugins.append("tests.integration.conftest")
+    pytester.makepyfile(
+        """
+        def test_dummy_integration_failing(tmp_path):
+            (tmp_path / "file.txt").write_text("hello")
+            assert False
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

We've been running into issues with integration tests (especially Java builds) running us out of disk space. When in CI, this simply deletes those temporary directories on cleanup (only from a successful test) to free up space for other things.

Drive-by: make the autotools integration test more resilient to Launchpad issues.