### PR TITLE
feat: use '@' for separating deb names and versions

### DIFF
--- a/craft_parts/packages/deb_package.py
+++ b/craft_parts/packages/deb_package.py
@@ -18,6 +18,8 @@
 
 from dataclasses import dataclass
 
+from . import errors
+
 
 @dataclass
 class DebPackage:
@@ -31,9 +33,10 @@ class DebPackage:
     def from_unparsed(cls, package: str) -> "DebPackage":
         """Parse package supported in yaml.
 
-        Package Format: <package-name>[:<arch>][=<version>]
+        Package Format: <package-name>[:<arch>][=<version>] or
+            <package-name>[:<arch>]@<version>
 
-        Examples: "foo", "foo:i386", "foo=1.5", "foo:i386=1.5"
+        Examples: "foo", "foo:i386", "foo=1.5", "foo:i386=1.5", "foo@1.5"
 
         :param package: Package to parse.
 
@@ -43,10 +46,19 @@ class DebPackage:
         parsed_arch: str | None = None
         parsed_version: str | None = None
 
-        if "=" in parsed_name:
-            parsed_name, parsed_version = parsed_name.split("=")
+        if "@" in parsed_name:
+            parsed_name, parsed_version = parsed_name.split("@", 1)
+        elif "=" in parsed_name:
+            parsed_name, parsed_version = parsed_name.split("=", 1)
 
         if ":" in parsed_name:
             parsed_name, parsed_arch = parsed_name.split(":")
+
+        # Reject padding around any part, e.g. "foo @ 1.5" or "foo: arch".
+        if any(
+            part is not None and part != part.strip()
+            for part in (parsed_name, parsed_arch, parsed_version)
+        ):
+            raise errors.DebPackageInvalidFormat(package)
 
         return DebPackage(name=parsed_name, arch=parsed_arch, version=parsed_version)

--- a/craft_parts/packages/deb_package.py
+++ b/craft_parts/packages/deb_package.py
@@ -34,7 +34,7 @@ class DebPackage:
         """Parse package supported in yaml.
 
         Package Format: <package-name>[:<arch>][=<version>] or
-            <package-name>[:<arch>]@<version>
+                        <package-name>[:<arch>]@<version>
 
         Examples: "foo", "foo:i386", "foo=1.5", "foo:i386=1.5", "foo@1.5"
 
@@ -46,6 +46,8 @@ class DebPackage:
         parsed_arch: str | None = None
         parsed_version: str | None = None
 
+        if "@" in parsed_name and "=" in parsed_name:
+            raise errors.DebPackageInvalidFormatError(package)
         if "@" in parsed_name:
             parsed_name, parsed_version = parsed_name.split("@", 1)
         elif "=" in parsed_name:
@@ -54,11 +56,16 @@ class DebPackage:
         if ":" in parsed_name:
             parsed_name, parsed_arch = parsed_name.split(":")
 
+        # Reject empty parts, e.g. "foo:arch=" or "foo@"
+        # (omitted values should be None, not empty strings)
+        if "" in (parsed_name, parsed_arch, parsed_version):
+            raise errors.DebPackageInvalidFormatError(package)
+
         # Reject padding around any part, e.g. "foo @ 1.5" or "foo: arch".
         if any(
             part is not None and part != part.strip()
             for part in (parsed_name, parsed_arch, parsed_version)
         ):
-            raise errors.DebPackageInvalidFormat(package)
+            raise errors.DebPackageInvalidFormatError(package)
 
         return DebPackage(name=parsed_name, arch=parsed_arch, version=parsed_version)

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -176,6 +176,23 @@ class UnpackError(PackagesError):
         super().__init__(brief=brief)
 
 
+class DebPackageInvalidFormat(PackagesError):  # noqa: N818
+    """The given package specification is not formatted correctly.
+
+    :param package: The package specification string.
+    """
+
+    def __init__(self, package: str) -> None:
+        self.package = package
+        brief = f"Invalid package specification: {package!r}."
+        resolution = (
+            "Ensure the package name, architecture, and version do not "
+            "contain leading, trailing, or surrounding whitespace."
+        )
+
+        super().__init__(brief=brief, resolution=resolution)
+
+
 class SnapInvalidFormat(PackagesError):  # noqa: N818
     """The given snap specification is not formatted correctly.
 

--- a/craft_parts/packages/errors.py
+++ b/craft_parts/packages/errors.py
@@ -176,7 +176,7 @@ class UnpackError(PackagesError):
         super().__init__(brief=brief)
 
 
-class DebPackageInvalidFormat(PackagesError):  # noqa: N818
+class DebPackageInvalidFormatError(PackagesError):
     """The given package specification is not formatted correctly.
 
     :param package: The package specification string.
@@ -187,7 +187,8 @@ class DebPackageInvalidFormat(PackagesError):  # noqa: N818
         brief = f"Invalid package specification: {package!r}."
         resolution = (
             "Ensure the package name, architecture, and version do not "
-            "contain leading, trailing, or surrounding whitespace."
+            "contain leading, trailing, or surrounding whitespace, and "
+            "that no more than one of '@' or '=' is used."
         )
 
         super().__init__(brief=brief, resolution=resolution)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -27,6 +27,10 @@ New features:
 - Allow ``stage-snaps`` and ``build-snaps`` to use the ``@`` separator between the
   snap name and channel.
 
+- Allow ``stage-packages`` and ``build-packages`` to use the ``@`` separator
+  between a deb package name and its version, in addition to the existing
+  ``=`` separator.
+
 - Add ``overlay-recommended-packages`` key to install overlay packages with their
   recommended dependencies.
 

--- a/tests/unit/packages/test_deb_package.py
+++ b/tests/unit/packages/test_deb_package.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-
 from craft_parts.packages import errors
 from craft_parts.packages.deb_package import DebPackage
 

--- a/tests/unit/packages/test_deb_package.py
+++ b/tests/unit/packages/test_deb_package.py
@@ -72,8 +72,14 @@ def test_parse_version_new_separator():
         "foo = 4.5",
         "foo= 4.5",
         "foo =4.5",
+        "foo@4.5=1.0",
+        "foo=",
+        "foo@",
+        "foo:arch=",
+        "foo:arch =1.5",
+        "foo:arch@ 1.5",
     ],
 )
-def test_parse_rejects_padding(package):
-    with pytest.raises(errors.DebPackageInvalidFormat):
+def test_parse_rejects_invalid_format(package):
+    with pytest.raises(errors.DebPackageInvalidFormatError):
         DebPackage.from_unparsed(package)

--- a/tests/unit/packages/test_deb_package.py
+++ b/tests/unit/packages/test_deb_package.py
@@ -14,6 +14,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
+from craft_parts.packages import errors
 from craft_parts.packages.deb_package import DebPackage
 
 
@@ -47,3 +50,31 @@ def test_parse_version():
     assert DebPackage.from_unparsed("foo=4.5") == DebPackage(
         name="foo", arch=None, version="4.5"
     )
+
+
+def test_parse_arch_and_version_new_separator():
+    assert DebPackage.from_unparsed("foo:arch@4.5") == DebPackage(
+        name="foo", arch="arch", version="4.5"
+    )
+
+
+def test_parse_version_new_separator():
+    assert DebPackage.from_unparsed("foo@4.5") == DebPackage(
+        name="foo", arch=None, version="4.5"
+    )
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        "foo @ 4.5",
+        "foo@ 4.5",
+        "foo @4.5",
+        "foo = 4.5",
+        "foo= 4.5",
+        "foo =4.5",
+    ],
+)
+def test_parse_rejects_padding(package):
+    with pytest.raises(errors.DebPackageInvalidFormat):
+        DebPackage.from_unparsed(package)


### PR DESCRIPTION
Expands #1575 beyond snaps to allow both `=` and `@` as valid separators for deb package name + version identifier in both build-packages and stage-packages.

CRAFT-5229

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
