### PR TITLE
test: overlay migration test requires root

### DIFF
--- a/tests/integration/executor/test_collisions.py
+++ b/tests/integration/executor/test_collisions.py
@@ -325,6 +325,7 @@ class TestCollisions:
         with lf.action_executor() as ctx:
             ctx.execute(actions)
 
+    @pytest.mark.requires_root
     @pytest.mark.usefixtures(
         "mock_overlay_support_prerequisites", "add_overlay_feature"
     )
@@ -348,6 +349,7 @@ class TestCollisions:
         with pytest.raises(OverlayStageConflict, match=expected_message):
             self._run_lifecycle(parts_yaml, new_dir, partitions)
 
+    @pytest.mark.requires_root
     @pytest.mark.usefixtures(
         "mock_overlay_support_prerequisites", "add_overlay_feature"
     )

--- a/tests/unit/features/overlay_partitions/test_executor_part_handler.py
+++ b/tests/unit/features/overlay_partitions/test_executor_part_handler.py
@@ -576,6 +576,7 @@ def create_overlay_whiteout(name: Path) -> None:
     os.mknod(name, stat.S_IFCHR, os.makedev(0, 0))
 
 
+@pytest.mark.requires_root
 @pytest.mark.usefixtures("new_dir")
 class TestOverlayMigrationFilesystems:
     """Overlay migration to stage and prime test cases with a non-default filesystems."""


### PR DESCRIPTION
Something changed in the reactive-amd64-focal self-hosted runner image
between 2026 Sep 1 18:15 and Sep 3 17:37 that revoked or blocked `CAP_MKNOD`
for the job's execution context. Mark tests using mknod as requiring root so it can
execute as expected.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
