### PR TITLE
feat: improve error message for checksum mismatch

### DIFF
--- a/craft_parts/sources/base.py
+++ b/craft_parts/sources/base.py
@@ -141,6 +141,7 @@ class SourceHandler(abc.ABC):
         self.source = str(source)
         self.part_src_dir = part_src_dir
         self._cache_dir = cache_dir
+        self._part_name: str | None = None
         self.source_details: dict[str, str | None] | None = None
         self._dirs = project_dirs
         self._checked = False
@@ -148,6 +149,10 @@ class SourceHandler(abc.ABC):
 
         self.outdated_files: list[str] | None = None
         self.outdated_dirs: list[str] | None = None
+
+    def set_part_name(self, part_name: str) -> None:
+        """Set the part name used for error reporting."""
+        self._part_name = part_name
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401 (this must be dynamic)
         return getattr(self._data, name)
@@ -271,7 +276,12 @@ class FileSourceHandler(SourceHandler):
 
         # Verify before provisioning
         if self.source_checksum:
-            verify_checksum(self.source_checksum, source_file)
+            verify_checksum(
+                self.source_checksum,
+                source_file,
+                part_name=self._part_name,
+                source=self.source,
+            )
 
         self.provision(self.part_src_dir, src=source_file)
 
@@ -323,6 +333,11 @@ class FileSourceHandler(SourceHandler):
 
         # if source_checksum is defined cache the file for future reuse
         if self.source_checksum:
-            verify_checksum(self.source_checksum, self._file)
+            verify_checksum(
+                self.source_checksum,
+                self._file,
+                part_name=self._part_name,
+                source=self.source,
+            )
             file_cache.cache(filename=str(self._file), key=self.source_checksum)
         return self._file

--- a/craft_parts/sources/checksum.py
+++ b/craft_parts/sources/checksum.py
@@ -40,12 +40,20 @@ def split_checksum(source_checksum: str) -> tuple[str, str]:
     return (algorithm, digest)
 
 
-def verify_checksum(source_checksum: str, checkfile: Path) -> tuple[str, str]:
+def verify_checksum(
+    source_checksum: str,
+    checkfile: Path,
+    *,
+    part_name: str | None = None,
+    source: str | None = None,
+) -> tuple[str, str]:
     """Verify that checkfile corresponds to the given source checksum.
 
     :param source_checksum: Source checksum in algorithm/hash format.
     :param checkfile: The file to calculate the sum for with the algorithm
         defined in source_checksum.
+    :param part_name: The name of the part being pulled, used for error reporting.
+    :param source: The source being pulled, used for error reporting.
 
     :return: A tuple consisting of the algorithm and the hash.
 
@@ -57,6 +65,11 @@ def verify_checksum(source_checksum: str, checkfile: Path) -> tuple[str, str]:
 
     calculated_digest = file_utils.calculate_hash(checkfile, algorithm=algorithm)
     if digest != calculated_digest:
-        raise errors.ChecksumMismatch(expected=digest, obtained=calculated_digest)
+        raise errors.ChecksumMismatch(
+            expected=digest,
+            obtained=calculated_digest,
+            part_name=part_name,
+            source=source,
+        )
 
     return (algorithm, digest)

--- a/craft_parts/sources/errors.py
+++ b/craft_parts/sources/errors.py
@@ -109,14 +109,35 @@ class ChecksumMismatch(SourceError):  # noqa: N818
 
     :param expected: The expected checksum.
     :param obtained: The actual checksum.
+    :param part_name: The name of the part being pulled.
+    :param source: The source being pulled.
     """
 
-    def __init__(self, *, expected: str, obtained: str) -> None:
+    def __init__(
+        self,
+        *,
+        expected: str,
+        obtained: str,
+        part_name: str | None = None,
+        source: str | None = None,
+    ) -> None:
         self.expected = expected
         self.obtained = obtained
-        brief = f"Expected digest {expected}, obtained {obtained}."
+        self.part_name = part_name
+        self.source = source
 
-        super().__init__(brief=brief)
+        if part_name:
+            subject = f" for part {part_name!r}"
+        elif source:
+            subject = f" for {source!r}"
+        else:
+            subject = ""
+
+        brief = f"Failed to pull source: checksum mismatch{subject}."
+        details = f"Expected digest {expected}, obtained {obtained}."
+        resolution = "Make sure the source-checksum matches the downloaded source."
+
+        super().__init__(brief=brief, details=details, resolution=resolution)
 
 
 class SourceUpdateUnsupported(SourceError):  # noqa: N818

--- a/craft_parts/sources/sources.py
+++ b/craft_parts/sources/sources.py
@@ -181,6 +181,8 @@ def get_source_handler(
             project_dirs=project_dirs,
             ignore_patterns=ignore_patterns,
         )
+        # Keep the constructor signature stable for custom source handlers.
+        source_handler.set_part_name(part.name)
 
     return source_handler
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -43,6 +43,8 @@ New features:
   ``stage-packages`` key. Defaults to True for backward compatibility, but new apps
   should set this to False and use the ``stage-slices`` key instead.
 
+- Add part name and resolution to error message for source checksum mismatch.
+
 Bug fixes:
 
 - The Overlay and Build steps of parts that organize content to the overlay

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -169,8 +169,11 @@ class TestFileSourceHandler:
 
     def test_pull_file_checksum_error(self, new_dir):
         self.set_source(
-            cache_dir=new_dir, source="src/my_file", source_checksum="md5/12345"
+            cache_dir=new_dir,
+            source="src/my_file",
+            source_checksum="md5/12345",
         )
+        self.source.set_part_name("foo")
         Path("src").mkdir()
         Path("src/my_file").write_text("content")
         Path("parts/foo/src").mkdir(parents=True)
@@ -179,6 +182,10 @@ class TestFileSourceHandler:
             self.source.pull()
         assert raised.value.expected == "12345"
         assert raised.value.obtained == "9a0364b9e99bb480dd25e1f0284c8555"
+        assert (
+            raised.value.brief
+            == "Failed to pull source: checksum mismatch for part 'foo'."
+        )
 
     def test_pull_url(self, requests_mock, new_dir):
         self.source.source = "http://test.com/some_file"

--- a/tests/unit/sources/test_checksum.py
+++ b/tests/unit/sources/test_checksum.py
@@ -75,8 +75,33 @@ def test_verify_checksum_digest_error():
     Path("checkfile").write_text("content")
     expected_digest = "digest"
     actual_digest = "9a0364b9e99bb480dd25e1f0284c8555"
-    with pytest.raises(
-        errors.ChecksumMismatch,
-        match=rf"^Expected digest {expected_digest}, obtained {actual_digest}\.$",
-    ):
+    with pytest.raises(errors.ChecksumMismatch) as raised:
         checksum.verify_checksum("md5/digest", Path("checkfile"))
+    assert raised.value.expected == expected_digest
+    assert raised.value.obtained == actual_digest
+    assert raised.value.brief == "Failed to pull source: checksum mismatch."
+    assert raised.value.details == (
+        f"Expected digest {expected_digest}, obtained {actual_digest}."
+    )
+    assert raised.value.resolution == (
+        "Make sure the source-checksum matches the downloaded source."
+    )
+
+
+@pytest.mark.usefixtures("new_dir")
+def test_verify_checksum_digest_error_with_context():
+    Path("checkfile").write_text("content")
+    expected_digest = "digest"
+    actual_digest = "9a0364b9e99bb480dd25e1f0284c8555"
+    with pytest.raises(errors.ChecksumMismatch) as raised:
+        checksum.verify_checksum(
+            "md5/digest",
+            Path("checkfile"),
+            part_name="foo",
+            source="http://test.com/some_file",
+        )
+    err = raised.value
+    assert err.brief == "Failed to pull source: checksum mismatch for part 'foo'."
+    assert err.details == (
+        f"Expected digest {expected_digest}, obtained {actual_digest}."
+    )

--- a/tests/unit/sources/test_errors.py
+++ b/tests/unit/sources/test_errors.py
@@ -66,9 +66,36 @@ def test_checksum_mismatch():
     err = errors.ChecksumMismatch(expected="1234", obtained="5678")
     assert err.expected == "1234"
     assert err.obtained == "5678"
-    assert err.brief == "Expected digest 1234, obtained 5678."
-    assert err.details is None
-    assert err.resolution is None
+    assert err.part_name is None
+    assert err.source is None
+    assert err.brief == "Failed to pull source: checksum mismatch."
+    assert err.details == "Expected digest 1234, obtained 5678."
+    assert (
+        err.resolution == "Make sure the source-checksum matches the downloaded source."
+    )
+
+
+def test_checksum_mismatch_with_part_name():
+    err = errors.ChecksumMismatch(
+        expected="1234",
+        obtained="5678",
+        part_name="foo",
+        source="http://test.com/some_file",
+    )
+    assert err.part_name == "foo"
+    assert err.source == "http://test.com/some_file"
+    assert err.brief == "Failed to pull source: checksum mismatch for part 'foo'."
+    assert err.details == "Expected digest 1234, obtained 5678."
+
+
+def test_checksum_mismatch_with_source_only():
+    err = errors.ChecksumMismatch(
+        expected="1234", obtained="5678", source="http://test.com/some_file"
+    )
+    assert err.part_name is None
+    assert err.brief == (
+        "Failed to pull source: checksum mismatch for 'http://test.com/some_file'."
+    )
 
 
 def test_source_update_unsupported():


### PR DESCRIPTION
Add a better checksum error message, move actual and expected digest
to details, provide a resolution entry, and show the name of the part
causing the problem. This provides better UX in case of checksum
mismatches and makes it clear where the error originates from.

Fixes #355

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
