### PR TITLE
test: add tests for chowns after file migration

### DIFF
--- a/tests/unit/executor/test_migration.py
+++ b/tests/unit/executor/test_migration.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import errno
+import os
 import stat
 from pathlib import Path
 
@@ -389,6 +391,77 @@ class TestFileMigration:
 
         assert new_mode == stat.S_IMODE(Path(stage_dir, "foo").stat().st_mode)
         assert new_mode == stat.S_IMODE(Path(stage_dir, "foo/bar").stat().st_mode)
+
+    def test_migrate_files_preserves_ownership(self, mock_chown, mocker, partitions):
+        install_dir = Path("install")
+        stage_dir = Path("stage")
+
+        Path(install_dir, "foo").mkdir(parents=True)
+        stage_dir.mkdir()
+
+        Path(install_dir, "foo", "bar").write_text("installed")
+
+        # Force the file to be copied so the implicit chown in copy() runs.
+        mocker.patch.object(
+            os, "link", side_effect=OSError(errno.EXDEV, "cross-device link")
+        )
+
+        files, dirs = filesets.migratable_filesets(
+            Fileset(["*"]),
+            install_dir,
+            default_partition="default",
+            partition="default" if partitions else None,
+        )
+        migration.migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir=install_dir,
+            destdir=stage_dir,
+            follow_symlinks=False,
+        )
+
+        for source, destination in [
+            (install_dir / "foo", stage_dir / "foo"),
+            (install_dir / "foo" / "bar", stage_dir / "foo" / "bar"),
+        ]:
+            source_stat = source.stat()
+            call = mock_chown[destination]
+            assert call.owner == source_stat.st_uid
+            assert call.group == source_stat.st_gid
+
+    def test_migrate_files_ownership_permission_error(self, mocker, partitions):
+        install_dir = Path("install")
+        stage_dir = Path("stage")
+
+        Path(install_dir, "foo").mkdir(parents=True)
+        stage_dir.mkdir()
+
+        Path(install_dir, "foo", "bar").write_text("installed")
+
+        # Force a copy path so the implicit chown in copy() is exercised.
+        mocker.patch.object(
+            os, "link", side_effect=OSError(errno.EXDEV, "cross-device link")
+        )
+        mocker.patch.object(os, "chown", side_effect=PermissionError)
+
+        files, dirs = filesets.migratable_filesets(
+            Fileset(["*"]),
+            install_dir,
+            default_partition="default",
+            partition="default" if partitions else None,
+        )
+
+        # Should not raise, ownership errors are logged and ignored.
+        migration.migrate_files(
+            files=files,
+            dirs=dirs,
+            srcdir=install_dir,
+            destdir=stage_dir,
+            follow_symlinks=False,
+        )
+
+        assert (stage_dir / "foo").is_dir()
+        assert (stage_dir / "foo" / "bar").read_text() == "installed"
 
     def test_migration_with_permissions(self, mock_chown):
         source = Path("source")


### PR DESCRIPTION
Add tests validating that file ownership is correct after file migration
operations.

Fixes #1338

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
