### PR TITLE
refactor: format partition errors inside error class

### DIFF
--- a/craft_parts/dirs.py
+++ b/craft_parts/dirs.py
@@ -82,8 +82,13 @@ class ProjectDirs:
         if self._partitions:
             if not partition:
                 raise PartitionUsageError(
-                    error_list=[
-                        f"Partitions are enabled, you must specify which partition's {dir_name!r} you want."
+                    partition_errors=[
+                        {
+                            "attribute": dir_name,
+                            "messages": [
+                                f"Partitions are enabled, you must specify which partition's {dir_name!r} you want."
+                            ],
+                        }
                     ],
                     partitions=self._partitions,
                 )

--- a/craft_parts/errors.py
+++ b/craft_parts/errors.py
@@ -21,11 +21,23 @@ from __future__ import annotations
 import abc
 import contextlib
 from io import StringIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
-from typing_extensions import override
+from typing_extensions import NotRequired, override
 
 from craft_parts.utils.formatting_utils import humanize_list
+
+
+class PartitionMessageInfo(TypedDict):
+    """Structured data for a partition message group."""
+
+    part_name: NotRequired[str]
+    attribute: str
+    messages: list[str]
+
+
+PartitionErrorInfo = PartitionMessageInfo
+PartitionWarningInfo = PartitionMessageInfo
 
 if TYPE_CHECKING:
     import pathlib
@@ -819,27 +831,45 @@ class PartitionError(PartsError):
         super().__init__(brief=brief, details=details, resolution=resolution)
 
 
+def _format_partition_messages(
+    partition_messages: list[PartitionMessageInfo],
+) -> list[str]:
+    formatted_lines: list[str] = []
+
+    for info in partition_messages:
+        part_name = info.get("part_name")
+        if part_name:
+            formatted_lines.append(f"  parts.{part_name}.{info['attribute']}")
+        else:
+            formatted_lines.append(f"  {info['attribute']}")
+        formatted_lines.extend(f"    {message}" for message in info["messages"])
+
+    return formatted_lines
+
+
 class PartitionUsageError(PartitionError):
     """Error for a list of invalid partition usages.
 
-    :param error_list: Iterable of strings describing the invalid usages.
+    :param partition_errors: Structured partition error data.
     :param partitions: Iterable of the names of valid partitions.
     :param brief: Override brief message.
     """
 
     def __init__(
         self,
-        error_list: Iterable[str],
+        partition_errors: list[PartitionErrorInfo],
         partitions: Iterable[str] | None,
         brief: str | None = None,
     ) -> None:
+        formatted_lines = _format_partition_messages(partition_errors)
+
         valid_partitions = (
             f"\nValid partitions: {', '.join(partitions)}" if partitions else ""
         )
 
         super().__init__(
             brief=brief or "Invalid usage of partitions",
-            details="\n".join(error_list) + valid_partitions,
+            details="\n".join(formatted_lines) + valid_partitions,
             resolution="Correct the invalid partition usage and try again.",
         )
 
@@ -847,16 +877,18 @@ class PartitionUsageError(PartitionError):
 class PartitionUsageWarning(PartitionError, Warning):  # noqa: N818
     """Warnings for possibly invalid usages of partitions.
 
-    :param warning_list: Iterable of strings describing the misuses.
+    :param partition_warnings: Structured partition warning data.
     """
 
-    def __init__(self, warning_list: Iterable[str]) -> None:
+    def __init__(self, partition_warnings: list[PartitionWarningInfo]) -> None:
+        formatted_lines = _format_partition_messages(partition_warnings)
+
         super().__init__(
             brief="Possible misuse of partitions",
             details=(
                 "The following entries begin with a valid partition name but are "
                 "not wrapped in parentheses. These entries will go into the "
-                "default partition.\n" + "\n".join(warning_list)
+                "default partition.\n" + "\n".join(formatted_lines)
             ),
             resolution=(
                 "Wrap the partition name in parentheses, for example "
@@ -879,7 +911,7 @@ class PartitionNotFound(PartitionUsageError):  # noqa: N818
         super().__init__(
             brief=f"Requested partition does not exist: {partition_name!r}",
             partitions=partitions,
-            error_list=[],
+            partition_errors=[],
         )
 
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -1119,7 +1119,8 @@ class Part:
 
         if warning_list:
             warnings.warn(
-                errors.PartitionUsageWarning(partition_warnings=warning_list), stacklevel=1
+                errors.PartitionUsageWarning(partition_warnings=warning_list),
+                stacklevel=1,
             )
 
         if error_list:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -772,9 +772,9 @@ def _get_build_partition_usage_error(fileset_name: str, partition: str) -> str |
         return None
 
     if fileset_name == "organize":
-        return "    cannot organize files into the build directory"
+        return "cannot organize files into the build directory"
 
-    return f"    ({partition}) cannot be used in {fileset_name!r}"
+    return f"({partition}) cannot be used in {fileset_name!r}"
 
 
 def _get_missing_partition_inner_path_error(
@@ -788,7 +788,7 @@ def _get_missing_partition_inner_path_error(
     if inner_path:
         return None
 
-    return f"    no path specified after partition in {filepath!r}"
+    return f"no path specified after partition in {filepath!r}"
 
 
 # pylint: disable=too-many-public-methods
@@ -1101,8 +1101,8 @@ class Part:
         if not self._partitions:
             return
 
-        error_list: list[str] = []
-        warning_list: list[str] = []
+        error_list: list[errors.PartitionErrorInfo] = []
+        warning_list: list[errors.PartitionWarningInfo] = []
 
         for fileset_name, fileset, require_inner_path in [
             # organize source entries do not use partitions and
@@ -1119,18 +1119,18 @@ class Part:
 
         if warning_list:
             warnings.warn(
-                errors.PartitionUsageWarning(warning_list=warning_list), stacklevel=1
+                errors.PartitionUsageWarning(partition_warnings=warning_list), stacklevel=1
             )
 
         if error_list:
             raise errors.PartitionUsageError(
-                error_list=error_list,
+                partition_errors=error_list,
                 partitions=self._partitions,
             )
 
     def _check_partitions_in_filepaths(
         self, fileset_name: str, fileset: Iterable[str], *, require_inner_path: bool
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[errors.PartitionWarningInfo], list[errors.PartitionErrorInfo]]:
         """Check if partitions are properly used in a fileset.
 
         If a filepath begins with a parentheses, then the text inside the parentheses
@@ -1156,11 +1156,11 @@ class Part:
             - A list of warnings of possible misuses of partitions in the fileset
             - A list of invalid uses of partitions in the fileset
         """
-        error_list: list[str] = []
-        warning_list: list[str] = []
+        error_messages: list[str] = []
+        warning_messages: list[str] = []
 
         if not self._partitions:
-            return warning_list, error_list
+            return [], []
 
         partition_pattern = re.compile("^-?\\((?P<partition>.*?)\\)")
         possible_partition_pattern = re.compile("^-?(?P<possible_partition>[a-z]+)/?")
@@ -1172,34 +1172,49 @@ class Part:
                 if build_error := _get_build_partition_usage_error(
                     fileset_name, str(partition)
                 ):
-                    error_list.append(build_error)
+                    error_messages.append(build_error)
                 elif str(partition) == OVERLAY_PARTITION and Features().enable_overlay:
                     # If overlays are enabled we can organize to (overlay)
                     pass
                 elif str(partition) not in self._partitions:
-                    error_list.append(
-                        f"    unknown partition {partition!r} in {filepath!r}"
+                    error_messages.append(
+                        f"unknown partition {partition!r} in {filepath!r}"
                     )
             else:
                 match = re.match(possible_partition_pattern, filepath)
                 if match:
                     partition = match.group("possible_partition")
                     if partition in self._partitions:
-                        warning_list.append(
-                            f"    misused partition {partition!r} in {filepath!r}"
+                        warning_messages.append(
+                            f"misused partition {partition!r} in {filepath!r}"
                         )
 
             if path_error := _get_missing_partition_inner_path_error(
                 filepath, self.default_partition, require_inner_path=require_inner_path
             ):
-                error_list.append(path_error)
+                error_messages.append(path_error)
 
-        if error_list:
-            error_list.insert(0, f"  parts.{self.name}.{fileset_name}")
-        if warning_list:
-            warning_list.insert(0, f"  parts.{self.name}.{fileset_name}")
+        result_warnings: list[errors.PartitionWarningInfo] = []
+        result_errors: list[errors.PartitionErrorInfo] = []
 
-        return warning_list, error_list
+        if warning_messages:
+            result_warnings.append(
+                {
+                    "part_name": self.name,
+                    "attribute": fileset_name,
+                    "messages": warning_messages,
+                }
+            )
+        if error_messages:
+            result_errors.append(
+                {
+                    "part_name": self.name,
+                    "attribute": fileset_name,
+                    "messages": error_messages,
+                }
+            )
+
+        return result_warnings, result_errors
 
 
 # pylint: enable=too-many-public-methods

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -17,6 +17,7 @@ import string
 from pathlib import Path
 
 import pytest
+from craft_parts import errors
 from craft_parts.dirs import ProjectDirs
 from hypothesis import given, strategies
 
@@ -61,7 +62,7 @@ def test_dirs_work_dir_resolving(partitions):
     partitions=strategies.lists(
         strategies.text(
             strategies.sampled_from(string.ascii_lowercase), min_size=1
-        ).filter(lambda x: x not in ("default", "overlay")),
+        ).filter(lambda x: x not in ("default", "overlay", "build")),
         min_size=1,
         unique=True,
     )
@@ -80,7 +81,7 @@ def test_get_stage_dir_with_partitions(partitions):
     partitions=strategies.lists(
         strategies.text(
             strategies.sampled_from(string.ascii_lowercase), min_size=1
-        ).filter(lambda x: x not in ("default", "overlay")),
+        ).filter(lambda x: x not in ("default", "overlay", "build")),
         min_size=1,
         unique=True,
     )
@@ -92,6 +93,38 @@ def test_get_prime_dir_with_partitions(partitions):
         assert dirs.get_prime_dir(partition=partition) == dirs.prime_dirs[partition]
     assert dirs.get_prime_dir(partition="default") == dirs.prime_dir
     assert dirs.get_prime_dir(partition="default") == dirs.prime_dirs["default"]
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_get_stage_dir_without_requested_partition_with_partitions():
+    dirs = ProjectDirs(partitions=["default", "kernel"])
+
+    with pytest.raises(errors.PartitionUsageError) as raised:
+        dirs.get_stage_dir()
+
+    assert raised.value.brief == "Invalid usage of partitions"
+    assert raised.value.details == (
+        "  stage_dir\n"
+        "    Partitions are enabled, you must specify which partition's "
+        "'stage_dir' you want.\n"
+        "Valid partitions: default, kernel"
+    )
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_get_prime_dir_without_requested_partition_with_partitions():
+    dirs = ProjectDirs(partitions=["default", "kernel"])
+
+    with pytest.raises(errors.PartitionUsageError) as raised:
+        dirs.get_prime_dir()
+
+    assert raised.value.brief == "Invalid usage of partitions"
+    assert raised.value.details == (
+        "  prime_dir\n"
+        "    Partitions are enabled, you must specify which partition's "
+        "'prime_dir' you want.\n"
+        "Valid partitions: default, kernel"
+    )
 
 
 def test_get_stage_dir_without_partitions():

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -430,9 +430,14 @@ class TestPartitionErrors:
 
     def test_invalid_partition_usage(self):
         err = errors.PartitionUsageError(
-            error_list=[
-                "  parts.test-part.organize",
-                "    unknown partition 'foo' in '(foo)'",
+            partition_errors=[
+                {
+                    "part_name": "test-part",
+                    "attribute": "organize",
+                    "messages": [
+                        "unknown partition 'foo' in '(foo)'",
+                    ],
+                }
             ],
             partitions=["default", "mypart", "yourpart"],
         )
@@ -447,9 +452,14 @@ class TestPartitionErrors:
 
     def test_invalid_partition_warning(self):
         err = errors.PartitionUsageWarning(
-            warning_list=[
-                "  parts.test-part.organize",
-                "    misused partition 'yourpart' in 'yourpart/test-file'",
+            partition_warnings=[
+                {
+                    "part_name": "test-part",
+                    "attribute": "organize",
+                    "messages": [
+                        "misused partition 'yourpart' in 'yourpart/test-file'",
+                    ],
+                }
             ]
         )
 


### PR DESCRIPTION
Refactor partition-related error classes to receive unformatted
data structures.

Fixes #670

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
