### PR TITLE
style: ty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include common.mk
 format: format-ruff format-codespell format-prettier format-pre-commit  ## Run all automatic formatters
 
 .PHONY: lint
-lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine lint-uv-lockfile  ## Run all linters
+lint: lint-ruff lint-codespell lint-ty lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine lint-uv-lockfile  ## Run all linters
 
 .PHONY: pack
 pack: pack-pip  ## Build all packages

--- a/common.mk
+++ b/common.mk
@@ -168,11 +168,11 @@ ifneq ($(CI),)
 endif
 
 .PHONY: lint-ty
-lint-ty: install-ty  ##- Check types with Astral ty (disabled by default)
+lint-ty: install-ty  ##- Check types with Astral ty
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	ty check --python .venv/bin/python $(SOURCES)
+	ty check --python .venv $(SOURCES)
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif
@@ -391,7 +391,7 @@ endif
 install-ty:
 ifneq ($(shell which ty),)
 else ifneq ($(shell which snap),)
-	sudo snap install --classic --edge astral-ty
+	sudo snap install --beta astral-ty
 	sudo snap alias astral-ty.ty ty
 else
 	make install-uv

--- a/craft_parts/callbacks.py
+++ b/craft_parts/callbacks.py
@@ -251,5 +251,5 @@ def _ensure_not_defined(
             if hook_point and hook.hook_point != hook_point:
                 continue
             raise errors.CallbackRegistrationError(
-                f"callback function {func.__name__!r} is already registered."
+                f"callback function {getattr(func, '__name__', '<anonymous>')!r} is already registered."
             )

--- a/craft_parts/filesystem_mounts.py
+++ b/craft_parts/filesystem_mounts.py
@@ -102,7 +102,7 @@ class FilesystemMount(
 ):
     """FilesystemMount defines the order in which devices should be mounted."""
 
-    def __iter__(self) -> Iterator[FilesystemMountItem]:  # type: ignore[override]
+    def __iter__(self) -> Iterator[FilesystemMountItem]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         return iter(self.root)
 
     def __reversed__(self) -> Iterator[FilesystemMountItem]:
@@ -181,7 +181,7 @@ class FilesystemMount(
 class FilesystemMounts(RootModel[SingleEntryDict[Literal["default"], FilesystemMount]]):
     """FilesystemMounts defines list of FilesystemMount."""
 
-    def __iter__(self) -> Iterator[Literal["default"]]:  # type: ignore[override]
+    def __iter__(self) -> Iterator[Literal["default"]]:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         return iter(self.root)
 
     def __getitem__(self, item: Literal["default"]) -> FilesystemMount | None:

--- a/craft_parts/overlays/chroot.py
+++ b/craft_parts/overlays/chroot.py
@@ -115,7 +115,7 @@ def _runner(
         res = target(*args, **kwargs)
     except Exception as exc:  # noqa: BLE001
         # Just send None for data since it won't be accessed anyways
-        conn.send((None, str(exc)))  # type: ignore[arg-type]
+        conn.send((None, str(exc)))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         return
 
     conn.send((res, None))

--- a/craft_parts/overlays/overlay_manager.py
+++ b/craft_parts/overlays/overlay_manager.py
@@ -186,7 +186,7 @@ class OverlayManager:
 
         mount_dir = self._project_info.overlay_mount_dir
         # Ensure we always run refresh_packages_list by resetting the cache
-        packages.Repository.refresh_packages_list.cache_clear()  # type: ignore[attr-defined]
+        packages.Repository.refresh_packages_list.cache_clear()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         chroot.chroot(
             mount_dir,
             _defer_evaluation(packages.Repository.refresh_packages_list),

--- a/craft_parts/plugins/cargo_use_plugin.py
+++ b/craft_parts/plugins/cargo_use_plugin.py
@@ -34,7 +34,7 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     # Python 3.10 compatibility
-    import tomli as tomllib  # type: ignore[import-not-found]
+    import tomli as tomllib  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
 
 CARGO_TOML_TEMPLATE = """\
 [source.craft-parts]

--- a/craft_parts/pydantic_schema.py
+++ b/craft_parts/pydantic_schema.py
@@ -64,16 +64,16 @@ class Part(pydantic.BaseModel):
         """Create the JSON schema for a Part."""
         registered_plugins = plugins.get_registered_plugins()
         plugin_models = [
-            cast(TypeAlias, plugin.properties_class)
+            cast(TypeAlias, plugin.properties_class)  # ty: ignore[invalid-type-form]
             for plugin in registered_plugins.values()
         ]
 
         # This type is not actually used outside of schema generation, so it is acceptable
         # to be dynamically defined at runtime
-        PluginUnion: TypeAlias = reduce(lambda acc, ty: acc | ty, plugin_models)  # type: ignore[reportInvalidTypeForm, valid-type]
+        PluginUnion: TypeAlias = reduce(lambda acc, ty: acc | ty, plugin_models)  # type: ignore[reportInvalidTypeForm, valid-type]  # ty: ignore[invalid-type-form]
 
         plugin_model = Annotated[
-            PluginUnion,
+            PluginUnion,  # ty: ignore[invalid-type-form]
             pydantic.Discriminator("plugin"),
             pydantic.ConfigDict(extra="allow"),
         ]

--- a/craft_parts/sources/git_source.py
+++ b/craft_parts/sources/git_source.py
@@ -489,8 +489,8 @@ class GitSource(SourceHandler):
         components = version.split(".", maxsplit=2)
 
         # Ignore the type, the regex already asserts that it will be a 3-piece tuple
-        # but mypy believes this is `tuple[int, ...]`
-        return tuple(int(component) for component in components)  # type: ignore[return-value]
+        # but type checkers believe this is `tuple[int, ...]`
+        return tuple(int(component) for component in components)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
 
 class ShallowFetchError(Exception):

--- a/craft_parts/utils/process.py
+++ b/craft_parts/utils/process.py
@@ -62,7 +62,7 @@ class _ProcessStream:
 
         # (Mostly) optimize away the process function if the read handle is empty
         if self.read_fd == DEVNULL:
-            self.process = self._process_nothing  # type: ignore[method-assign]
+            self.process = self._process_nothing  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
     @property
     def singular(self) -> bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,13 +349,13 @@ class ChmodCall(NamedTuple):
 
 
 @pytest.fixture
-def mock_chown(mocker) -> dict[str, ChmodCall]:
+def mock_chown(mocker) -> dict[Path, ChmodCall]:
     """Mock os.chown() and keep a record of calls to it.
 
     The returned object is a dict where the keys match the ``path`` parameter of the
     os.chown() call and the values are ``ChmodCall`` tuples containing the other parameters.
     """
-    calls = {}
+    calls: dict[Path, ChmodCall] = {}
 
     def fake_chown(path, uid, gid, **kwargs):
         calls[Path(path)] = ChmodCall(owner=uid, group=gid, kwargs=kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,8 @@ from unittest import mock
 import craft_parts
 import craft_parts.packages
 import pytest
-import xdg  # type: ignore[import]
 from craft_parts.features import Features
+from xdg import BaseDirectory  # type: ignore[import]
 
 from . import fake_servers
 from .fake_snap_command import FakeSnapCommand
@@ -240,13 +240,13 @@ def temp_xdg(tmp_path: Path, mocker):
     mocker.patch(
         "xdg.BaseDirectory.xdg_config_dirs",
         new=[
-            xdg.BaseDirectory.xdg_config_home  # pyright: ignore[reportGeneralTypeIssues]
+            BaseDirectory.xdg_config_home  # pyright: ignore[reportGeneralTypeIssues]
         ],
     )
     mocker.patch(
         "xdg.BaseDirectory.xdg_data_dirs",
         new=[
-            xdg.BaseDirectory.xdg_data_home  # pyright: ignore[reportGeneralTypeIssues]
+            BaseDirectory.xdg_data_home  # pyright: ignore[reportGeneralTypeIssues]
         ],
     )
     mocker.patch.dict(

--- a/tests/integration/lifecycle/test_build_environment.py
+++ b/tests/integration/lifecycle/test_build_environment.py
@@ -16,6 +16,7 @@
 
 import textwrap
 from collections.abc import Generator
+from typing import Any
 
 import craft_parts
 import yaml
@@ -43,7 +44,7 @@ basic_parts_yaml = textwrap.dedent(
 def test_build_environment(new_dir, capfd):
     parts = yaml.safe_load(basic_parts_yaml)
 
-    lf_kwargs = {
+    lf_kwargs: dict[str, Any] = {
         "application_name": "test_demo",
         "cache_dir": new_dir,
         "build_environment": ["FOO=hello"],
@@ -64,7 +65,7 @@ def test_build_environment_generator(new_dir, capfd):
 
     parts = yaml.safe_load(basic_parts_yaml)
 
-    lf_kwargs = {
+    lf_kwargs: dict[str, Any] = {
         "application_name": "test_demo",
         "cache_dir": new_dir,
         "build_environment": test_gen(),

--- a/tests/integration/lifecycle/test_lifecycle_organize_to_overlay.py
+++ b/tests/integration/lifecycle/test_lifecycle_organize_to_overlay.py
@@ -16,6 +16,7 @@
 
 import textwrap
 from pathlib import Path
+from typing import Any
 
 import craft_parts
 import pytest
@@ -55,7 +56,7 @@ def test_basic_lifecycle_actions(new_dir, mocker):
     # no need to untar the file
     mocker.patch("craft_parts.sources.tar_source.TarSource.provision")
 
-    lf_kwargs = {
+    lf_kwargs: dict[str, Any] = {
         "application_name": "test_demo",
         "cache_dir": new_dir,
         "partitions": ["default"],

--- a/tests/integration/plugins/test_poetry/test_poetry/__init__.py
+++ b/tests/integration/plugins/test_poetry/test_poetry/__init__.py
@@ -1,4 +1,4 @@
-import distro  # type: ignore[import-not-found]
+import distro  # type: ignore[import-not-found]  # ty: ignore[unresolved-import]
 
 
 def main() -> int:

--- a/tests/unit/executor/test_replace_attr.py
+++ b/tests/unit/executor/test_replace_attr.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Any
+
 import pytest
 from craft_parts.executor import environment
 
@@ -162,7 +164,7 @@ def test_dict_with_string_replacements(subject, expected):
 
 
 def test_string_replacement_with_complex_data():
-    subject = {
+    subject: dict[str, Any] = {
         "filesets": {
             "files": [
                 "somefile",
@@ -173,7 +175,7 @@ def test_string_replacement_with_complex_data():
         "configflags": ["--with-python", "--with-swig $CRAFT_STAGE/swig"],
     }
 
-    expected = {
+    expected: dict[str, Any] = {
         "filesets": {
             "files": [
                 "somefile",

--- a/tests/unit/executor/test_step_handler.py
+++ b/tests/unit/executor/test_step_handler.py
@@ -309,7 +309,7 @@ class TestStepHandlerBuiltins:
 
     def test_run_builtin_invalid(self, new_dir):
         sh = _step_handler_for_step(
-            999,  # type: ignore[reportGeneralTypeIssues]
+            999,  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
             cache_dir=new_dir,
             part_info=self._part_info,
             part=self._part,

--- a/tests/unit/features/overlay/test_parts.py
+++ b/tests/unit/features/overlay/test_parts.py
@@ -91,7 +91,7 @@ class TestPartSpecs:
 
     def test_unmarshal_not_dict(self):
         with pytest.raises(TypeError) as raised:
-            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues]
+            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
         assert str(raised.value) == "part data is not a dictionary"
 
     def test_unmarshal_both_overlay_key(self):
@@ -442,7 +442,7 @@ class TestPartUnmarshal:
 
     def test_part_spec_not_dict(self):
         with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", False)  # type: ignore[reportGeneralTypeIssues]
+            Part("foo", False)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
         assert raised.value.part_name == "foo"
         assert raised.value.message == "part data is not a dictionary"
 
@@ -568,7 +568,7 @@ class TestPartValidation:
 
     def test_part_validation_data_type(self):
         with pytest.raises(TypeError) as raised:
-            parts.validate_part("invalid data")  # type: ignore[reportGeneralTypeIssues]
+            parts.validate_part("invalid data")  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
         assert str(raised.value) == "value must be a dictionary"
 

--- a/tests/unit/features/overlay/test_parts.py
+++ b/tests/unit/features/overlay/test_parts.py
@@ -89,11 +89,6 @@ class TestPartSpecs:
         new_data = spec.marshal()
         assert new_data == data_copy
 
-    def test_unmarshal_not_dict(self):
-        with pytest.raises(TypeError) as raised:
-            PartSpec.unmarshal(False)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-        assert str(raised.value) == "part data is not a dictionary"
-
     def test_unmarshal_both_overlay_key(self):
         data = {
             "overlay-script": "overlay-script",
@@ -439,12 +434,6 @@ class TestPartUnmarshal:
             "- Extra inputs are not permitted in field 'a'\n"
             "- Extra inputs are not permitted in field 'b'"
         )
-
-    def test_part_spec_not_dict(self):
-        with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", False)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-        assert raised.value.part_name == "foo"
-        assert raised.value.message == "part data is not a dictionary"
 
     def test_part_unmarshal_type_error(self):
         with pytest.raises(errors.PartSpecificationError) as raised:

--- a/tests/unit/features/overlay/test_sequencer.py
+++ b/tests/unit/features/overlay/test_sequencer.py
@@ -91,7 +91,7 @@ def test_sequencer_run_step_invalid(new_dir):
 
     seq = Sequencer(part_list=[p1], project_info=info)
     with pytest.raises(RuntimeError) as raised:
-        seq._run_step(p1, 999)  # type: ignore[reportGeneralTypeIssues]
+        seq._run_step(p1, 999)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
     assert str(raised.value) == "invalid step 999"
 
 

--- a/tests/unit/features/partitions/test_lifecycle_manager.py
+++ b/tests/unit/features/partitions/test_lifecycle_manager.py
@@ -415,7 +415,7 @@ class TestPluginProperties(test_lifecycle_manager.TestPluginProperties):
     """Tests for plugin properties with partitions enabled."""
 
     def _get_manager(self, new_dir, **kwargs):
-        manager_kwargs = {
+        manager_kwargs: dict[str, Any] = {
             "application_name": "test_manager",
             "cache_dir": new_dir,
             "partitions": ["default", "mypart", "yourpart", "our/special-part"],

--- a/tests/unit/packages/test_normalize.py
+++ b/tests/unit/packages/test_normalize.py
@@ -214,14 +214,14 @@ class TestFixShebang:
 
     def test_fix_shebang(self):
         for _, data in self.scenarios:
-            path = data["file_path"]
+            path = Path(data["file_path"])
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(data["content"])
+            path.write_text(str(data["content"]))
 
         normalize(Path("root"), repository=DummyRepository)
 
         for _, data in self.scenarios:
-            with data["file_path"].open() as fd:
+            with Path(data["file_path"]).open() as fd:
                 assert fd.read() == data["expected"]
 
 

--- a/tests/unit/packages/test_snaps.py
+++ b/tests/unit/packages/test_snaps.py
@@ -283,7 +283,7 @@ class TestSnapPackageIsValid:
 
     def test_installed(self):
         snap_pkg = snaps.SnapPackage("fake-snap/strict/stable/branch")
-        snap_pkg.get_local_snap_info = lambda: {"channel": "strict/stable/branch"}
+        snap_pkg.get_local_snap_info = lambda: {"channel": "strict/stable/branch"}  # ty: ignore[invalid-assignment]
         assert snap_pkg.is_valid()
 
     def test_404(self, fake_snapd):

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -99,7 +99,7 @@ def test_abstract_methods(new_dir):
     )
 
     with pytest.raises(TypeError, match=expected):
-        FaultyPlugin(properties=None, part_info=part_info)  # type: ignore[reportGeneralTypeIssues]
+        FaultyPlugin(properties=None, part_info=part_info)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 class FooPythonPlugin(BasePythonPlugin):
@@ -225,7 +225,7 @@ def test_python_get_handle_symlinks_commands(
         template.format(install_dir=new_dir / "parts" / "p1" / "install")
         for template in expected_template
     ]
-    python_plugin._should_remove_symlinks = lambda: should_remove_symlinks  # type: ignore[method-assign]
+    python_plugin._should_remove_symlinks = lambda: should_remove_symlinks  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
 
     assert python_plugin._get_handle_symlinks_commands() == expected
 

--- a/tests/unit/plugins/test_npm_plugin.py
+++ b/tests/unit/plugins/test_npm_plugin.py
@@ -284,7 +284,7 @@ class TestPluginNpmPlugin:
                 "npm-node-version": version,
             }
         )
-        NpmPlugin._fetch_node_release_index = lambda: [
+        NpmPlugin._fetch_node_release_index = lambda: [  # ty: ignore[invalid-assignment]
             {
                 "version": "v99.99.99",
                 "date": "3304-12-31",
@@ -421,4 +421,4 @@ class TestPluginNpmPlugin:
         part = Part("my-part", spec, plugin_properties=properties)
 
         assert part.spec.build_attributes == ["self-contained"]
-        assert part.plugin_properties.build_attributes == ["self-contained"]  # type: ignore[reportAttributeAccessIssue]
+        assert part.plugin_properties.build_attributes == ["self-contained"]  # type: ignore[reportAttributeAccessIssue]  # ty: ignore[unresolved-attribute]

--- a/tests/unit/plugins/test_plugins.py
+++ b/tests/unit/plugins/test_plugins.py
@@ -107,7 +107,7 @@ class TestGetPlugin:
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
-                properties=None,  # type: ignore[reportGeneralTypeIssues]
+                properties=None,  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
             )
 
     def test_get_plugin_unspecified(self, new_dir):
@@ -119,7 +119,7 @@ class TestGetPlugin:
             plugins.get_plugin(
                 part=part,
                 part_info=part_info,
-                properties=None,  # type: ignore[reportGeneralTypeIssues]
+                properties=None,  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
             )
 
 

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from pathlib import Path
 from re import escape
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
 import requests
@@ -112,7 +112,7 @@ class TestFileSourceHandler:
 
     def set_source(self, cache_dir, **kwargs) -> None:
         """Set the source."""
-        source_kwargs = {
+        source_kwargs: dict[str, Any] = {
             "source": "source",
             "part_src_dir": Path("parts/foo/src"),
             "project_dirs": self._dirs,

--- a/tests/unit/sources/test_base.py
+++ b/tests/unit/sources/test_base.py
@@ -310,8 +310,8 @@ class TestFileSourceHandler:
         )
         with pytest.raises(TypeError, match=expected):
             FaultyFileSource(  # type: ignore[reportGeneralTypeIssues]
-                source=None,  # type: ignore[reportGeneralTypeIssues]
-                part_src_dir=None,  # type: ignore[reportGeneralTypeIssues]
+                source=None,  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
+                part_src_dir=None,  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
                 cache_dir=Path(),
                 project_dirs=self._dirs,
             )

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -69,10 +69,6 @@ class TestBuildState:
         assert err[0]["loc"] == ("overlay-hash",)
         assert err[0]["type"] == "value_error"
 
-    def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            BuildState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
 
 @pytest.mark.usefixtures("new_dir")
 class TestBuildStatePersist:

--- a/tests/unit/state_manager/test_build_state.py
+++ b/tests/unit/state_manager/test_build_state.py
@@ -71,7 +71,7 @@ class TestBuildState:
 
     def test_unmarshal_invalid(self):
         with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            BuildState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+            BuildState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -61,7 +61,7 @@ class TestPrimeState:
 
     def test_unmarshal_invalid(self):
         with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            PrimeState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+            PrimeState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_prime_state.py
+++ b/tests/unit/state_manager/test_prime_state.py
@@ -59,10 +59,6 @@ class TestPrimeState:
         state = PrimeState.unmarshal(state_data)
         assert state.marshal() == state_data
 
-    def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            PrimeState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
 
 @pytest.mark.usefixtures("new_dir")
 class TestPrimeStatePersist:

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -63,7 +63,7 @@ class TestPullState:
 
     def test_unmarshal_invalid(self):
         with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            PullState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+            PullState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_pull_state.py
+++ b/tests/unit/state_manager/test_pull_state.py
@@ -61,10 +61,6 @@ class TestPullState:
         state = PullState.unmarshal(state_data)
         assert state.marshal() == state_data
 
-    def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            PullState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
 
 @pytest.mark.usefixtures("new_dir")
 class TestPullStatePersist:

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -67,10 +67,6 @@ class TestStageState:
         assert err[0]["loc"] == ("overlay-hash",)
         assert err[0]["type"] == "value_error"
 
-    def test_unmarshal_invalid(self):
-        with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            StageState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
 
 @pytest.mark.usefixtures("new_dir")
 class TestStageStatePersist:

--- a/tests/unit/state_manager/test_stage_state.py
+++ b/tests/unit/state_manager/test_stage_state.py
@@ -69,7 +69,7 @@ class TestStageState:
 
     def test_unmarshal_invalid(self):
         with pytest.raises(TypeError, match="^state data is not a dictionary$"):
-            StageState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+            StageState.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.usefixtures("new_dir")

--- a/tests/unit/state_manager/test_state_manager.py
+++ b/tests/unit/state_manager/test_state_manager.py
@@ -61,13 +61,13 @@ class TestStateWrapper:
         stw = state_manager._StateWrapper(state=state, serial=500)
 
         with pytest.raises(dataclasses.FrozenInstanceError):
-            stw.state = states.PullState()  # type: ignore[reportGeneralTypeIssues]
+            stw.state = states.PullState()  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-assignment]
 
         with pytest.raises(dataclasses.FrozenInstanceError):
-            stw.serial = 5  # type: ignore[reportGeneralTypeIssues]
+            stw.serial = 5  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-assignment]
 
         with pytest.raises(dataclasses.FrozenInstanceError):
-            stw.step_updated = True  # type: ignore[reportGeneralTypeIssues]
+            stw.step_updated = True  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-assignment]
 
 
 class TestStateDB:

--- a/tests/unit/state_manager/test_step_state.py
+++ b/tests/unit/state_manager/test_step_state.py
@@ -219,7 +219,7 @@ class TestStepState:
         }
 
     def test_ignore_additional_data(self):
-        state = SomeStepState(extra="something")  # type: ignore[reportGeneralTypeIssues]
+        state = SomeStepState.model_validate({"extra": "something"})
         assert state.marshal() == {
             "partition": None,
             "part-properties": {},

--- a/tests/unit/test_filesystem_mounts.py
+++ b/tests/unit/test_filesystem_mounts.py
@@ -43,7 +43,7 @@ def test_filesystem_mount_item_unmarshal_not_dict():
     with pytest.raises(
         TypeError, match=r"^Filesystem input data must be a dictionary\.$"
     ):
-        FilesystemMountItem.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+        FilesystemMountItem.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ def test_filesystem_mount_marshal_unmarshal(data):
 
 def test_filesystem_mount_unmarshal_not_list():
     with pytest.raises(TypeError, match=r"^Filesystem entry must be a list\.$"):
-        FilesystemMount.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+        FilesystemMount.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 @pytest.mark.parametrize(
@@ -332,7 +332,7 @@ def test_filesystem_mounts_marshal_unmarshal():
 
 def test_filesystem_mounts_unmarshal_not_dict():
     with pytest.raises(TypeError, match="^filesystems is not a dictionary$"):
-        FilesystemMounts.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+        FilesystemMounts.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
 
 def test_filesystem_mounts_iterable():

--- a/tests/unit/test_filesystem_mounts.py
+++ b/tests/unit/test_filesystem_mounts.py
@@ -330,11 +330,6 @@ def test_filesystem_mounts_marshal_unmarshal():
     assert spec.marshal() == data_copy
 
 
-def test_filesystem_mounts_unmarshal_not_dict():
-    with pytest.raises(TypeError, match="^filesystems is not a dictionary$"):
-        FilesystemMounts.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
-
 def test_filesystem_mounts_iterable():
     data = {
         "default": [

--- a/tests/unit/test_infos.py
+++ b/tests/unit/test_infos.py
@@ -999,7 +999,7 @@ class TestProjectVarInfo:
         expected_error = "Project variable info must be a dictionary."
 
         with pytest.raises(TypeError, match=expected_error):
-            ProjectVarInfo.unmarshal("invalid")  # pyright: ignore[reportArgumentType]
+            ProjectVarInfo.unmarshal("invalid")  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type]
 
     @pytest.mark.parametrize(
         ("attr", "expected"),

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -477,7 +477,7 @@ class TestPluginProperties:
     """Verify if plugin properties are correctly handled."""
 
     def _get_manager(self, new_dir, **kwargs):
-        manager_kwargs = {
+        manager_kwargs: dict[str, Any] = {
             "application_name": "test_manager",
             "cache_dir": new_dir,
         }

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -80,7 +80,7 @@ class TestPartSpecs:
 
     def test_unmarshal_not_dict(self, partitions):
         with pytest.raises(TypeError, match="^part data is not a dictionary$"):
-            PartSpec.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]
+            PartSpec.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
     @pytest.mark.parametrize(
         ("stage_packages", "stage_packages_slice_support", "expectation"),
@@ -640,7 +640,7 @@ class TestPartUnmarshal:
 
     def test_part_spec_not_dict(self, partitions):
         with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", None, partitions=partitions)  # type: ignore[reportGeneralTypeIssues]
+            Part("foo", None, partitions=partitions)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
         assert raised.value.part_name == "foo"
         assert raised.value.message == "part data is not a dictionary"
 
@@ -748,7 +748,7 @@ class TestPartValidation:
 
     def test_part_validation_data_type(self, partitions):
         with pytest.raises(TypeError) as raised:
-            parts.validate_part("invalid data")  # type: ignore[reportGeneralTypeIssues]
+            parts.validate_part("invalid data")  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
 
         assert str(raised.value) == "value must be a dictionary"
 

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -78,10 +78,6 @@ class TestPartSpecs:
         spec = PartSpec.unmarshal(data)
         assert spec.marshal() == data_copy
 
-    def test_unmarshal_not_dict(self, partitions):
-        with pytest.raises(TypeError, match="^part data is not a dictionary$"):
-            PartSpec.unmarshal(None)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-
     @pytest.mark.parametrize(
         ("stage_packages", "stage_packages_slice_support", "expectation"),
         [
@@ -637,12 +633,6 @@ class TestPartUnmarshal:
             "- Extra inputs are not permitted in field 'a'\n"
             "- Extra inputs are not permitted in field 'b'"
         )
-
-    def test_part_spec_not_dict(self, partitions):
-        with pytest.raises(errors.PartSpecificationError) as raised:
-            Part("foo", None, partitions=partitions)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
-        assert raised.value.part_name == "foo"
-        assert raised.value.message == "part data is not a dictionary"
 
     def test_part_unmarshal_type_error(self, partitions):
         with pytest.raises(errors.PartSpecificationError) as raised:

--- a/tests/unit/test_sequencer.py
+++ b/tests/unit/test_sequencer.py
@@ -124,7 +124,7 @@ def test_sequencer_run_step_invalid(new_dir):
 
     seq = Sequencer(part_list=[p1], project_info=info)
     with pytest.raises(RuntimeError) as raised:
-        seq._run_step(p1, 999)  # type: ignore[reportGeneralTypeIssues]
+        seq._run_step(p1, 999)  # type: ignore[reportGeneralTypeIssues]  # ty: ignore[invalid-argument-type]
     assert str(raised.value) == "invalid step 999"
 
 

--- a/tests/unit/utils/test_maven_utils.py
+++ b/tests/unit/utils/test_maven_utils.py
@@ -837,7 +837,7 @@ def test_maven_plugin_set_remaining_plugins() -> None:
 
     # Force remaining_plugins to be a list to keep its ordered property
     # This keeps the test reproducible
-    MavenPlugin._set_remaining_plugins(remaining_plugins, project, {})  # type: ignore[reportArgumentType, arg-type]
+    MavenPlugin._set_remaining_plugins(remaining_plugins, project, {})  # type: ignore[reportArgumentType, arg-type]  # ty: ignore[invalid-argument-type]
 
     assert (
         etree.tostring(project, pretty_print=True).decode(errors="replace") == expected


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Enables `ty` as a lint target and fixes its warnings. 

Commits are ordered from least to most controversial.