### PR TITLE
ci: use empty strings to prevent workflow evaluation failures

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -50,7 +50,7 @@ jobs:
   test-flaky:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
+      fast-test-platforms: ""
       slow-test-platforms: >
         [
           "ubuntu-22.04",
@@ -67,7 +67,7 @@ jobs:
   test-java-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
+      fast-test-platforms: ""
       slow-test-platforms: >
         [
           "ubuntu-22.04",
@@ -85,7 +85,7 @@ jobs:
   test-python-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
+      fast-test-platforms: ""
       slow-test-platforms: >
         [
           "ubuntu-24.04",
@@ -101,7 +101,7 @@ jobs:
   test-python-plugins-jammy:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
+      fast-test-platforms: ""
       slow-test-platforms: >
         [
           "ubuntu-22.04",
@@ -115,7 +115,7 @@ jobs:
   test-other-plugins:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
+      fast-test-platforms: ""
       slow-test-platforms: >
         [
           "ubuntu-22.04",


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Prevents us from getting spammed with failures from runs such as https://github.com/canonical/craft-parts/actions/runs/33126725158