### PR TITLE
feat: better error message for cache prepare failure

### DIFF
--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -201,7 +201,7 @@ class AptCache(ContextDecorator):
             raise errors.PackagesError(
                 brief="Cannot prepare the package cache.",
                 details=(
-                    f"Failed to prepare the apt cache at {self.stage_cache}: {err}."
+                    f"Failed to prepare the APT cache at {self.stage_cache}: {err}."
                 ),
                 resolution=(
                     "This is usually caused by running the application with sudo "

--- a/craft_parts/packages/apt_cache.py
+++ b/craft_parts/packages/apt_cache.py
@@ -165,33 +165,50 @@ class AptCache(ContextDecorator):
         # Copy apt configuration from host.
         cache_etc_apt_path = Path(self.stage_cache, "etc", "apt")
 
-        # Delete potentially outdated cache configuration.
-        if cache_etc_apt_path.is_symlink():
-            cache_etc_apt_path.unlink()
-        elif cache_etc_apt_path.exists():
-            shutil.rmtree(cache_etc_apt_path)
+        try:
+            # Delete potentially outdated cache configuration.
+            if cache_etc_apt_path.is_symlink():
+                cache_etc_apt_path.unlink()
+            elif cache_etc_apt_path.exists():
+                shutil.rmtree(cache_etc_apt_path)
 
-        # Copy current cache configuration.
-        cache_etc_apt_path.parent.mkdir(parents=True, exist_ok=True)
+            # Copy current cache configuration.
+            cache_etc_apt_path.parent.mkdir(parents=True, exist_ok=True)
 
-        shutil.copytree("/etc/apt", cache_etc_apt_path, ignore=_ignore_unreadable_files)
+            shutil.copytree(
+                "/etc/apt", cache_etc_apt_path, ignore=_ignore_unreadable_files
+            )
 
-        # Specify default arch (if specified).
-        if self.stage_cache_arch is not None:
-            arch_conf_path = cache_etc_apt_path / "apt.conf.d" / "00default-arch"
-            arch_conf_path.write_text(f'APT::Architecture "{self.stage_cache_arch}";\n')
+            # Specify default arch (if specified).
+            if self.stage_cache_arch is not None:
+                arch_conf_path = cache_etc_apt_path / "apt.conf.d" / "00default-arch"
+                arch_conf_path.write_text(
+                    f'APT::Architecture "{self.stage_cache_arch}";\n'
+                )
 
-        # dpkg also needs to be in the rootdir in order to support multiarch
-        # (apt calls dpkg --print-foreign-architectures).
-        dpkg_path = shutil.which("dpkg")
-        if dpkg_path:
-            # Symlink it into place
-            destination = Path(self.stage_cache, dpkg_path[1:])
-            if not destination.exists():
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                destination.symlink_to(dpkg_path)
-        else:
-            logger.warning("Cannot find 'dpkg' command needed to support multiarch")
+            # dpkg also needs to be in the rootdir in order to support multiarch
+            # (apt calls dpkg --print-foreign-architectures).
+            dpkg_path = shutil.which("dpkg")
+            if dpkg_path:
+                # Symlink it into place
+                destination = Path(self.stage_cache, dpkg_path[1:])
+                if not destination.exists():
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    destination.symlink_to(dpkg_path)
+            else:
+                logger.warning("Cannot find 'dpkg' command needed to support multiarch")
+        except OSError as err:
+            raise errors.PackagesError(
+                brief="Cannot prepare the package cache.",
+                details=(
+                    f"Failed to prepare the apt cache at {self.stage_cache}: {err}."
+                ),
+                resolution=(
+                    "This is usually caused by running the application with sudo "
+                    "and then without. Remove the cache directory manually or run "
+                    "the application with the same privileges."
+                ),
+            ) from err
 
     def _autokeep_packages(self) -> None:
         # If the package has been installed automatically as a dependency

--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -386,7 +386,7 @@ class TestMockedApt:
 
         assert raised.value.brief == "Cannot prepare the package cache."
         assert raised.value.details == (
-            f"Failed to prepare the apt cache at {stage_cache}: "
+            f"Failed to prepare the APT cache at {stage_cache}: "
             "Permission denied."
         )
         assert "sudo" in raised.value.resolution

--- a/tests/unit/packages/test_apt_cache.py
+++ b/tests/unit/packages/test_apt_cache.py
@@ -369,6 +369,49 @@ class TestMockedApt:
             call.cache.Cache().close(),
         ]
 
+    def test_stage_cache_setup_error_when_cache_cannot_be_removed(self, tmpdir, mocker):
+        stage_cache = Path(tmpdir, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+        (stage_cache / "etc" / "apt").mkdir(parents=True, exist_ok=True)
+
+        mocker.patch("craft_parts.packages.apt_cache.apt")
+        mocker.patch(
+            "craft_parts.packages.apt_cache.shutil.rmtree",
+            side_effect=PermissionError("Permission denied"),
+        )
+
+        with pytest.raises(errors.PackagesError) as raised:
+            with AptCache(stage_cache=stage_cache):
+                pass
+
+        assert raised.value.brief == "Cannot prepare the package cache."
+        assert raised.value.details == (
+            f"Failed to prepare the apt cache at {stage_cache}: "
+            "Permission denied."
+        )
+        assert "sudo" in raised.value.resolution
+
+    def test_stage_cache_setup_error_when_cache_cannot_be_copied(self, tmpdir, mocker):
+        stage_cache = Path(tmpdir, "cache")
+        stage_cache.mkdir(exist_ok=True, parents=True)
+
+        mocker.patch("craft_parts.packages.apt_cache.apt")
+        mocker.patch(
+            "craft_parts.packages.apt_cache.shutil.copytree",
+            side_effect=PermissionError("Permission denied"),
+        )
+
+        with pytest.raises(errors.PackagesError) as raised:
+            with AptCache(stage_cache=stage_cache):
+                pass
+
+        assert raised.value.brief == "Cannot prepare the package cache."
+        assert raised.value.details == (
+            f"Failed to prepare the package cache at {stage_cache}: "
+            "Permission denied."
+        )
+        assert "sudo" in raised.value.resolution
+
     def test_host_cache_setup(self, mocker):
         fake_apt = mocker.patch("craft_parts.packages.apt_cache.apt")
 


### PR DESCRIPTION
Catch errors in apt cache preparation. An example error message would look like this:

    Cannot prepare the package cache.
    Failed to prepare the APT cache at <path>: Permission denied.
    This is usually caused by running the application with sudo and then
    without. Remove the cache directory manually or run the application
    with the same privileges.

Fixes #648

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
