### PR TITLE
refactor: put chisel call in its own module

### DIFF
--- a/craft_parts/packages/chisel.py
+++ b/craft_parts/packages/chisel.py
@@ -1,0 +1,55 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for Chisel operations."""
+
+import logging
+import pathlib
+import subprocess
+from io import StringIO
+
+from craft_parts.packages import errors
+from craft_parts.packages.base import logger
+from craft_parts.utils import os_utils
+
+
+def cut_slices(slices: list[str], target_dir: pathlib.Path) -> None:
+    """Cut Chisel slices into a destination path.
+
+    :param slices: The list of names of slices to cut.
+    :param target_dir: The destination directory.
+    """
+    output_stream = StringIO()
+    handler = logging.StreamHandler(stream=output_stream)
+    logger.addHandler(handler)
+    try:
+        os_utils.process_run(
+            [
+                "chisel",
+                "cut",
+                "--ignore=unmaintained",
+                "--ignore=unstable",
+                f"--root={target_dir}",
+                *slices,
+            ],
+            logger.debug,
+        )
+    except subprocess.CalledProcessError as err:
+        command_output = output_stream.getvalue()
+        raise errors.ChiselError(slices=slices, output=command_output) from err
+    finally:
+        logger.removeHandler(handler)
+        handler.close()

--- a/craft_parts/packages/deb.py
+++ b/craft_parts/packages/deb.py
@@ -29,7 +29,6 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable, Sequence
-from io import StringIO
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -37,7 +36,7 @@ import zstandard
 
 from craft_parts.utils import deb_utils, file_utils, os_utils
 
-from . import errors
+from . import chisel, errors
 from .base import BaseRepository, get_pkg_name_parts, mark_origin_stage_package
 from .deb_package import DebPackage
 from .normalize import normalize
@@ -979,27 +978,7 @@ class Ubuntu(BaseRepository):
         :param stage_packages: The list of names of slices to cut.
         :param install_path: The destination directory.
         """
-        output_stream = StringIO()
-        handler = logging.StreamHandler(stream=output_stream)
-        logger.addHandler(handler)
-        try:
-            process_run(
-                [
-                    "chisel",
-                    "cut",
-                    "--ignore=unmaintained",
-                    "--ignore=unstable",
-                    f"--root={install_path}",
-                    *stage_packages,
-                ]
-            )
-        except subprocess.CalledProcessError as err:
-            command_output = output_stream.getvalue()
-            raise errors.ChiselError(
-                slices=stage_packages, output=command_output
-            ) from err
-        finally:
-            logger.removeHandler(handler)
+        chisel.cut_slices(slices=stage_packages, target_dir=install_path)
 
         normalize(install_path, repository=cls)
 

--- a/tests/unit/packages/conftest.py
+++ b/tests/unit/packages/conftest.py
@@ -43,6 +43,11 @@ def fake_apt_cache(mocker):
 
 
 @pytest.fixture
+def fake_process_run(mocker):
+    return mocker.patch("craft_parts.utils.os_utils.process_run")
+
+
+@pytest.fixture
 def fake_deb_run(mocker):
     return mocker.patch("craft_parts.packages.deb.process_run")
 

--- a/tests/unit/packages/test_chisel.py
+++ b/tests/unit/packages/test_chisel.py
@@ -21,7 +21,7 @@ import craft_parts
 import pytest
 import yaml
 from craft_parts import Step
-from craft_parts.packages import deb
+from craft_parts.packages import base, deb
 from craft_parts.utils.deb_utils import has_slices
 
 
@@ -52,7 +52,7 @@ def test_fetch_stage_slices(tmp_path, fake_apt_cache):
     assert not fake_apt_cache.called
 
 
-def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
+def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_process_run, mocker):
     stage_dir = tmp_path / "stage"
     stage_dir.mkdir()
 
@@ -67,7 +67,8 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
         stage_packages_path=stage_dir, install_path=install_dir, stage_packages=slices
     )
 
-    fake_deb_run.assert_called_once_with(
+    logger = base.logger
+    fake_process_run.assert_called_once_with(
         [
             "chisel",
             "cut",
@@ -76,7 +77,8 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
             f"--root={install_dir}",
             "package1_slice1",
             "package2_slice2",
-        ]
+        ],
+        logger.debug,
     )
 
     # Make sure the contents of the cut slices have been normalized.
@@ -84,7 +86,7 @@ def test_unpack_stage_slices(tmp_path, fake_apt_cache, fake_deb_run, mocker):
 
 
 @pytest.mark.slow
-def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):
+def test_chisel_pull_build(new_dir, fake_apt_cache, fake_process_run):
     """Test the combination of 'pulling' and 'building' chisel slices."""
     _parts_yaml = textwrap.dedent(
         """\
@@ -108,7 +110,8 @@ def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):
 
     install_dir = lf.project_info.parts_dir / "foo/install"
 
-    fake_deb_run.assert_called_once_with(
+    logger = base.logger
+    fake_process_run.assert_called_once_with(
         [
             "chisel",
             "cut",
@@ -117,5 +120,6 @@ def test_chisel_pull_build(new_dir, fake_apt_cache, fake_deb_run):
             f"--root={install_dir}",
             "package1_slice1",
             "package2_slice2",
-        ]
+        ],
+        logger.debug,
     )


### PR DESCRIPTION
This is to facilitate upcoming changes (build-slices). The existing codepath to handle slices in the Repository is kept because that step needs path normalization (fixing symlinks, etc), which needs the Repository itself. So it makes sense to decouple the cutting from the normalizing.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
