### PR TITLE
feat(part): add build-slices model

### DIFF
--- a/craft_parts/features.py
+++ b/craft_parts/features.py
@@ -31,10 +31,12 @@ class Features(metaclass=Singleton):
 
     :cvar enable_overlay: Enables the overlay step.
     :cvar enable_partitions: Enables the usage of partitions.
+    :cvar enable_build_slices: Enables cutting Chisel slices into a build root.
     """
 
     enable_overlay: bool = False
     enable_partitions: bool = False
+    enable_build_slices: bool = False
 
     @classmethod
     def reset(cls) -> None:

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -380,6 +380,18 @@ class PartSpec(BaseModel):
     Build packages must be listed by their name on the host system.
     """
 
+    build_slices: list[ChiselSliceStr] = Field(
+        default=[],
+        description="The Chisel slices to make available during the build.",
+        examples=["[python3.12_standard, gcc-12_bins]"],
+    )
+    """The Chisel slices to make available during the build step.
+    The slices from all parts are collected and cut into a single directory that
+    becomes the system root of the build step. Since slices and Debian packages
+    cannot be safely mixed in a single filesystem, ``build-slices`` is mutually
+    exclusive with ``build-packages`` and ``build-snaps`` in the same part.
+    """
+
     build_environment: list[dict[str, str]] = Field(
         default=[],
         description="The environment variables to define for the build step, as key-value pairs.",
@@ -621,6 +633,23 @@ class PartSpec(BaseModel):
         if self.override_overlay is not None and self.overlay_script is not None:
             raise ValueError(
                 "override-overlay and overlay-script cannot both be defined"
+            )
+        return self
+
+    @field_validator("build_slices")
+    @classmethod
+    def validate_build_slices_feature(cls, item: _T_validate) -> _T_validate:
+        """Check if build-slices is specified when the feature is disabled."""
+        if item and not Features().enable_build_slices:
+            raise ValueError("'build-slices' are not supported")
+        return item
+
+    @model_validator(mode="after")
+    def validate_build_slices_mutually_exclusive(self) -> Self:
+        """Check that build-slices is not mixed with build-packages/build-snaps."""
+        if self.build_slices and (self.build_packages or self.build_snaps):
+            raise ValueError(
+                "'build-slices' cannot be used with 'build-packages' or 'build-snaps'"
             )
         return self
 

--- a/craft_parts/parts.py
+++ b/craft_parts/parts.py
@@ -641,7 +641,7 @@ class PartSpec(BaseModel):
     def validate_build_slices_feature(cls, item: _T_validate) -> _T_validate:
         """Check if build-slices is specified when the feature is disabled."""
         if item and not Features().enable_build_slices:
-            raise ValueError("'build-slices' are not supported")
+            raise ValueError("The 'build-slices' key is not supported")
         return item
 
     @model_validator(mode="after")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import dataclasses
 import http.server
 import os
 import pathlib
@@ -172,6 +172,16 @@ def enable_overlay_and_partitions_features():
     yield
 
     Features.reset()
+
+
+@pytest.fixture
+def enable_build_slices():
+    current = dataclasses.asdict(Features())
+    Features.reset()
+    Features(enable_build_slices=True)
+    yield
+    Features.reset()
+    Features(**current)
 
 
 @pytest.fixture

--- a/tests/unit/features/overlay/test_parts.py
+++ b/tests/unit/features/overlay/test_parts.py
@@ -54,6 +54,7 @@ class TestPartSpecs:
             "stage-slices": [],
             "build-snaps": ["build-snap1", "build-snap2"],
             "build-packages": ["build-pkg1", "build-pkg2"],
+            "build-slices": [],
             "build-environment": [{"ENV1": "on"}, {"ENV2": "off"}],
             "build-attributes": ["attr1", "attr2"],
             "organize": {"src1": "dest1", "src2": "dest2"},

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -53,6 +53,7 @@ class TestPartSpecs:
             "stage-slices": [],
             "build-snaps": ["build-snap1", "build-snap2"],
             "build-packages": ["build-pkg1", "build-pkg2"],
+            "build-slices": [],
             "build-environment": [{"ENV1": "on"}, {"ENV2": "off"}],
             "build-attributes": ["attr1", "attr2"],
             "organize": {"src1": "dest1", "src2": "dest2"},
@@ -217,6 +218,18 @@ class TestPartSpecs:
         error = r"overlays not supported"
         with pytest.raises(pydantic.ValidationError, match=error):
             PartSpec.unmarshal(data)
+
+    @pytest.mark.usefixtures("enable_build_slices")
+    def test_marshal_unmarshal_build_slices(self, partitions):
+        data = {
+            "plugin": "nil",
+            "build-slices": ["pkg1_slice1", "pkg2_slices2"],
+        }
+
+        data_copy = deepcopy(data)
+
+        spec = PartSpec.unmarshal(data)
+        assert spec.marshal()["build-slices"] == data_copy["build-slices"]
 
 
 class TestPartPartitionUsage:
@@ -784,4 +797,33 @@ class TestPartValidation:
         data = {"plugin": "nil", "build-attributes": ["self-contained"]}
 
         with pytest.raises(errors.UnsupportedBuildAttributesError):
+            parts.validate_part(data)
+
+    def test_part_validate_build_slices_feature(self, partitions):
+        data = {"plugin": "nil", "build-slices": ["python3.12_standard"]}
+
+        with pytest.raises(
+            pydantic.ValidationError, match="'build-slices' are not supported"
+        ):
+            parts.validate_part(data)
+
+    @pytest.mark.usefixtures("enable_build_slices")
+    def test_part_validate_build_slices_feature_enabled(self, partitions):
+        data = {"plugin": "nil", "build-slices": ["python3.12_standard"]}
+
+        # Should not raise an error when the feature is enabled
+        parts.validate_part(data)
+
+    @pytest.mark.usefixtures("enable_build_slices")
+    @pytest.mark.parametrize("build_param", ["build-packages", "build-snaps"])
+    def test_part_validate_build_slices_other_types(self, partitions, build_param):
+        data = {
+            "plugin": "nil",
+            "build-slices": ["python3.12_standard"],
+            build_param: ["package1"],
+        }
+
+        # Should raise an error from conflicting package types
+        msg = "'build-slices' cannot be used with 'build-packages' or 'build-snaps'"
+        with pytest.raises(pydantic.ValidationError, match=re.escape(msg)):
             parts.validate_part(data)

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -803,7 +803,7 @@ class TestPartValidation:
         data = {"plugin": "nil", "build-slices": ["python3.12_standard"]}
 
         with pytest.raises(
-            pydantic.ValidationError, match="'build-slices' are not supported"
+            pydantic.ValidationError, match="The 'build-slices' key is not supported"
         ):
             parts.validate_part(data)
 


### PR DESCRIPTION
'build-slices' is a Part property that lists Chisel slices that must be cut to form the part's 'build root'. This commit just adds the model gated by a new Feature, plus validation.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
