### PR TITLE
fix: add git source mutual exclusivity to schema

### DIFF
--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -49,9 +49,7 @@ def _get_json_extra_schema(type_pattern: str) -> dict[str, Any]:
     """Get extra values for the git source JSON schema.
 
     Declares that ``source-tag``, ``source-branch`` and ``source-commit`` are
-    mutually exclusive using a JSON Schema ``oneOf`` construct, so the
-    constraint is visible to consumers of the generated schema. The existing
-    source-type inference pattern is preserved.
+    mutually exclusive.
     """
     one_of: list[dict[str, Any]] = [
         {

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -54,7 +54,14 @@ def _get_json_extra_schema(type_pattern: str) -> dict[str, Any]:
     source-type inference pattern is preserved.
     """
     one_of: list[dict[str, Any]] = [
-        {"required": [ref], "not": {"required": [r for r in _SOURCE_REFS if r != ref]}}
+        {
+            "required": [ref],
+            "not": {
+                "anyOf": [
+                    {"required": [other]} for other in _SOURCE_REFS if other != ref
+                ]
+            },
+        }
         for ref in _SOURCE_REFS
     ]
     one_of.append({"not": {"anyOf": [{"required": [ref]} for ref in _SOURCE_REFS]}})

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -41,12 +41,34 @@ logger = logging.getLogger(__name__)
 
 MAX_COMMIT_LENGTH = 40
 
+# Mutually exclusive git source options as declared in the JSON schema.
+_SOURCE_REFS = ("source-tag", "source-branch", "source-commit")
+
+
+def _get_json_extra_schema(type_pattern: str) -> dict[str, Any]:
+    """Get extra values for the git source JSON schema.
+
+    Declares that ``source-tag``, ``source-branch`` and ``source-commit`` are
+    mutually exclusive using a JSON Schema ``oneOf`` construct, so the
+    constraint is visible to consumers of the generated schema. The existing
+    source-type inference pattern is preserved.
+    """
+    one_of: list[dict[str, Any]] = [
+        {"required": [ref], "not": {"required": [r for r in _SOURCE_REFS if r != ref]}}
+        for ref in _SOURCE_REFS
+    ]
+    one_of.append({"not": {"anyOf": [{"required": [ref]} for ref in _SOURCE_REFS]}})
+
+    schema: dict[str, Any] = get_json_extra_schema(type_pattern)
+    schema["oneOf"] = one_of
+    return schema
+
 
 class GitSourceModel(BaseSourceModel, frozen=True):  # type: ignore[misc]
     """Pydantic model for a git-based source."""
 
     pattern = r"(^git(\+.+:|[@:])|\.git$)"
-    model_config = get_model_config(get_json_extra_schema(r"(^git[+@:]|\.git$)"))
+    model_config = get_model_config(_get_json_extra_schema(r"(^git[+@:]|\.git$)"))
     source_type: Literal["git"] = "git"
     source: str
     source_tag: str | None = None

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -55,6 +55,7 @@ Bug fixes:
   causing builds to fail.
 - Set ``DEBIAN_FRONTEND=noninteractive`` in the global execution environment,
   so all steps run non-interactively by default.
+- Add git source mutual exclusivity to JSON schema.
 
 .. _release-2.34.1:
 

--- a/tests/unit/test_pydantic_schema.py
+++ b/tests/unit/test_pydantic_schema.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import jsonschema
 import pydantic
 import pytest
-from craft_parts import pydantic_schema, PartsError
+from craft_parts import pydantic_schema
+from craft_parts.sources import errors as source_errors
 from craft_parts.plugins import plugins
 
 VALID_PLUGIN_DATAS = [
@@ -88,6 +89,9 @@ INVALID_PART_DATAS = [
         {"plugin": "nil", "source-type": "git", "source": ".", "source-checksum": ""},
         id="checksum-on-git-source",
     ),
+]
+
+INCOMPATIBLE_PART_DATAS = [
     pytest.param(
         {
             "plugin": "nil",
@@ -173,5 +177,17 @@ def test_invalid_part_data(validator, part_data):
     # Some invalid schema cases are caught earlier by the Pydantic model
     # validator, which raises IncompatibleSourceOptions rather than
     # ValidationError. Treat either as a rejected part.
-    with pytest.raises((pydantic.ValidationError, PartsError)):
+    with pytest.raises(pydantic.ValidationError):
+        pydantic_schema.Part.model_validate(part_data)
+
+
+@pytest.mark.parametrize("part_data", INCOMPATIBLE_PART_DATAS)
+def test_incompatible_part_data(validator, part_data):
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(part_data)
+
+    # Some invalid schema cases are caught earlier by the Pydantic model
+    # validator, which raises IncompatibleSourceOptions rather than
+    # ValidationError. Treat either as a rejected part.
+    with pytest.raises(source_errors.IncompatibleSourceOptions):
         pydantic_schema.Part.model_validate(part_data)

--- a/tests/unit/test_pydantic_schema.py
+++ b/tests/unit/test_pydantic_schema.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import jsonschema
 import pydantic
 import pytest
-from craft_parts import pydantic_schema
+from craft_parts import pydantic_schema, PartsError
 from craft_parts.plugins import plugins
 
 VALID_PLUGIN_DATAS = [
@@ -88,6 +88,47 @@ INVALID_PART_DATAS = [
         {"plugin": "nil", "source-type": "git", "source": ".", "source-checksum": ""},
         id="checksum-on-git-source",
     ),
+    pytest.param(
+        {
+            "plugin": "nil",
+            "source-type": "git",
+            "source": "https://example.com/repo.git",
+            "source-branch": "main",
+            "source-tag": "v1.0.0",
+        },
+        id="git-branch-and-tag",
+    ),
+    pytest.param(
+        {
+            "plugin": "nil",
+            "source-type": "git",
+            "source": "https://example.com/repo.git",
+            "source-branch": "main",
+            "source-commit": "abcdef1234567890abcdef1234567890abcdef12",
+        },
+        id="git-branch-and-commit",
+    ),
+    pytest.param(
+        {
+            "plugin": "nil",
+            "source-type": "git",
+            "source": "https://example.com/repo.git",
+            "source-tag": "v1.0.0",
+            "source-commit": "abcdef1234567890abcdef1234567890abcdef12",
+        },
+        id="git-tag-and-commit",
+    ),
+    pytest.param(
+        {
+            "plugin": "nil",
+            "source-type": "git",
+            "source": "https://example.com/repo.git",
+            "source-branch": "main",
+            "source-tag": "v1.0.0",
+            "source-commit": "abcdef1234567890abcdef1234567890abcdef12",
+        },
+        id="git-branch-tag-and-commit",
+    ),
 ]
 
 
@@ -129,5 +170,8 @@ def test_invalid_part_data(validator, part_data):
     with pytest.raises(jsonschema.ValidationError):
         validator.validate(part_data)
 
-    with pytest.raises(pydantic.ValidationError):
+    # Some invalid schema cases are caught earlier by the Pydantic model
+    # validator, which raises IncompatibleSourceOptions rather than
+    # ValidationError. Treat either as a rejected part.
+    with pytest.raises((pydantic.ValidationError, PartsError)):
         pydantic_schema.Part.model_validate(part_data)

--- a/tests/unit/test_pydantic_schema.py
+++ b/tests/unit/test_pydantic_schema.py
@@ -21,8 +21,8 @@ import jsonschema
 import pydantic
 import pytest
 from craft_parts import pydantic_schema
-from craft_parts.sources import errors as source_errors
 from craft_parts.plugins import plugins
+from craft_parts.sources import errors as source_errors
 
 VALID_PLUGIN_DATAS = [
     *(


### PR DESCRIPTION
Encode the mutually exclusive properties of `source-tag`, `source-branch`,
and `source-commit` into the Pydantic schema.

Fixes #1332

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
