### PR TITLE
fix: normalize leading slashes in migration paths

### DIFF
--- a/craft_parts/permissions.py
+++ b/craft_parts/permissions.py
@@ -115,7 +115,10 @@ class Permissions(BaseModel):
         if self.path == "*":
             return True
 
-        return fnmatch(str(path), self.path)
+        # Normalize leading slashes so patterns written relative to the filesystem
+        # root (e.g. "/var/lib/foo") also match migration paths, which are always
+        # relative to the prime directory.
+        return fnmatch(str(path).lstrip("/"), self.path.lstrip("/"))
 
     def apply_permissions(self, target: Path) -> None:
         """Apply the permissions configuration to ``target``.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -56,6 +56,8 @@ Bug fixes:
 - Set ``DEBIAN_FRONTEND=noninteractive`` in the global execution environment,
   so all steps run non-interactively by default.
 - Add git source mutual exclusivity to JSON schema.
+- Normalize leading slashes in migration paths, fixing application of permissions
+  and ownership in files specified with absolute paths.
 
 .. _release-2.34.1:
 

--- a/tests/unit/executor/test_migration.py
+++ b/tests/unit/executor/test_migration.py
@@ -440,6 +440,38 @@ class TestFileMigration:
             assert call.owner == 1111
             assert call.group == 2222
 
+    def test_migration_with_leading_slash_permissions(self, mock_chown):
+        source = Path("source")
+        source.mkdir()
+
+        (source / "var").mkdir()
+        (source / "var/lib").mkdir()
+        (source / "var/lib/zincsearch").mkdir()
+        (source / "var/lib/zincsearch/data.txt").touch()
+
+        target = Path("target")
+        target.mkdir()
+
+        permissions = [
+            Permissions(
+                path="/var/lib/zincsearch", owner=584792, group=584792, mode="755"
+            )
+        ]
+
+        migration.migrate_files(
+            files={Path("var/lib/zincsearch/data.txt")},
+            dirs={Path("var/lib"), Path("var/lib/zincsearch")},
+            srcdir=source,
+            destdir=target,
+            permissions=permissions,
+        )
+
+        assert stat.S_IMODE((target / "var/lib/zincsearch").stat().st_mode) == 0o755
+
+        call = mock_chown[Path("target/var/lib/zincsearch")]
+        assert call.owner == 584792
+        assert call.group == 584792
+
     @pytest.mark.parametrize(
         ("filters", "filemap"),
         [

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -83,6 +83,15 @@ def test_applies_to():
     assert not perm.applies_to("etc/file.bin")
 
 
+def test_applies_to_with_leading_slash():
+    """Patterns with a leading slash still match relative migration paths."""
+    perm = Permissions(path="/var/lib/zincsearch", owner=1111, group=2222, mode="755")
+
+    assert perm.applies_to("var/lib/zincsearch")
+    assert not perm.applies_to("var/lib/other")
+    assert not perm.applies_to("var/lib")
+
+
 def test_filter_permissions():
     p1 = Permissions()
     p2 = Permissions(path="etc/*")


### PR DESCRIPTION
Ensure that path patterns starting with a leading slash are normalized
to match relative migration paths, preventing mismatches between absolute
and relative file paths.

Fixes #507

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
